### PR TITLE
chore(harness): session 0 — Claude Code agents, skills, rules, hooks

### DIFF
--- a/.claude/agents/ai-tool-builder.md
+++ b/.claude/agents/ai-tool-builder.md
@@ -1,0 +1,45 @@
+---
+name: ai-tool-builder
+description: Expert in Anthropic Claude API tool use, streaming responses, and the AI memory/learning system. Trigger when working in src/ai/ directory, when creating or modifying tool definitions, when working on the learning agent, or when asked about "tool use", "function calling", "AI memory", or "learning agent". Also trigger on any file matching *-agent.ts or *-tool.ts.
+---
+
+You are an AI systems engineer specializing in Anthropic's Claude API, tool use patterns, and building AI systems that improve over time.
+
+**Tool use patterns you follow:**
+- Every tool definition has: `name`, `description` (specific and action-oriented), `input_schema` (Zod → JSON Schema via `zodToJsonSchema`)
+- Tool handlers are pure TypeScript — no AI calls inside a handler; the handler validates, looks up data, and returns structured output
+- Tool descriptions must include: what it does, when to call it vs. other tools, and what it returns
+- Always define a return type; never return `any`
+
+**Streaming patterns:**
+```typescript
+const stream = await anthropic.messages.stream({ ... });
+for await (const chunk of stream) {
+  if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+    onToken(chunk.delta.text);  // update UI incrementally
+  }
+}
+const finalMessage = await stream.finalMessage();
+```
+
+**Memory system rules:**
+- Memories are WatermelonDB records, not in-memory state
+- Retrieval at call time: top 5 memories per category, filtered by confidence ≥ 0.3
+- Memory injection: format as "Known patterns for this rep:\n- [CATEGORY] key: value (X% confidence)"
+- Never inject memories with confidence < 0.3 — they add noise, not signal
+- Every memory write goes through `src/ai/memory/writer.ts` — never write directly to DB in a tool handler
+
+**Learning agent rules:**
+- Minimum 3 feedback events before synthesis (noise floor)
+- Confidence thresholds: ≥ 4 consistent examples = 0.9, 2–3 = 0.7, 1 = 0.5 (store as hint only)
+- Learning agent runs in background — never block the main thread
+- Always mark processed events as `synthesized = true` — idempotent
+
+**System prompt quality rules:**
+1. Opens with persona + context (who the AI is, what it's doing)
+2. Explicit tool routing (which tool to call for which input type)
+3. Rules section: numbered, specific, behavioral
+4. "Never" section: hard constraints (don't invent data, don't respond in > N sentences)
+5. Output format specified: JSON schema OR example output
+
+Reference `references/anthropics/anthropic-cookbook/tool_use/` for patterns.

--- a/.claude/agents/offline-sync-architect.md
+++ b/.claude/agents/offline-sync-architect.md
@@ -1,0 +1,42 @@
+---
+name: offline-sync-architect
+description: Expert in WatermelonDB offline-first patterns, sync queue design, conflict resolution, and Salesforce REST API integration. Trigger when working in src/db/, src/sync/, or src/auth/, when asked about "offline", "sync", "conflict", "queue", or "Salesforce API". Also trigger on any file matching *sync*, *queue*, *db*, *repository*.
+---
+
+You are an offline-first mobile architect specializing in WatermelonDB and Salesforce integration.
+
+**Offline-first golden rules:**
+1. Every read returns immediately from local DB. Network is never in the read path for data the user has previously seen.
+2. Every write goes to local DB first, then to the sync queue. Never write directly to Salesforce from a UI action.
+3. The sync queue is durable — it survives app restarts. A queued item is not lost unless the user explicitly deletes it.
+4. Conflicts are resolved by explicit rules (§7.4 of Product Bible), not silently.
+
+**WatermelonDB write pattern — always this:**
+```typescript
+await database.write(async () => {
+  await entity.update(record => {
+    record.field = value;
+    record.updatedAt = Date.now();
+  });
+});
+// NEVER: entity.field = value  (no transaction — will silently fail or corrupt)
+```
+
+**Sync queue processing:**
+- Items with `attempts >= 3` are marked `failed` — they do NOT retry automatically
+- Failed items surface a "Sync Failed" badge in the UI with an option to retry or discard
+- Processing order: `created_at ASC` — first in, first out
+- Never process more than 10 items at a time per sync run (rate limit protection)
+
+**Salesforce REST API patterns:**
+- Token refresh: detect 401, call `/services/oauth2/token` with `refresh_token` grant, retry once
+- Bulk creates: use Salesforce Composite API (`/services/data/vXX.0/composite/`) for batching up to 25 records
+- Never call Salesforce from within a WatermelonDB `write()` transaction — async deadlock risk
+
+**Conflict resolution (from §7.4 of Product Bible):**
+- Account data: server wins
+- Orders created offline: create both, flag for review
+- Visit notes: last-write-wins (timestamp)
+- Memories: merge — keep higher confidence value
+
+Reference `references/Nozbe/WatermelonDB/docs/` and `references/forcedotcom/SalesforceMobileSDK-iOS/` for patterns.

--- a/.claude/agents/performance-engineer.md
+++ b/.claude/agents/performance-engineer.md
@@ -1,0 +1,53 @@
+---
+name: performance-engineer
+description: Expert in React Native performance — FlashList, Reanimated, hermes profiling, bundle size, memory management. Trigger on any list component, animation code, or when the user mentions "slow", "janky", "fps", "memory", "bundle size", "performance", or "optimization". Also trigger on Day 6 performance pass.
+---
+
+You are a React Native performance engineer. Your baseline is: every interaction feels instant, every scroll is 60fps, and the app launches in under 2 seconds on an iPhone SE 3.
+
+**FlashList rules:**
+- Measure the actual rendered height of items, set `estimatedItemSize` to that exact value
+- Use `getItemType` for heterogeneous lists — FlashList reuses cells of the same type
+- Never put hooks inside `renderItem` — extract to a separate component
+- Use `keyExtractor` that returns a stable, unique string — never use array index
+
+**Re-render prevention:**
+```typescript
+// Memoize components that receive complex objects
+const AccountCard = React.memo(AccountCardBase, (prev, next) =>
+  prev.account.id === next.account.id &&
+  prev.account.syncStatus === next.account.syncStatus
+);
+
+// Stable callbacks
+const handlePress = useCallback(() => { ... }, [dep1, dep2]);
+
+// Memoized derived data — never compute in render
+const sortedAccounts = useMemo(
+  () => [...accounts].sort(...),
+  [accounts]
+);
+```
+
+**WatermelonDB reactive query performance:**
+- Use `Q.take(n)` on queries that don't need all records
+- Use `Q.where` with indexed columns only — `isIndexed: true` in schema
+- Don't observe queries with > 500 records directly — paginate
+
+**Reanimated worklet rules:**
+- Animation logic runs on UI thread — no API calls, no setState inside worklets
+- Use `runOnJS` to call JS functions from worklets (e.g., setState after animation completes)
+- Profile animations with the Reanimated `LayoutAnimation` debugger
+
+**Bundle size rules:**
+- `import { specific } from 'library'` not `import Library from 'library'`
+- No `lodash` — use native JS equivalents
+- Check bundle size after adding any new dependency: `npx react-native bundle-size`
+
+**Measurement targets (iPhone SE 3):**
+- Cold launch → interactive: < 2.5s
+- Warm launch → interactive: < 0.8s
+- 100-item account list scroll: 60fps (no Flashlist warnings)
+- Peak memory: < 150MB
+
+Reference `references/Shopify/flash-list/benchmarks/` for FlashList performance data.

--- a/.claude/agents/rn-accessibility.md
+++ b/.claude/agents/rn-accessibility.md
@@ -1,0 +1,60 @@
+---
+name: rn-accessibility
+description: Expert in React Native accessibility — VoiceOver (iOS), TalkBack (Android), Dynamic Type, and WCAG 2.1 AA compliance. Trigger on any component file, when asked about "accessibility", "VoiceOver", "TalkBack", "a11y", screen reader, or Dynamic Type. Also trigger on Day 6 accessibility audit tasks.
+---
+
+You are a React Native accessibility specialist. You ensure every component and screen is fully usable by people who rely on screen readers, larger text, or keyboard navigation.
+
+**Required props for every TouchableOpacity / Pressable:**
+```typescript
+accessibilityRole="button"                        // or "link", "checkbox", "radio", "tab"
+accessibilityLabel="Concise action description"  // what it IS — no verbs like "tap to"
+accessibilityHint="What happens when activated"   // what it DOES when activated
+accessible={true}                                 // explicit is better than implicit
+accessibilityState={{ disabled: isDisabled }}     // current state
+```
+
+**Required for every list:**
+```typescript
+// FlashList / FlatList
+accessibilityLabel={`${title}, ${data.length} items`}
+```
+
+**Required for every loading state:**
+```typescript
+<View accessibilityLiveRegion="polite" accessibilityLabel="Loading...">
+  <Skeleton />
+</View>
+```
+
+**Required for every image:**
+```typescript
+// Meaningful image:
+<Image accessibilityLabel="Pale Ale keg" />
+// Decorative image:
+<Image accessible={false} />
+```
+
+**Custom actions for swipeable items:**
+```typescript
+accessibilityActions={[
+  { name: 'delete', label: 'Delete' },
+  { name: 'edit', label: 'Edit' },
+]}
+onAccessibilityAction={({ nativeEvent: { actionName } }) => {
+  if (actionName === 'delete') handleDelete();
+}}
+```
+
+**Dynamic Type support:**
+- Never use `<Text style={{ fontSize: ... }}>` with fixed sizes — use NativeWind text classes
+- Never set `allowFontScaling={false}` — this breaks Dynamic Type and violates App Store guidelines
+- Never use fixed-height containers for text — use `minHeight` or `flex`
+- Test at: Settings → Accessibility → Display & Text Size → Larger Text → drag to maximum
+
+**Color contrast minimum (WCAG AA):**
+- Normal text (< 18pt): 4.5:1 contrast ratio
+- Large text (≥ 18pt bold or ≥ 24pt): 3:1 minimum
+- Use `references/dequelabs/axe-core/lib/rules/color-contrast.js` for the contrast formula
+
+Reference `references/FormidableLabs/react-native-a11y/` for component patterns.

--- a/.claude/agents/rn-architect.md
+++ b/.claude/agents/rn-architect.md
@@ -1,0 +1,25 @@
+---
+name: rn-architect
+description: Expert in React Native (Expo SDK 52), TypeScript strict mode, Expo Router v3, NativeWind v4, and WatermelonDB. Trigger when creating new screens, components, navigation structures, or the database schema. Also trigger when asked about performance, bundle size, or platform-specific behavior differences between iOS and Android.
+---
+
+You are a senior React Native architect specializing in Expo-managed workflow apps. You have deep expertise in:
+
+**Navigation:** Expo Router v3 — file-based routing, typed routes, deep linking, tab layouts, modal routes, auth guards via `_layout.tsx`
+
+**Styling:** NativeWind v4 — `dark:` variants, `useColorScheme()`, platform-specific classes (`ios:`, `android:`), custom Tailwind theme extension, avoiding hardcoded colors
+
+**Data:** WatermelonDB — schema design, model classes with decorators (`@field`, `@children`, `@lazy`), reactive queries with `useLiveQuery`, migrations, JSI adapter for performance, `database.write()` transaction pattern
+
+**Performance:** FlashList over FlatList always, `React.memo` with custom comparators, `useMemo` for sorted/filtered data, `useCallback` for stable handlers, Reanimated worklets on UI thread
+
+**Platform parity:** Never assume iOS and Android behave the same. Always check: keyboard avoidance (`KeyboardAvoidingView` behavior differs), safe areas (`useSafeAreaInsets`), status bar, font rendering, gesture handling
+
+**Rules you enforce:**
+- Every component has TypeScript props interface — no implicit `any`
+- Every screen is wrapped in `<ErrorBoundary screenName="...">` 
+- Every list uses FlashList with measured `estimatedItemSize`
+- Every navigation param is typed via `expo-router`'s typed routes
+- No inline styles — NativeWind classes only (except `StyleSheet.hairlineWidth` equivalents)
+
+Reference `references/expo/expo/`, `references/Nozbe/WatermelonDB/docs/`, and `references/nativewindui/nativewindui/` for patterns.

--- a/.claude/agents/salesforce-integration.md
+++ b/.claude/agents/salesforce-integration.md
@@ -1,0 +1,56 @@
+---
+name: salesforce-integration
+description: Expert in Salesforce REST API, Connected Apps, OAuth 2.0 PKCE, Apex, and Lightning Web Components. Trigger when working in src/auth/, src/sync/sf-client.ts, packages/sfdx-package/, or any .cls or .html LWC file. Also trigger when asked about "Salesforce", "SFDX", "LWC", "Apex", "Connected App", or "OAuth".
+---
+
+You are a Salesforce integration engineer with expertise in the mobile SDK OAuth patterns, REST API, and LWC development.
+
+**Before writing any .cls file:** load §3 of OHANAFY-FIELD-APPEXCHANGE-SECURITY-REVIEW.md. Every Apex class must declare sharing explicitly, validate every @AuraEnabled input, avoid SOQL/DML in loops, enforce FLS via `WITH SECURITY_ENFORCED`, and have ≥90% test coverage. Run `pmd check --dir packages/sfdx-package/force-app/main/default/classes/ --rulesets scripts/pmd-ruleset.xml --format text --fail-on-violation` before any deploy. Zero violations required.
+
+**OAuth PKCE flow for mobile:**
+1. Generate `code_verifier` (43–128 char URL-safe random string)
+2. Generate `code_challenge` = BASE64URL(SHA256(code_verifier))
+3. Authorization URL: `{instanceUrl}/services/oauth2/authorize?response_type=code&client_id={id}&redirect_uri={uri}&code_challenge={challenge}&code_challenge_method=S256`
+4. Exchange code: POST to `{instanceUrl}/services/oauth2/token` with `code_verifier`
+5. Store `access_token` + `refresh_token` in `expo-secure-store`
+
+**Token refresh pattern:**
+```typescript
+async function refreshAccessToken(refreshToken: string): Promise<string> {
+  const response = await fetch(`${instanceUrl}/services/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: SF_CLIENT_ID,
+      refresh_token: refreshToken,
+    }).toString(),
+  });
+  const data = await response.json();
+  if (!data.access_token) throw new Error('Token refresh failed');
+  return data.access_token;
+}
+```
+
+**Salesforce REST API rules:**
+- Always include `Authorization: Bearer {token}` header
+- `Content-Type: application/json` for POST/PATCH
+- Use `/services/data/v59.0/` (or latest available)
+- Create: `POST /sobjects/{ObjectName}/`
+- Update: `PATCH /sobjects/{ObjectName}/{id}`
+- Composite (batch creates): `POST /composite/`
+- Error shape: `[{ message, errorCode, fields }]`
+
+**Ohanafy namespace:** `ohfy__` for existing objects, `ohfy_field__` for new objects in this module
+
+**LWC wire adapter pattern:**
+```javascript
+@wire(getRecentVisits, { repId: '$repId', limit: 10 })
+wiredVisits({ data, error }) {
+  if (data) this.visits = data;
+  if (error) this.error = error;
+}
+```
+
+Reference `references/trailheadapps/lwc-recipes/` for LWC patterns.
+Reference `references/sfdx-isv/sfdx-falcon-template/` for 2GP structure.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,80 @@
+---
+name: test-writer
+description: Expert in Jest + React Native Testing Library + Maestro E2E. Trigger when creating test files, when asked to "write tests", "add coverage", "test this", or when a feature is marked as needing tests. Also trigger on Day 5 test suite work. Trigger on any file matching *.test.ts, *.spec.ts, or files in __tests__/ or maestro/.
+---
+
+You are a test engineer specializing in React Native mobile apps. You write tests that are fast, reliable, and actually test the right things.
+
+**TDD workflow you enforce:**
+1. Write the failing test FIRST
+2. Run it — confirm it fails (red)
+3. Write the minimum implementation to pass
+4. Confirm it passes (green)
+5. Refactor — test must stay green
+
+**Jest unit test patterns:**
+```typescript
+// Arrange → Act → Assert — always this structure
+describe('functionName', () => {
+  describe('with valid input', () => {
+    it('returns expected result', () => {
+      // Arrange
+      const input = { ... };
+      // Act
+      const result = functionName(input);
+      // Assert
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('with edge case', () => {
+    it('handles edge case gracefully', () => {
+      // ...
+    });
+  });
+});
+```
+
+**WatermelonDB integration tests:**
+```typescript
+// Always use in-memory SQLite adapter for tests
+const adapter = new SQLiteAdapter({ schema, dbName: ':memory:' });
+const db = new Database({ adapter, modelClasses });
+// Seed data in beforeEach, teardown in afterEach
+```
+
+**AI tool tests — fixture-based, no real API calls:**
+```typescript
+// Mock the Anthropic SDK — no real calls in CI
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class Anthropic {
+    messages = { create: vi.fn() };
+  }
+}));
+// Test the tool handler directly with fixture inputs
+```
+
+**Maestro YAML patterns:**
+```yaml
+# Always start with a known state
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+# Use data-testid attributes for stability
+- tapOn:
+    id: "account-card-the-rail"
+# Use assertVisible to confirm state, not just tapOn
+- assertVisible: "InsightBanner"
+# Test offline: toggle airplane mode via Maestro device API
+```
+
+**Coverage requirements:**
+- `src/ai/`: ≥ 90% lines
+- `src/zpl/templates/`: 100% lines
+- `src/sync/`: ≥ 85% lines
+- `src/utils/`: ≥ 90% lines
+- Never write tests that test implementation details — test behavior
+
+Reference `references/testing-library/react-native-testing-library/docs/` for RNTL API.
+Reference `references/mobile-dev-inc/maestro/docs/` for Maestro YAML syntax.

--- a/.claude/agents/voice-ui-designer.md
+++ b/.claude/agents/voice-ui-designer.md
@@ -1,0 +1,34 @@
+---
+name: voice-ui-designer
+description: Specialist in mobile voice UX for noisy environments. Trigger when working on VoiceButton.tsx, VoiceStateMachine.ts, TranscriptDisplay.tsx, CommandFeedback.tsx, or any file related to speech recognition or voice commands. Also trigger when the user says "voice", "mic", "speech", or "dictation".
+---
+
+You are a voice UX designer and React Native engineer. You specialize in building voice interfaces that work in loud, distracting real-world environments (bars, warehouses, truck cabs).
+
+**Voice UX principles you apply:**
+1. **Forgiving input** — the interface assumes the user spoke correctly; it never blames the user for misrecognition
+2. **Instant feedback** — interim transcript must appear within 200ms of first word; users need to see the system is hearing them
+3. **Graceful degradation** — if recognition fails, offer to retry; never crash or show an error screen
+4. **Confirmation before action** — nothing changes until the user accepts; the AI suggests, the human confirms
+5. **One tap to undo** — every voice action can be rejected with one tap
+
+**State machine you enforce:**
+IDLE → LISTENING → PROCESSING → CONFIRMING → IDLE
+- IDLE → LISTENING: requires microphone permission (handle gracefully if denied)
+- LISTENING → PROCESSING: on silence > 1.5s or manual stop
+- PROCESSING → CONFIRMING: on AI response (structured CommandAction received)
+- CONFIRMING → IDLE: on Accept/Reject tap or 5s auto-timeout
+
+**React Native Voice API patterns:**
+- Always call `Voice.destroy()` in cleanup
+- Use `onSpeechPartialResults` for interim transcript display
+- `onSpeechError` must never surface a technical error code — translate to human language
+- Set `locale` based on device region
+
+**Reanimated animation patterns for voice:**
+- Mic button pulse while LISTENING: `useSharedValue` → `withRepeat(withTiming(...))`
+- Transcript fade-in: `FadeIn` layout animation
+- CommandFeedback slide-up: `SlideInDown` from Reanimated layout animations
+- All animations must be interruptible — never block user interaction
+
+Reference `references/software-mansion/react-native-reanimated/docs/` for animation APIs.

--- a/.claude/agents/zpl-engineer.md
+++ b/.claude/agents/zpl-engineer.md
@@ -1,0 +1,45 @@
+---
+name: zpl-engineer
+description: Expert in ZPL II (Zebra Programming Language) label design, Zebra printer hardware, and the Labelary preview API. Trigger when working in src/zpl/, when creating or modifying label templates, when asked about "ZPL", "label", "shelf talker", "Zebra", "printer", or "Labelary". Also trigger on any file matching *label*, *zpl*, *template* in the zpl/ directory.
+---
+
+You are a ZPL label engineer. You design labels for Zebra mobile printers (ZQ520, ZQ630) and write TypeScript functions that generate ZPL II strings.
+
+**ZPL II fundamentals:**
+- Every label: `^XA` (start) ... `^XZ` (end). No exceptions.
+- `^CI28` immediately after `^XA` — UTF-8 character set
+- `^PW` — print width in dots. 8dpmm × 25.4 × inches = dots
+- `^LL` — label length in dots. Same formula.
+- `^FO x,y` — field origin. x = distance from left edge, y = distance from top. Both in dots.
+- `^A0N,h,w` — scalable font. h = height in dots, w = width in dots. Use for all text.
+- `^FD text ^FS` — field data. Always end with `^FS`.
+- `^GB w,h,t` — graphic box. w = width, h = height, t = thickness.
+
+**Hardware targets:**
+| Printer | DPI | dpmm | Max width |
+|---|---|---|---|
+| ZQ520 | 203 | 8 | 2" or 4" stock |
+| ZQ630 | 300 | 12 | 4" stock |
+- Default all templates for 8dpmm (203dpi) unless otherwise specified
+- 4" labels: `^PW640` (4" × 8dpmm × 20)
+- 2.5" labels: `^PW400` (2.5" × 8dpmm × 20... approx; test with Labelary)
+
+**Text safety rules:**
+- Always truncate text that could overflow the label. Use `.substring(0, n)` with `…` suffix.
+- Max chars per line at 36pt: ~22 chars on a 2.5" label, ~28 chars on a 4" label
+- Never place a `^FO x` closer than 20 dots to the right edge
+- Verify every template against Labelary before committing: `POST http://api.labelary.com/v1/printers/8dpmm/labels/{W}x{H}/0/`
+
+**TypeScript pattern:**
+```typescript
+export function generateLabel(params: LabelParams): string {
+  // 1. Validate and truncate all string inputs
+  // 2. Build ZPL as array of lines
+  // 3. Join with '\n'
+  // 4. Return string — never side effects in the generator
+}
+```
+
+**Testing rule:** Every template must have a Vitest snapshot test AND a Labelary live-render verification in the test comment. Snapshot tests catch regressions; Labelary verification catches render errors the snapshot won't.
+
+Reference Zebra Developer Portal ZPL II Programming Guide (linked in `references/` README) for command reference.

--- a/.claude/commands/a11y-audit.md
+++ b/.claude/commands/a11y-audit.md
@@ -1,0 +1,32 @@
+---
+name: a11y-audit
+description: Runs an accessibility audit on a screen or component. Checks VoiceOver/TalkBack compliance, tap target sizes, Dynamic Type support, and color contrast. Usage: /a11y-audit [screen-or-component-path]
+---
+
+For the specified file, audit:
+
+1. **Interactive elements** — every TouchableOpacity/Pressable/Button has:
+   - `accessibilityRole`
+   - `accessibilityLabel` (no "tap to" — just what it is)
+   - `accessibilityHint` (what happens)
+   - `accessibilityState` if disabled or selected
+
+2. **Tap targets** — every interactive element:
+   - Minimum 44×44pt (use `hitSlop` if smaller)
+   - Report all elements that may be too small
+
+3. **Images** — every Image has:
+   - `accessibilityLabel` if meaningful
+   - `accessible={false}` if decorative
+
+4. **Lists** — every FlashList/FlatList:
+   - Has `accessibilityLabel` with item count
+   - Items announce their key information
+
+5. **Dynamic Type** — no fixed heights on Text containers, `allowFontScaling` not false
+
+6. **Loading/error states** — have `accessibilityLiveRegion="polite"`
+
+7. **Custom actions** — swipe-to-delete has keyboard/screen reader alternative
+
+Report: a numbered list of violations with file:line and the fix. Severity: high/medium/low.

--- a/.claude/commands/daily-retro.md
+++ b/.claude/commands/daily-retro.md
@@ -1,0 +1,19 @@
+---
+name: daily-retro
+description: Fills in today's retrospective in §25 of the Product Bible. Run at end of each day. Usage: /daily-retro [day-number]
+---
+
+1. Read the Day [N] targets from §9 of OHANAFY-FIELD-PRODUCT-BIBLE.md
+2. Check each target against the current codebase
+3. Fill in the Day [N] Retro in §25:
+   - Targets completed: list each with [x]
+   - Targets missed: list each with [ ] and why
+   - Blockers: any unresolved issues
+   - Tomorrow's first two targets: the highest-priority incomplete items
+
+4. Generate a daily build health summary:
+   - Run `npx jest --coverage --silent` → report coverage %
+   - Run `npx tsc --noEmit` → report zero or count of errors
+   - Report total Sentry errors in the last 24 hours (if accessible)
+
+5. Commit the updated Product Bible: `docs: day [N] retro`

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,19 @@
+---
+name: handoff
+description: Generates a session handoff document for the next Claude Code session. Run at the end of every work session. Creates HANDOFF.md with current state, uncommitted changes, and next priorities.
+---
+
+Generate `HANDOFF.md` in the project root with:
+
+1. **Session summary** — date, time, what was accomplished (from recent git log)
+2. **Current branch and status** — `git status` output, any uncommitted changes
+3. **Day N status** — which Product Bible targets are complete, which are not
+4. **Blockers** — any unresolved issues or decisions
+5. **Next 3 priorities** — exactly what the next session should do first
+6. **Files in progress** — any files that are partially implemented (incomplete functions, TODO comments)
+7. **Test status** — last jest run result, any failing tests
+8. **Known issues** — bugs found but not yet fixed
+
+Commit HANDOFF.md with message: `chore: session handoff [date]`
+
+The next session starts with: "Read HANDOFF.md. Confirm you understand the current state. Then proceed."

--- a/.claude/commands/new-ai-tool.md
+++ b/.claude/commands/new-ai-tool.md
@@ -1,0 +1,27 @@
+---
+name: new-ai-tool
+description: Scaffolds a new Claude AI tool — Zod schema, tool definition, handler, test with fixtures, and wires it into the tools index. Usage: /new-ai-tool [tool-name] [description]
+---
+
+Scaffold the following for tool `[tool-name]`:
+
+1. **Tool file** at `src/ai/tools/[tool-name].ts`:
+   - Zod InputSchema
+   - Zod OutputSchema
+   - Tool definition (name, description, input_schema)
+   - Handler function (pure TypeScript — no AI calls inside)
+   - Export both the tool and the handler
+
+2. **Test file** at `__tests__/unit/ai/[tool-name].test.ts`:
+   - 5 fixture test cases (happy path, edge case, invalid input, empty input, boundary value)
+   - All use static fixtures — no real Anthropic API calls
+   - Mock the Anthropic SDK
+
+3. **Fixture file** at `__tests__/fixtures/[tool-name]-inputs.ts`:
+   - At least 5 sample inputs with expected outputs
+
+4. **Wire into index** — add export to `src/ai/tools/index.ts`
+
+5. **Update CLAUDE.md** — add a one-line description of the new tool to the "AI Tools" section
+
+Report: what the tool does, its inputs, its outputs, and which agent should call it.

--- a/.claude/commands/new-screen.md
+++ b/.claude/commands/new-screen.md
@@ -1,0 +1,30 @@
+---
+name: new-screen
+description: Scaffolds a new Expo Router screen with all boilerplate — TypeScript, NativeWind, ErrorBoundary, HelpButton, accessibility, dark mode, skeleton state, and empty state. Usage: /new-screen [name] [route-path]
+---
+
+When invoked, scaffold the following for screen `[name]` at `app/[route-path].tsx`:
+
+1. **Screen file** with:
+   - TypeScript props interface
+   - ErrorBoundary wrapper
+   - HelpButton in header right
+   - LoadingSkeleton during data fetch
+   - EmptyState when no data
+   - Dark mode support (NativeWind `dark:` variants)
+   - `accessibilityLabel` on root View
+
+2. **Unit test** at `__tests__/unit/screens/[name].test.tsx` with:
+   - Renders without crashing
+   - Shows skeleton while loading
+   - Shows empty state with no data
+   - Shows content when data present
+
+3. **Maestro flow stub** at `maestro/flows/[name].yaml` with:
+   - launchApp + navigate to this screen
+   - assertVisible of primary content
+   - TODO comment for specific assertions
+
+4. **Help content** — add entry to `src/components/shared/HelpButton.tsx` HelpContent map
+
+Report: file paths created, next step (populate the data hook).

--- a/.claude/commands/new-zpl-template.md
+++ b/.claude/commands/new-zpl-template.md
@@ -1,0 +1,33 @@
+---
+name: new-zpl-template
+description: Creates a new ZPL label template — TypeScript generator, Vitest snapshot test, Labelary preview verification. Usage: /new-zpl-template [name] [width-inches] [height-inches]
+---
+
+Scaffold for template `[name]` at `[W]"×[H]"`:
+
+1. **Template file** at `src/zpl/templates/[name].ts`:
+   - Params interface with JSDoc for each field
+   - Generator function that returns a ZPL string
+   - Input validation and truncation for all string fields
+   - All `^FO x` coordinates verified to be within (`^PW` - 20) dots
+
+2. **Test file** at `__tests__/unit/zpl/[name].test.ts`:
+   - Starts with ^XA, ends with ^XZ
+   - Contains ^CI28
+   - No ^FO x coordinate > (label_width_dots - 20)
+   - Long strings are truncated
+   - Price formatted correctly ($X.XX)
+   - Snapshot test (`.toMatchSnapshot()`)
+
+3. **Labelary verification comment** — add to the test file:
+   ```
+   // Verify with Labelary:
+   // curl -X POST 'http://api.labelary.com/v1/printers/8dpmm/labels/[W]x[H]/0/'
+   //   --data-urlencode '@zpl-string.txt' --output preview.png && open preview.png
+   ```
+
+4. **Add to ZPL engine index** — export from `src/zpl/index.ts`
+
+5. **Add to label selector** — add the template type to `LabelSelector.tsx`
+
+Report: the template's exact dimensions, target printer, and primary use case.

--- a/.claude/commands/perf-audit.md
+++ b/.claude/commands/perf-audit.md
@@ -1,0 +1,18 @@
+---
+name: perf-audit
+description: Audits a screen or component for React Native performance issues — unnecessary re-renders, unoptimized lists, missing memoization, heavy computations in render. Usage: /perf-audit [file-path]
+---
+
+Audit the specified file for:
+
+1. **FlatList** — any FlatList for > 10 items (replace with FlashList)
+2. **Missing React.memo** — components that receive complex object props
+3. **Anonymous functions in JSX** — `onPress={() => fn(args)}` (use useCallback)
+4. **Computed values in render** — array operations (filter, sort, map) without useMemo
+5. **Missing keyExtractor** or using array index as key
+6. **Missing estimatedItemSize** on FlashList
+7. **State that could be derived** — state that duplicates something in a query
+8. **Unsubscribed WatermelonDB observations** — missing cleanup in useEffect
+9. **Heavy synchronous operations on the JS thread** — crypto, large string processing
+
+Report: numbered list of issues with file:line, severity (high/medium/low), and the fix.

--- a/.claude/hooks/post-commit-log.sh
+++ b/.claude/hooks/post-commit-log.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Appends significant commits to a daily log for retro and handoff
+
+COMMIT_MSG=$(git log -1 --pretty=%B)
+COMMIT_HASH=$(git log -1 --pretty=%h)
+TIMESTAMP=$(date '+%H:%M')
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Only log feat:, fix:, test:, a11y:, perf:, and docs: commits
+if echo "$COMMIT_MSG" | grep -qE "^(feat|fix|test|a11y|perf|docs|refactor)\("; then
+  LOG_FILE="DAILY_LOG_$(date '+%Y-%m-%d').md"
+
+  if [ ! -f "$LOG_FILE" ]; then
+    echo "# Daily Log — $(date '+%B %d, %Y')" > "$LOG_FILE"
+    echo "" >> "$LOG_FILE"
+  fi
+
+  echo "- [$TIMESTAMP] \`$COMMIT_HASH\` — $COMMIT_MSG" >> "$LOG_FILE"
+fi

--- a/.claude/hooks/pre-merge-checklist.sh
+++ b/.claude/hooks/pre-merge-checklist.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Verifies a PR is ready to merge
+
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+echo "═══════════════════════════════════════"
+echo "  Pre-Merge Checklist: $PR_BRANCH"
+echo "═══════════════════════════════════════"
+echo ""
+
+echo "Required before merge:"
+echo "  [ ] TypeScript: npx tsc --noEmit → 0 errors"
+echo "  [ ] Lint: npx eslint src/ app/ → 0 warnings"
+echo "  [ ] Tests: npx jest --coverage → thresholds met"
+echo "  [ ] New screen/component: /a11y-audit run"
+echo "  [ ] New list: FlashList + estimatedItemSize"
+echo "  [ ] New AI feature: FeedbackCapture component added"
+echo "  [ ] New ZPL template: Labelary verified"
+echo "  [ ] Dark mode: tested on both themes"
+echo "  [ ] Offline: tested in airplane mode"
+echo ""
+
+# Ask for confirmation
+read -p "Have you verified all items above? (y/N): " CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+  echo "❌ Merge blocked. Complete the checklist first."
+  exit 1
+fi
+
+echo "✅ Checklist confirmed. Proceeding with merge."

--- a/.claude/hooks/pre-push-quality-gate.sh
+++ b/.claude/hooks/pre-push-quality-gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Blocks push if quality gates fail
+
+set -e
+echo "→ Running pre-push quality gate..."
+
+# 1. TypeScript check
+echo "   Checking TypeScript..."
+npx tsc --noEmit || {
+  echo "❌ TypeScript errors found. Fix before pushing."
+  exit 1
+}
+
+# 2. Lint check
+echo "   Checking lint..."
+npx eslint src/ app/ --ext .ts,.tsx --max-warnings 0 || {
+  echo "❌ ESLint warnings/errors found. Fix before pushing."
+  exit 1
+}
+
+# 3. Test check (fast — no coverage on push, only in CI)
+echo "   Running tests..."
+npx jest --passWithNoTests --bail 1 || {
+  echo "❌ Tests failing. Fix before pushing."
+  exit 1
+}
+
+# 4. Credential scan (simple)
+echo "   Scanning for credentials..."
+if git diff HEAD~1..HEAD --name-only | xargs grep -l "sk-ant-\|00D[A-Z0-9]\{15\}" 2>/dev/null; then
+  echo "❌ Possible credential in diff. Check and remove before pushing."
+  exit 1
+fi
+
+echo "✅ Quality gate passed. Pushing."

--- a/.claude/rules/accessibility-mandatory.md
+++ b/.claude/rules/accessibility-mandatory.md
@@ -1,0 +1,18 @@
+# Rule: Accessibility Is Mandatory
+
+**Scope:** All .tsx component files
+
+Accessibility is part of the definition of done — not a post-launch task.
+
+Every PR that adds a new interactive element must include:
+- `accessibilityRole`
+- `accessibilityLabel`
+- `accessibilityHint` (unless the action is completely obvious from the label)
+
+Every PR that adds a new list must include:
+- `accessibilityLabel` with item count on the FlashList
+
+Every PR that adds a loading state must include:
+- `accessibilityLiveRegion="polite"` so screen readers announce when content loads
+
+**The test:** Run `/a11y-audit [changed file]` before marking any component PR as done.

--- a/.claude/rules/ai-never-invents.md
+++ b/.claude/rules/ai-never-invents.md
@@ -1,0 +1,22 @@
+# Rule: AI Never Invents Data
+
+**Scope:** All files in src/ai/
+
+The AI layer may:
+- Interpret natural language input
+- Summarize or clean text the user provided
+- Suggest products from the catalog
+- Surface patterns from the user's own history
+- Generate structured output from structured input
+
+The AI layer may NEVER:
+- Create account names, contact names, or addresses
+- Invent product names, SKU codes, or prices not in the product catalog
+- Fabricate historical order data
+- Generate visit notes that weren't dictated by the rep
+- Hallucinate Salesforce record IDs
+
+**Enforcement pattern:**
+Every tool handler that touches account/product data must validate against the local WatermelonDB — not against Claude's knowledge. Claude's knowledge of specific company data is not reliable.
+
+**The test:** every tool handler test should include a fixture with an unknown product name — the handler must return `confidence: 'low'` or an empty result, never a fabricated match.

--- a/.claude/rules/error-boundaries-everywhere.md
+++ b/.claude/rules/error-boundaries-everywhere.md
@@ -1,0 +1,13 @@
+# Rule: Error Boundaries on Every Screen
+
+**Scope:** All app/**/*.tsx screen files (not components)
+
+Every screen-level component must be wrapped in `<ErrorBoundary screenName="ScreenName">`.
+
+The ErrorBoundary must:
+- Show a human-readable error message (not a technical stack trace)
+- Show a "Try Again" button that resets the error state
+- Log the error to Sentry with the screenName tag
+- Never crash the entire app due to one screen's error
+
+**The test:** throw `new Error('test')` inside the screen's render function. Confirm the ErrorBoundary catches it and shows the fallback UI. Then remove the throw.

--- a/.claude/rules/no-credentials-in-code.md
+++ b/.claude/rules/no-credentials-in-code.md
@@ -1,0 +1,15 @@
+# Rule: No Credentials in Code
+
+**Scope:** All files
+
+Zero tolerance. Any API key, token, password, or secret must live in:
+- `.env.local` for local development (gitignored)
+- EAS Secrets for CI/production builds
+
+**Violations that will cause the pre-push hook to fail:**
+- Any string matching `sk-ant-` (Anthropic key)
+- Any string matching `Bearer ` followed by a 40+ char token
+- Any string matching `password` as a variable name with a non-empty string value
+- Any string matching `00D` followed by 15 chars (Salesforce org ID in a string literal)
+
+**The fix:** move to `process.env.EXPO_PUBLIC_*` (public) or SecureStore (private runtime values).

--- a/.claude/rules/offline-first.md
+++ b/.claude/rules/offline-first.md
@@ -1,0 +1,16 @@
+# Rule: Offline First
+
+**Scope:** All files in src/db/, src/sync/, src/hooks/, app/**/*.tsx
+
+Every data read in the render path must be satisfied from WatermelonDB without requiring network access. Network is ONLY permitted in:
+- The sync engine (src/sync/)
+- The AI tools (src/ai/) — these are gracefully hidden if offline
+- Authentication (src/auth/) — on first launch only
+
+**Violations to flag:**
+- Direct fetch() calls inside screen components
+- useQuery() with no offline fallback
+- Loading states that spin indefinitely (no cached data shown while loading)
+- Any component that throws an error when `navigator.onLine === false`
+
+**The test:** mentally simulate airplane mode. If the screen shows an error or spinner forever, it's a violation.

--- a/.claude/rules/tdd-required.md
+++ b/.claude/rules/tdd-required.md
@@ -1,0 +1,16 @@
+# Rule: Test-Driven Development Required
+
+**Scope:** src/ai/tools/, src/zpl/templates/, src/sync/, src/utils/
+
+For every new function in these directories:
+1. Write the failing test FIRST
+2. Confirm it fails (run jest and see the failure)
+3. Implement the function
+4. Confirm it passes
+5. Add edge cases
+
+**Exceptions (not TDD, but still requires tests):**
+- UI components — write tests after implementation, before the PR
+- WatermelonDB model classes — test queries in integration tests
+
+**The pre-push hook checks:** if a new .ts file in the above directories exists without a corresponding .test.ts file, the push is blocked with: "Missing test file for [filename]. Add tests or use /new-ai-tool or /new-zpl-template commands."

--- a/.claude/rules/typescript-strict.md
+++ b/.claude/rules/typescript-strict.md
@@ -1,0 +1,15 @@
+# Rule: TypeScript Strict Mode
+
+**Scope:** All .ts and .tsx files
+
+TypeScript strict mode is non-negotiable. Enforce:
+- No `any` types — use `unknown` + type narrowing, or define the proper interface
+- No `// @ts-ignore` — fix the type error
+- No `as unknown as TargetType` double casting — define a proper type guard
+- No `!` non-null assertions without a comment explaining why it's safe
+- Every function has explicit return type
+- Every component has explicit props interface
+
+**When adding new dependencies:** check if `@types/package-name` is available. If not, write a `.d.ts` declaration file.
+
+**The test:** `npx tsc --noEmit` must exit 0 before every commit.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://anthropic.com/claude-code/settings.schema.json",
+  "model": "claude-opus-4-5",
+  "tools": {
+    "enabled": ["bash", "view", "str_replace", "create_file"]
+  },
+  "hooks": {
+    "postCommit":  ".claude/hooks/post-commit-log.sh",
+    "prePush":     ".claude/hooks/pre-push-quality-gate.sh",
+    "preMerge":    ".claude/hooks/pre-merge-checklist.sh"
+  },
+  "contextFiles": [
+    "CLAUDE.md",
+    "OHANAFY-FIELD-PRODUCT-BIBLE.md"
+  ],
+  "ignorePatterns": [
+    "references/**",
+    "node_modules/**",
+    ".expo/**",
+    "android/**",
+    "ios/**",
+    "*.generated.*"
+  ]
+}

--- a/.claude/skills/claude-tool-use-streaming.md
+++ b/.claude/skills/claude-tool-use-streaming.md
@@ -1,0 +1,64 @@
+# Claude API Tool Use + Streaming Patterns
+
+## Tool definition (TypeScript)
+```typescript
+import { Tool } from '@anthropic-ai/sdk/resources';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const InputSchema = z.object({ transcript: z.string().min(1).max(500) });
+
+export const myTool: Tool = {
+  name: 'tool_name',
+  description: 'What it does. When to call it (specific conditions). What it returns.',
+  input_schema: zodToJsonSchema(InputSchema) as Tool['input_schema'],
+};
+```
+
+## Streaming with tool use
+```typescript
+const stream = await anthropic.messages.stream({
+  model: 'claude-sonnet-4-20250514',
+  max_tokens: 1000,
+  system: SYSTEM_PROMPT,
+  tools: [tool1, tool2],
+  messages: [{ role: 'user', content: userMessage }],
+});
+
+for await (const chunk of stream) {
+  if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+    onTextToken(chunk.delta.text);  // stream to UI
+  }
+}
+
+const message = await stream.finalMessage();
+// Extract tool use block
+const toolUse = message.content.find(b => b.type === 'tool_use');
+if (toolUse?.type === 'tool_use') {
+  const result = await toolHandlers[toolUse.name](toolUse.input);
+  // Build follow-up message with tool_result
+}
+```
+
+## Memory injection template
+```typescript
+const memoriesContext = memories.length > 0
+  ? `\n\nKnown patterns for this rep:\n${memories.map(m =>
+      `- [${m.category}] ${m.key}: ${m.value} (${(m.confidence*100).toFixed(0)}% confidence)`
+    ).join('\n')}`
+  : '';
+
+const systemWithMemory = SYSTEM_PROMPT + memoriesContext;
+```
+
+## Error handling
+```typescript
+try {
+  const response = await anthropic.messages.create({ ... });
+} catch (error) {
+  if (error instanceof Anthropic.APIError) {
+    if (error.status === 529) // overloaded — retry with backoff
+    if (error.status === 400) // bad request — log and surface to user
+  }
+}
+```

--- a/.claude/skills/maestro-e2e-patterns.md
+++ b/.claude/skills/maestro-e2e-patterns.md
@@ -1,0 +1,48 @@
+# Maestro E2E Patterns for Ohanafy Field
+
+## Flow file structure
+```yaml
+appId: com.ohanafy.field
+---
+# Comment describing what this flow tests
+- launchApp:
+    clearState: true   # always start clean
+    env:
+      MAESTRO_TEST_MODE: "true"
+```
+
+## Test data strategy
+All E2E tests use seeded test data (via MAESTRO_TEST_MODE env var).
+In test mode, the app loads from a static JSON fixture instead of Salesforce.
+Never use production Salesforce data in E2E tests.
+
+## Stable selectors (in priority order)
+1. `id: "data-testid-value"` — most stable; add data-testid to all testable elements
+2. `text: "Exact text"` — stable if text is static (not from API)
+3. `accessibilityLabel: "Label"` — good; also tests a11y
+4. Avoid: element type selectors (`button`, `text`) — too fragile
+
+## Offline testing
+```yaml
+# Enable airplane mode
+- setLocation:
+    lat: 0
+    lon: 0
+# Or use Maestro's network control
+- stopNetwork
+# ...test offline behavior...
+- startNetwork
+- assertVisible: "Synced ✓"
+```
+
+## Timing
+```yaml
+# Wait for async operations
+- waitForAnimationToEnd
+- waitFor:
+    visible: "Account list"
+    timeout: 3000   # ms
+```
+
+## Screenshot on failure
+Maestro auto-captures screenshots on failure. Check `.maestro/` output directory after failures.

--- a/.claude/skills/nativewind-patterns.md
+++ b/.claude/skills/nativewind-patterns.md
@@ -1,0 +1,27 @@
+# NativeWind v4 Patterns for Ohanafy Field
+
+## Brand token usage
+Always use semantic tokens from tailwind.config.js, never raw colors:
+- `bg-ohanafy-primary` not `bg-blue-600`
+- `text-ohanafy-ink` not `text-gray-900`
+- `dark:bg-ohanafy-dark-surface` for dark mode surfaces
+
+## Platform-specific classes
+- `ios:pt-safe` — iOS safe area top
+- `android:pt-4` — Android has no notch
+- `ios:rounded-xl android:rounded-lg` — platform-native feel
+
+## Component patterns
+Sheet bottom: `rounded-t-3xl bg-white dark:bg-ohanafy-dark-surface`
+Card: `bg-white dark:bg-ohanafy-dark-surface rounded-2xl shadow-sm p-4`
+Badge: `rounded-full px-2 py-0.5 text-xs font-semibold`
+Section header: `text-xs font-semibold uppercase tracking-wider text-gray-500`
+
+## Responsive (tablet split pane)
+Width check via `useTabletLayout()` hook — NOT via NativeWind breakpoints
+(RN doesn't have CSS media queries; use the custom hook instead)
+
+## Forbidden patterns
+- No `style={{}}` inline styles (exception: StyleSheet.hairlineWidth for borders)
+- No `text-black` or `text-white` (use theme tokens)
+- No fixed pixel dimensions for text containers (use min-height or flex)

--- a/.claude/skills/rn-performance-patterns.md
+++ b/.claude/skills/rn-performance-patterns.md
@@ -1,0 +1,53 @@
+# React Native Performance Patterns
+
+## The FlashList contract
+```typescript
+<FlashList
+  data={items}
+  renderItem={({ item }) => <MemoizedItem item={item} />}  // always memo
+  estimatedItemSize={MEASURED_ITEM_HEIGHT}  // measure once; never guess
+  getItemType={item => item.type}           // for heterogeneous lists
+  keyExtractor={item => item.id}
+  removeClippedSubviews={true}             // default true, be explicit
+/>
+```
+Rule: every list > 10 items uses FlashList. No FlatList in production.
+
+## Measuring estimatedItemSize
+```typescript
+// In development, log the actual height:
+onLayout={({ nativeEvent: { layout: { height } } }) => {
+  if (__DEV__) console.log('ItemHeight:', height);  // remove before shipping
+}}
+// Then set estimatedItemSize to the logged value
+```
+
+## The memo pattern
+```typescript
+const Item = React.memo(ItemBase, (prev, next) =>
+  // Only re-render if these specific fields changed
+  prev.item.id === next.item.id &&
+  prev.item.updatedAt === next.item.updatedAt &&
+  prev.isSelected === next.isSelected
+);
+```
+
+## Avoiding anonymous functions in JSX
+```typescript
+// BAD — creates new function on every render
+<Item onPress={() => navigate(item.id)} />
+
+// GOOD — stable reference
+const handlePress = useCallback(() => navigate(item.id), [item.id]);
+<Item onPress={handlePress} />
+```
+
+## Launch performance
+- Use expo-splash-screen to keep splash visible until DB hydrated
+- Hydrate WatermelonDB before rendering the account list
+- Defer non-critical init (PostHog, learning agent) with setTimeout(fn, 0)
+
+## Memory management
+- Unsubscribe from WatermelonDB observations in useEffect cleanup
+- Destroy Voice in cleanup: `Voice.destroy().then(Voice.removeAllListeners)`
+- Cancel in-flight fetch requests in useEffect cleanup

--- a/.claude/skills/sf-oauth-patterns.md
+++ b/.claude/skills/sf-oauth-patterns.md
@@ -1,0 +1,36 @@
+# Salesforce OAuth 2.0 PKCE Patterns
+
+## Flow summary
+1. Generate verifier + challenge (PKCE)
+2. Open authorizationEndpoint in system browser (expo-auth-session)
+3. App receives redirect with `code`
+4. Exchange code for tokens at tokenEndpoint
+5. Store tokens in expo-secure-store
+6. Auto-refresh: intercept 401, refresh, retry once
+
+## expo-auth-session boilerplate
+```typescript
+const discovery = {
+  authorizationEndpoint: `${SF_URL}/services/oauth2/authorize`,
+  tokenEndpoint: `${SF_URL}/services/oauth2/token`,
+};
+const request = new AuthSession.AuthRequest({
+  clientId: SF_CLIENT_ID,
+  scopes: ['api', 'refresh_token', 'offline_access'],
+  redirectUri: AuthSession.makeRedirectUri({ scheme: 'com.ohanafy.field' }),
+  usePKCE: true,
+});
+const result = await request.promptAsync(discovery);
+```
+
+## Token storage keys (SecureStore)
+- `sf_access_token`
+- `sf_refresh_token`
+- `sf_instance_url`
+- `anthropic_api_key` (retrieved from SF org settings post-auth)
+
+## Connected App settings (Salesforce)
+- OAuth scopes: api, refresh_token, offline_access
+- Callback URL: com.ohanafy.field://oauth/callback
+- PKCE: enabled (required)
+- IP relaxation: Relax IP restrictions (for mobile clients)

--- a/.claude/skills/watermelondb-patterns.md
+++ b/.claude/skills/watermelondb-patterns.md
@@ -1,0 +1,57 @@
+# WatermelonDB Patterns for Ohanafy Field
+
+## Always write inside transactions
+```typescript
+await database.write(async () => {
+  await collection.create(record => {
+    record.name = value;
+  });
+});
+```
+Writing outside transactions is silent corruption risk.
+
+## Reactive queries (UI layer)
+```typescript
+// In components: use withObservables HOC or useLiveQuery hook
+const accounts = useLiveQuery(
+  () => database.get<Account>('accounts').query(Q.where('needs_attention', true)),
+  []
+);
+```
+The UI re-renders automatically when the query result changes.
+
+## Non-reactive queries (in sync engine, agents)
+```typescript
+const items = await database.get<SyncQueueItem>('sync_queue')
+  .query(Q.where('status', 'pending'), Q.take(10))
+  .fetch();
+```
+
+## Migration pattern
+```typescript
+// src/db/migrations/index.ts
+import { schemaMigrations, addColumns } from '@nozbe/watermelondb/Schema/migrations';
+export default schemaMigrations({
+  migrations: [
+    {
+      toVersion: 2,
+      steps: [addColumns({ table: 'accounts', columns: [{ name: 'new_field', type: 'string' }] })],
+    },
+  ],
+});
+```
+Always increment `schema.version` AND add a migration. Mismatched versions crash on launch.
+
+## Index strategy
+Index: `sf_id`, `account_id`, `rep_id`, `status`, `sync_status`, `needs_attention`, `created_at`
+Do NOT index: `notes`, `raw_transcript`, `payload_json` (large text fields)
+
+## Batch operations
+```typescript
+await database.write(async () => {
+  await database.batch(
+    ...items.map(item => collection.prepareCreate(r => { r.field = item.value; }))
+  );
+});
+```
+Use `batch` for seeding or bulk updates — orders of magnitude faster than individual creates.

--- a/.claude/skills/zpl2-reference.md
+++ b/.claude/skills/zpl2-reference.md
@@ -1,0 +1,47 @@
+# ZPL II Quick Reference for Ohanafy Field
+
+## Hardware targets
+| Printer | dpmm | Dots per inch | Common label widths |
+|---|---|---|---|
+| ZQ520 | 8 | 203 | 2", 2.5", 4" |
+| ZQ630 | 12 | 300 | 4" |
+
+## Dot conversion
+dots = inches × dpmm × 25.4
+- 2.5" @ 8dpmm = 2.5 × 8 × 25.4 = ~508 dots (use ^PW400 for safe margin)
+- 4" @ 8dpmm = 4 × 8 × 25.4 = ~812 dots (use ^PW640 for safe margin)
+
+## Essential commands
+| Command | Purpose | Example |
+|---|---|---|
+| ^XA | Label start | ^XA |
+| ^XZ | Label end | ^XZ |
+| ^CI28 | UTF-8 charset | ^CI28 |
+| ^PW n | Print width (dots) | ^PW640 |
+| ^LL n | Label length (dots) | ^LL480 |
+| ^FO x,y | Field origin | ^FO30,25 |
+| ^A0N,h,w | Scalable font | ^A0N,36,36 |
+| ^FD text ^FS | Field data | ^FDYellowhammer Pale Ale^FS |
+| ^GB w,h,t | Graphic box (line) | ^GB580,2,2 |
+
+## Font size guide (at 8dpmm)
+| ^A0N height | Approx pt | Use for |
+|---|---|---|
+| 18 | ~7pt | Footer, secondary info |
+| 22 | ~9pt | Body, SKU codes |
+| 28 | ~11pt | Subheadings |
+| 36 | ~14pt | Product names |
+| 48 | ~19pt | Section headers |
+| 54+ | ~21pt+ | Price (most prominent) |
+
+## Labelary preview API
+POST http://api.labelary.com/v1/printers/{dpmm}dpmm/labels/{W}x{H}/{idx}/
+Content-Type: application/x-www-form-urlencoded
+Body: [ZPL string URL-encoded]
+Returns: PNG image
+
+## Safety rules
+1. Truncate all text inputs — never trust external strings
+2. Verify ^FO x coordinates: max x = ^PW value - 20 (margin)
+3. Always include ^CI28 for UTF-8 (special chars in product names)
+4. Test every new template against Labelary before printing on hardware

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# Ohanafy Field — environment example
+# Copy to .env.local (gitignored) and fill in real values for local dev.
+# Production values live in EAS Secrets — never commit real secrets here.
+#
+# Naming convention:
+#   EXPO_PUBLIC_*  → embedded in the mobile app bundle (visible in compiled JS)
+#   no prefix      → server-side / build-time only, NEVER shipped to the device
+#
+# Persistence across Conductor worktrees: edit ~/.config/ohanafy-field/.env.local
+# (the workspace .env.local is a symlink). Run `bash scripts/link-env.sh` once
+# per new worktree to set up the symlink.
+
+# ─── Salesforce ─────────────────────────────────────────────────────
+# External Client App (or Connected App in the AppExchange managed package).
+# OAuth 2.0 PKCE-enabled, scopes: api, refresh_token (= refresh_token + offline_access)
+#
+# Instance URL: use the My Domain salesforce.com URL, NOT the lightning.force.com URL.
+#   ✓ https://<my-domain>.my.salesforce.com
+#   ✗ https://<my-domain>.lightning.force.com
+EXPO_PUBLIC_SF_INSTANCE_URL=
+EXPO_PUBLIC_SF_CLIENT_ID=
+
+# Consumer Secret — NOT used by the mobile PKCE flow (PKCE replaces secrets for
+# public clients). Stored for: Apex callouts, server-side JWT bearer flow, refresh
+# token flow if "Require Secret for Refresh Token Flow" is enabled on the app.
+# DO NOT prefix with EXPO_PUBLIC_ — that would ship the secret to every device.
+SFDC_CONSUMER_SECRET=
+
+# ─── Anthropic Claude ────────────────────────────────────────────────
+# Dev only. Production reads the key from Salesforce Custom Metadata
+# (ohfy_field__AI_Config__mdt) post-auth. NOT prefixed with EXPO_PUBLIC_.
+ANTHROPIC_API_KEY=
+
+# ─── Sentry (error tracking) ─────────────────────────────────────────
+SENTRY_DSN=
+
+# ─── PostHog (product analytics) ─────────────────────────────────────
+EXPO_PUBLIC_POSTHOG_API_KEY=
+EXPO_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+
+# ─── Dev-only flags ──────────────────────────────────────────────────
+# Load fixture data instead of hitting Salesforce (Maestro tests, demo mode)
+EXPO_PUBLIC_USE_SEED_DATA=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Expo
+.expo/
+.expo-shared/
+dist/
+web-build/
+
+# Native
+ios/
+android/
+*.apk
+*.ipa
+*.app
+
+# Node / Metro
+node_modules/
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+.pnpm-debug.log*
+metro-cache/
+
+# Build artifacts
+*.generated.*
+*.tsbuildinfo
+coverage/
+
+# Reference repos (cloned by harness; not project code)
+references/
+
+# Salesforce CLI local cache (auto-generated org tracking)
+.sf/
+.sfdx/
+
+# Secrets (NEVER commit)
+.env.local
+.env.*.local
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*.swo
+
+# Daily logs (per-engineer, ephemeral)
+DAILY_LOG_*.md
+
+# Maestro local cache
+.maestro/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+# Ohanafy Field — Claude Code Project Context
+
+## What this is
+A production-quality native mobile app (iOS + Android) for field sales reps at
+beverage distributors. Offline-first, AI-powered, ZPL label printing.
+
+Built on: Expo SDK 52, React Native, TypeScript strict, Expo Router v3,
+NativeWind v4, WatermelonDB, TanStack Query, Zustand, Reanimated v3,
+FlashList, @react-native-voice/voice, Zebra Link-OS (custom Expo module),
+Anthropic Claude Sonnet API, Sentry, PostHog.
+
+## Session startup (required every session)
+1. Read this file completely
+2. Check HANDOFF.md (if exists) for prior session context
+3. Open OHANAFY-FIELD-PRODUCT-BIBLE.md §9 — identify today's day
+4. Read §25 for today's retro — what's done, what's not
+5. State your plan for this session in one sentence
+6. Begin
+
+---
+## Document hierarchy
+
+| Doc | Purpose | Read when |
+|---|---|---|
+| OHANAFY-FIELD-PRODUCT-BIBLE.md | Day-by-day engineering plan, architecture, full stack spec | Every session |
+| OHANAFY-FIELD-ROLES-AND-ADMIN.md | Six user roles, full permission matrix, admin console spec | Every session — adds work to every day |
+| OHANAFY-FIELD-APPEXCHANGE-SECURITY-REVIEW.md | Apex security requirements, PMD rules, submission checklist | Every session that touches Apex or LWC |
+| OHANAFY-FIELD-HARNESS.md | Reference only after Session 0 | If re-running setup |
+
+## Cross-doc rules
+
+The Roles doc is additive to the Product Bible. §12 of the Roles doc lists specific tasks added to Day 1 (permission system), the WatermelonDB schema (permissions table), Salesforce objects (6 new custom objects), and Maestro flows (5 new role-based E2E tests). These are not optional.
+
+The Security Review doc constrains every line of Apex. Before writing any .cls file, the salesforce-integration agent loads §3 of the Security Review doc. PMD runs in CI on every push — zero violations required.
+
+## Permanent behavioral rules across all sessions
+
+1. Permission system before any screen. The PermissionGate component and usePermissionStore must exist before any screen component is built. Roles determine navigation structure — screens built before permissions exist will need to be rebuilt.
+2. Every Apex class has explicit sharing declaration. No exceptions. Undeclared sharing = automatic AppExchange rejection.
+3. Every @AuraEnabled method validates its inputs. Null check, size limit, type check. Every one.
+4. PMD must pass before any SFDX deploy. Run: pmd check --dir packages/sfdx-package/force-app/main/default/classes/ --rulesets scripts/pmd-ruleset.xml --format text --fail-on-violation
+5. WatermelonDB writes always inside database.write(async () => { ... }). Never outside.
+6. FlashList for every list over 10 items. Never FlatList in production.
+7. Every component has accessibilityLabel on every interactive element.
+8. AI never invents data. Tool handlers validate against WatermelonDB. Never against Claude's knowledge.
+9. Feature freeze is end of Day 6. Day 7 is documentation and submission only.
+10. Run /handoff at the end of every session.
+---
+
+## Non-negotiables (§0 of Product Bible)
+1. Offline first — every read works in airplane mode
+2. Tests before features (TDD in src/ai/, src/zpl/, src/sync/)
+3. TypeScript strict — zero `any`, zero `@ts-ignore`
+4. Accessibility on every component — VoiceOver/TalkBack
+5. AI never invents data — validates against WatermelonDB
+6. ErrorBoundary on every screen
+7. Feature freeze: Day 6, 5pm. Day 7 is docs + submission only.
+
+## Available agents (delegate to these)
+- `rn-architect` — screen/component scaffold, navigation, WatermelonDB
+- `voice-ui-designer` — voice state machine, mic UI, transcript display
+- `ai-tool-builder` — Claude tool definitions, handlers, memory system
+- `zpl-engineer` — ZPL templates, printer integration, Labelary
+- `rn-accessibility` — VoiceOver, TalkBack, Dynamic Type, tap targets
+- `offline-sync-architect` — WatermelonDB patterns, SF REST, conflict resolution
+- `performance-engineer` — FlashList, Reanimated, bundle size, memory
+- `test-writer` — Jest unit tests, Maestro E2E flows, WDB integration tests
+- `salesforce-integration` — OAuth, REST API, LWC, SFDX
+
+## Available slash commands
+- `/new-screen [name] [route]` — scaffold a complete screen with all boilerplate
+- `/new-ai-tool [name] [desc]` — scaffold AI tool with tests and fixtures
+- `/new-zpl-template [name] [W] [H]` — scaffold ZPL template with validation
+- `/a11y-audit [file]` — accessibility audit with file:line violations
+- `/perf-audit [file]` — performance audit with ranked issues
+- `/handoff` — generate HANDOFF.md for next session
+- `/daily-retro [day]` — fill in §25 retro
+
+## Domain: beverage field sales rep
+Jake Thornton is a field sales rep at Yellowhammer Beverage (beer + Red Bull
+distributor, Birmingham AL). He visits 10 accounts per day, has a Zebra ZQ520
+printer on his belt, and often has no signal in back-of-house areas.
+
+Key vocabulary: account (retailer), visit, order, keg (1/2 bbl = 15.5gal),
+case (24-unit pack), route, territory, tap, depletion, STW, CDA, three-tier.
+
+NEVER say: fermenter, brewhouse, brewhouse, mash, grain bill, hop contracts.
+These are brewery words. Jake works for a distributor, not a brewery.
+
+## Architecture decisions (locked)
+| Decision | Choice |
+|---|---|
+| Framework | Expo SDK 52 + React Native |
+| Navigation | Expo Router v3 (file-based) |
+| Styling | NativeWind v4 (Tailwind in RN) |
+| Local DB | WatermelonDB (SQLite, reactive) |
+| Server state | TanStack Query v5 |
+| Client state | Zustand v4 |
+| Lists | Shopify FlashList (never FlatList for > 10 items) |
+| Animations | React Native Reanimated v3 |
+| Voice | @react-native-voice/voice (on-device) |
+| ZPL printing | Custom Expo module wrapping Zebra Link-OS SDK |
+| AI | Anthropic Claude Sonnet, tool use, streaming |
+| Error tracking | Sentry React Native |
+| Analytics | PostHog React Native |
+| E2E testing | Maestro |
+| Unit testing | Jest + React Native Testing Library |
+| Build/Submit | EAS (Expo Application Services) |
+
+## Code conventions
+- Commits: `feat(scope): description` / `fix(scope):` / `test(scope):` / `a11y(scope):` / `perf(scope):`
+- File names: kebab-case for route files, PascalCase for components
+- DB writes: always inside `database.write(async () => { ... })`
+- AI outputs: always have Accept/Edit/Reject path — never locked outputs
+- Errors: caught, logged to Sentry via `logger.error()`, shown to user with message
+- Imports: named imports from packages; barrel imports from src/ directories
+
+## Reference repos (read for patterns, don't copy verbatim)
+Path: `./references/`
+Key ones: expo/expo, Nozbe/WatermelonDB, Shopify/flash-list,
+nativewindui/nativewindui, mobile-dev-inc/maestro,
+hesreallyhim/awesome-claude-code, wshobson/agents
+
+## Environment
+- Dev: `.env.local` — EXPO_PUBLIC_* for public values, SecureStore for secrets
+- CI/Prod: EAS Secrets
+- Never hardcode any credential, API key, or token in source code
+
+## .env.local persistence across worktrees
+Credentials live in `~/.config/ohanafy-field/.env.local` (chmod 600, outside any worktree). Each Conductor worktree's `.env.local` is a symlink to that shared file. New worktree bootstrap:
+
+```bash
+bash scripts/link-env.sh
+```
+
+The script is idempotent — it promotes the first worktree's `.env.local` to the shared location, then symlinks every subsequent worktree's `.env.local` back to the same source. Edit credentials in one place; every worktree picks up the change.

--- a/HARNESS-VERIFICATION.md
+++ b/HARNESS-VERIFICATION.md
@@ -1,0 +1,162 @@
+# Ohanafy Field — Harness Verification (Session 0)
+
+**Generated:** 2026-04-25
+**Workspace:** `/Users/danielzeder/conductor/workspaces/ohanafy-field/da-nang-v1`
+**Branch:** `dzeder/ohanafy-field`
+**Setup script:** `scripts/setup-harness.sh` (run; full log at `.context/harness-setup.log`)
+
+Walking the §2 checklist from `OHANAFY-FIELD-HARNESS.md` item by item.
+
+Legend: ✔ pass · ✘ fail · ⚠ partial / manual action needed
+
+---
+
+## Claude Code plugins
+
+The harness §2 expects four named plugins. The plugin IDs in §1 of the harness do **not** exist in the marketplaces as documented (the script attempted them and each step was skipped with `(skip: ...)`). The marketplaces themselves were added successfully.
+
+| Item | Status | Notes |
+|---|---|---|
+| `anthropics/skills:document-skills` | ⚠ | marketplace `anthropic-agent-skills` added; plugin ID does not resolve — install attempt was skipped. |
+| `anthropics/skills:skill-creator` | ⚠ | same as above |
+| `obra/superpowers:test-driven-development` | ⚠ | marketplace `superpowers-dev` added; plugin ID does not resolve |
+| `obra/superpowers:systematic-debugging` | ⚠ | same as above |
+
+**Action:** The harness's plugin IDs were aspirational. Browse `claude plugin marketplace list anthropics/skills` and `… obra/superpowers` for the actual available skill names, then either install the equivalents or accept that these specific plugins aren't installable and rely on the in-repo agents/skills/rules instead. The in-repo `.claude/` files cover the same ground (TDD via `tdd-required.md` rule, etc.).
+
+---
+
+## Reference repos
+
+26 repos cloned to `references/`. Note: `gh repo clone` flattens to the repo's basename, so paths in the harness doc like `references/Nozbe/WatermelonDB/` are actually at `references/WatermelonDB/`.
+
+| Harness §2 item | Actual path | Status |
+|---|---|---|
+| `references/hesreallyhim/awesome-claude-code/` | `references/awesome-claude-code/` | ✔ |
+| `references/wshobson/agents/` | `references/agents/` | ✔ |
+| `references/expo/expo/` | `references/expo/` | ✔ |
+| `references/Nozbe/WatermelonDB/` (critical Day 1) | `references/WatermelonDB/` | ✔ |
+| `references/Shopify/flash-list/` (critical Day 2) | `references/flash-list/` | ✔ |
+| `references/mobile-dev-inc/maestro/` (critical Day 5) | `references/Maestro/` | ✔ |
+| `references/nativewindui/nativewindui/` (critical Day 1) | `references/nativewindui/` | ✔ — cloned from `roninoss/nativewindui` (harness doc had wrong org `nativewindui/nativewindui`; corrected) |
+| `references/getsentry/sentry-react-native/` | `references/sentry-react-native/` | ✔ |
+
+**Also cloned (from §3 catalog):** router, react-native-reanimated, axe-core, claude-cookbooks, claude-code-best-practice, awesome-claude-code-toolkit, agentic-ai-systems, ui (shadcn), tailwindcss, react-native-testing-library, lwc-recipes, sfdx-falcon-template, SalesforceMobileSDK-iOS, posthog-react-native, eslint-plugin-react-native-a11y (substitute for `FormidableLabs/react-native-a11y` which no longer exists at that path), typedoc, jsdoc.
+
+**Private Ohanafy repos** `ohanafy/ohanafy-managed-package` and `ohanafy/ohanafy-connect`: attempted with `dzeder`'s gh token; skipped (no access). Not blocking for Day 1 — read the existing managed package out-of-band when needed (or grant access to dzeder's account).
+
+---
+
+## .claude/ files
+
+| Item | Status | Detail |
+|---|---|---|
+| `.claude/settings.json` exists and parses | ✔ | `jq -e . .claude/settings.json` exits 0 |
+| `.claude/agents/` has 9 files | ✔ | 9 agents: rn-architect, voice-ui-designer, ai-tool-builder, zpl-engineer, rn-accessibility, offline-sync-architect, performance-engineer, test-writer, salesforce-integration |
+| `.claude/skills/` has 9 files | ⚠ 7 written | Harness §6 only specifies 7 skills (nativewind-patterns, watermelondb-patterns, claude-tool-use-streaming, zpl2-reference, sf-oauth-patterns, rn-performance-patterns, maestro-e2e-patterns). §2 verification asks for 9. Discrepancy in the source doc. **Optional follow-up:** add `ai-memory-system.md` and `roles-and-permissions.md` to reach 9 — neither is strictly necessary; the agents/rules cover the topics already. |
+| `.claude/commands/` has 7 files | ✔ | new-screen, new-ai-tool, new-zpl-template, a11y-audit, perf-audit, handoff, daily-retro |
+| `.claude/rules/` has 7 files | ✔ | offline-first, typescript-strict, ai-never-invents, accessibility-mandatory, error-boundaries-everywhere, no-credentials-in-code, tdd-required |
+| `.claude/hooks/` has 3 executable scripts | ✔ | post-commit-log.sh, pre-push-quality-gate.sh, pre-merge-checklist.sh — all `chmod +x` |
+
+---
+
+## Accounts and credentials
+
+| Item | Status | Action |
+|---|---|---|
+| `.env.local` exists with all keys from §10 of Bible | ⚠ | File created with all keys present but blank. **Fill in before Day 1 device run.** |
+| `.env.example` exists, committed | ✔ | All keys, values blank |
+| `eas whoami` returns your Expo account | ✘ | `eas-cli` not installed. **Run:** `npm install -g eas-cli && eas login` |
+| Apple Developer account active | ✘ | Manual: confirm at developer.apple.com — $99/yr |
+| Google Play Console account active | ✘ | Manual: confirm at play.google.com/console — $25 one-time |
+| Salesforce sandbox reachable + Ohanafy package installed | ✘ | Manual: provision sandbox, install `ohfy__` managed package, create Connected App with PKCE, scopes `api refresh_token offline_access`, callback `com.ohanafy.field://oauth/callback`. Capture URL + Client ID into `.env.local`. |
+| Anthropic API key valid | ✘ | Manual: generate at console.anthropic.com, add to `.env.local` (or store in SF org settings per §6 of Bible) |
+
+---
+
+## Toolchain
+
+| Item | Status | Detail |
+|---|---|---|
+| `node --version` ≥ 20 | ✔ | v24.10.0 |
+| `npx expo --version` ≥ 52 | ✔ | 55.0.26 |
+| Xcode installed + license accepted | ⚠ | CLI tools present (xcode-select 2410); **Xcode.app not installed** at `/Applications/Xcode.app`. Manual: install Xcode from Mac App Store, then `sudo xcodebuild -license accept`. |
+| Android Studio installed + emulator created | ✘ | Not installed. Manual: download from developer.android.com/studio, install, create AVD. |
+| `gh auth status` authenticated | ✔ | dzeder logged in (HTTPS, token scope `repo`+more) |
+
+### Additional tooling beyond §2
+
+| Item | Status | Action |
+|---|---|---|
+| `pmd` for Apex (Security Review §3, Day 4 onward) | ✘ | **Run:** `brew install pmd` |
+| `sfdx` / Salesforce CLI for managed package work | ✘ | **Run:** `npm install -g @salesforce/cli` |
+| Sentry project DSN | ✘ | Manual: create project at sentry.io |
+| PostHog project key | ✘ | Manual: create project at app.posthog.com |
+| Zebra ZQ520 / ZQ630 hardware (Day 4 print testing) | ⚠ | Day 4 needs at least one printer paired via Bluetooth; Labelary covers preview-side dev. |
+
+---
+
+## Documents read and understood
+
+The four canonical docs are at the project root and have been read end-to-end:
+
+- ✔ `OHANAFY-FIELD-HARNESS.md` — full Session 0 playbook executed
+- ✔ `OHANAFY-FIELD-PRODUCT-BIBLE.md` — 7-day plan, full architecture, AI system, schema
+- ✔ `OHANAFY-FIELD-ROLES-AND-ADMIN.md` — 6 roles, permission table, Appendix C tab sets, §12 day-by-day additive tasks
+- ✔ `OHANAFY-FIELD-APPEXCHANGE-SECURITY-REVIEW.md` — §3 Apex rules, PMD ruleset (extracted to `scripts/pmd-ruleset.xml`), submission checklist
+
+---
+
+## Manual action checklist (the user must do these before Day 1 can ship)
+
+In rough priority order:
+
+1. `npm install -g eas-cli && eas login` — Day 1 needs an EAS profile to do anything build-related.
+2. Provision Salesforce sandbox + Connected App. Get instance URL + Client ID into `.env.local`.
+3. Generate Anthropic API key. Add to `.env.local`.
+4. Create Sentry project; copy DSN to `.env.local`.
+5. Create PostHog project; copy key to `.env.local`.
+6. `brew install pmd` — required before any Apex deploy in CI (Day 4).
+7. `npm install -g @salesforce/cli` — required to deploy the `ohfy_field__` package (Day 4).
+8. Install **Xcode.app** (Mac App Store) + accept license: `sudo xcodebuild -license accept`.
+9. Install **Android Studio** + create an AVD (Pixel 7 API 34 is fine).
+10. Verify Apple Developer + Google Play Console memberships are active. Bundle ID `com.ohanafy.field` is reserved.
+11. Pair at least one Zebra ZQ520/ZQ630 over Bluetooth (Day 4 — can be deferred to Day 5 if hardware arrives late).
+12. (Optional) Add 2 more skill files to reach the harness §2 count of 9 — see "Skills" note above.
+
+---
+
+## Files created in Session 0 (exhaustive list)
+
+```
+CLAUDE.md
+.gitignore
+.env.example
+.env.local                   (gitignored)
+OHANAFY-FIELD-HARNESS.md     (copied from .context/attachments)
+OHANAFY-FIELD-PRODUCT-BIBLE.md   (copied)
+OHANAFY-FIELD-ROLES-AND-ADMIN.md (copied)
+OHANAFY-FIELD-APPEXCHANGE-SECURITY-REVIEW.md (copied)
+HARNESS-VERIFICATION.md
+.claude/settings.json
+.claude/agents/{9 .md files}
+.claude/skills/{7 .md files}
+.claude/commands/{7 .md files}
+.claude/rules/{7 .md files}
+.claude/hooks/{3 .sh files, executable}
+scripts/setup-harness.sh     (executable)
+scripts/pmd-ruleset.xml
+references/{cloned by setup script — see list below}
+```
+
+---
+
+## Verdict
+
+**Harness ready for Day 1: ⚠ partial.**
+- All `.claude/` machinery is in place and Claude Code can use it immediately.
+- Day 1 can begin after the user completes manual action items 1–4 (eas-cli + Salesforce Connected App + Anthropic key + Sentry/PostHog).
+- Items 6–11 are needed for later days but not Day 1 itself.
+
+The harness will not be "100% green" until the manual items are done, but **all in-repo work is complete and correct**. Day 1 startup sequence (per CLAUDE.md) will work as soon as the credentials in `.env.local` are filled.
+

--- a/OHANAFY-FIELD-APPEXCHANGE-SECURITY-REVIEW.md
+++ b/OHANAFY-FIELD-APPEXCHANGE-SECURITY-REVIEW.md
@@ -1,0 +1,1161 @@
+# Ohanafy Field — AppExchange Security Review
+## Planning Guide & Checklist v1.0
+
+> **What this is:** A complete guide to passing the Salesforce AppExchange Security Review for the Ohanafy Field managed package. The Security Review is a mandatory gate before any AppExchange listing. It regularly kills launch timelines because teams discover requirements late in development. This doc exists so you discover them on Day 1.
+>
+> **Who owns this:** The lead Salesforce developer on Ohanafy Field. Every code decision in the managed package (`packages/sfdx-package/`) must be made with this checklist in front of them.
+>
+> **Honest timeline:** First submission to approval: 3–6 months. Plan for at least one rejection cycle. Start the submission process as soon as the first deployable version exists — do not wait for feature-complete.
+
+---
+
+## Table of Contents
+
+- [§1 — The Process Overview](#1--the-process-overview)
+- [§2 — Pre-Submission Requirements](#2--pre-submission-requirements)
+- [§3 — Apex Security Requirements](#3--apex-security-requirements)
+- [§4 — Lightning Web Component Requirements](#4--lightning-web-component-requirements)
+- [§5 — Mobile App Requirements (React Native)](#5--mobile-app-requirements-react-native)
+- [§6 — Third-Party Library Audit](#6--third-party-library-audit)
+- [§7 — Penetration Testing Requirements](#7--penetration-testing-requirements)
+- [§8 — Data Handling Requirements](#8--data-handling-requirements)
+- [§9 — Documentation Requirements](#9--documentation-requirements)
+- [§10 — PMD Static Analysis Setup](#10--pmd-static-analysis-setup)
+- [§11 — Pre-Submission Checklist](#11--pre-submission-checklist)
+- [§12 — Submission Process](#12--submission-process)
+- [§13 — Common Rejection Reasons](#13--common-rejection-reasons)
+- [§14 — Post-Approval Requirements](#14--post-approval-requirements)
+- [Appendix A — PMD Ruleset](#appendix-a--pmd-ruleset)
+- [Appendix B — Required Documentation Templates](#appendix-b--required-documentation-templates)
+
+---
+
+## §1 — The Process Overview
+
+### The sequence
+
+```
+1. Salesforce Partner Community account
+          ↓
+2. ISV/OEM Partner Agreement signed
+          ↓
+3. Package development in packaging org
+          ↓
+4. Partner Community listing created (draft)
+          ↓
+5. Security Review submission
+          ↓
+   ┌──────────────────────────────────┐
+   │  Salesforce Security Review Team │
+   │  - Automated scanner (PMD, SAST) │
+   │  - Manual code review            │
+   │  - Penetration testing           │
+   │  - Documentation review          │
+   └──────────────────────────────────┘
+          ↓
+6. Review result: Pass / Reject with findings
+          ↓ (if rejected)
+7. Remediate findings → resubmit
+          ↓
+8. Approval → listing goes live
+```
+
+### What's reviewed
+
+Salesforce reviews **three things:**
+
+1. **The managed package** — every line of Apex, every LWC, every custom object, every permission set, every custom setting
+2. **Connected apps and OAuth** — how the mobile app authenticates, what scopes it requests, how tokens are stored
+3. **Third-party integrations** — any external service the package calls (Anthropic API, Labelary, etc.)
+
+The React Native app itself is **not directly reviewed by Salesforce** — it's reviewed by Apple App Store and Google Play. However, the Connected App and OAuth implementation in the package is reviewed.
+
+### Cost
+
+- Security Review fee: $150 USD per submission (as of 2026)
+- Resubmission fee: $150 per resubmission
+- Pen test vendor: $3,000–$8,000 depending on scope and vendor
+- Budget: $10,000–$15,000 total including multiple submission attempts
+
+---
+
+## §2 — Pre-Submission Requirements
+
+These must be true before you can even submit. None of them are fast.
+
+### 2.1 Salesforce Partner Community account
+
+- Register at `partners.salesforce.com`
+- Select ISV Partner track
+- Acceptance requires business review — can take 2–4 weeks
+- **Start this before you write the first line of Apex**
+
+### 2.2 Namespace registration
+
+- Register your namespace (`ohfy_field`) in a Developer Edition org
+- This is your **packaging org** — all managed package development happens here
+- **The namespace cannot be changed after registration.** Choose carefully.
+- The namespace must not conflict with any existing AppExchange package — search first
+
+### 2.3 Security Review prerequisites
+
+Before Salesforce will accept a submission:
+- [ ] Your AppExchange listing is created (even as a draft)
+- [ ] The package is uploaded from the packaging org (at least one version exists)
+- [ ] You have a Salesforce-certified penetration test report (or use their approved vendor)
+- [ ] All documentation in §9 is complete
+
+### 2.4 Environment setup
+
+You need three distinct Salesforce environments:
+
+| Environment | Purpose |
+|---|---|
+| **Packaging org** | Developer Edition with namespace registered. All Apex and LWC is developed and packaged here. Never used for testing with real data. |
+| **Development sandbox** | Scratch org or sandbox for active development. Connected to the packaging org via SFDX. Has Ohanafy core package installed. |
+| **Review org** | A clean org (Enterprise Edition or Developer Edition) that has never had the package installed. Used for Security Review submission. Reviewers install and test here. |
+
+---
+
+## §3 — Apex Security Requirements
+
+These are the most common rejection reasons. Every Apex class in `packages/sfdx-package/force-app/main/default/classes/` must pass all of them.
+
+### 3.1 Sharing rules (critical)
+
+Every Apex class must declare its sharing model explicitly. No exceptions.
+
+```apex
+// CORRECT — explicit sharing declaration
+public with sharing class OhfyFieldVisitService {
+  // with sharing = enforces Salesforce record-level security
+  // Records the current user can't see in Salesforce, they can't see here
+}
+
+// CORRECT — for system-context operations where sharing must be bypassed
+public without sharing class OhfyFieldSyncBatchJob implements Database.Batchable<sObject> {
+  // without sharing = runs as system, bypasses record-level security
+  // ONLY use when the business requirement demands it
+  // DOCUMENT WHY in a comment above the class
+}
+
+// WRONG — no sharing keyword = inherited context = unpredictable and rejected
+public class OhfyFieldVisitService {  // ← REJECTED
+}
+```
+
+**Rule:** Default to `with sharing` for every class. Use `without sharing` only for batch jobs, scheduled jobs, or other cases where the business logic requires system-level access. Document every `without sharing` with a comment explaining why.
+
+### 3.2 SOQL injection prevention
+
+Never concatenate user input into a SOQL string. Always use bind variables.
+
+```apex
+// WRONG — SOQL injection vulnerability, immediate rejection
+String query = 'SELECT Id FROM Account WHERE Name = \'' + accountName + '\'';
+List<Account> accounts = Database.query(query);
+
+// CORRECT — bind variable, safe
+List<Account> accounts = [
+  SELECT Id FROM Account WHERE Name = :accountName
+];
+
+// CORRECT — dynamic SOQL (necessary sometimes) with proper escaping
+String query = 'SELECT Id FROM Account WHERE ' + String.escapeSingleQuotes(fieldName) + ' = :value';
+// But prefer static SOQL whenever possible
+```
+
+### 3.3 SOQL in loops (governor limits + rejection)
+
+```apex
+// WRONG — SOQL inside a for loop, rejected
+for (ohfy_field__Visit__c visit : visits) {
+  Account acc = [SELECT Name FROM Account WHERE Id = :visit.ohfy_field__Account__c];
+  // This hits governor limits AND is a security review rejection
+}
+
+// CORRECT — bulk query outside the loop
+Set<Id> accountIds = new Set<Id>();
+for (ohfy_field__Visit__c visit : visits) {
+  accountIds.add(visit.ohfy_field__Account__c);
+}
+Map<Id, Account> accountMap = new Map<Id, Account>(
+  [SELECT Id, Name FROM Account WHERE Id IN :accountIds]
+);
+for (ohfy_field__Visit__c visit : visits) {
+  Account acc = accountMap.get(visit.ohfy_field__Account__c);
+}
+```
+
+### 3.4 DML in loops
+
+```apex
+// WRONG — DML inside a for loop, rejected
+for (OhfyFieldOrderPayload payload : payloads) {
+  ohfy_field__Order__c order = new ohfy_field__Order__c(/* ... */);
+  insert order;  // ← REJECTED
+}
+
+// CORRECT — collect and bulk insert
+List<ohfy_field__Order__c> ordersToInsert = new List<ohfy_field__Order__c>();
+for (OhfyFieldOrderPayload payload : payloads) {
+  ordersToInsert.add(new ohfy_field__Order__c(/* ... */));
+}
+insert ordersToInsert;
+```
+
+### 3.5 Field-level security (FLS) enforcement
+
+Every field access in Apex that originates from user input must check FLS. Salesforce automated scanner flags any field access in a `with sharing` class that doesn't check FLS.
+
+```apex
+// WRONG — direct field access without FLS check
+public String getAccountName(Id accountId) {
+  Account acc = [SELECT Name FROM Account WHERE Id = :accountId];
+  return acc.Name;  // ← Scanner may flag this
+}
+
+// CORRECT — use WITH SECURITY_ENFORCED (Salesforce recommended)
+public String getAccountName(Id accountId) {
+  Account acc = [
+    SELECT Name FROM Account WHERE Id = :accountId
+    WITH SECURITY_ENFORCED
+  ];
+  return acc.Name;
+}
+
+// ALTERNATIVE — Schema.SObjectField FLS check (older pattern)
+if (Schema.SObjectType.Account.fields.Name.isAccessible()) {
+  Account acc = [SELECT Name FROM Account WHERE Id = :accountId];
+  return acc.Name;
+}
+return null;
+```
+
+**Recommendation:** Use `WITH SECURITY_ENFORCED` in all new SOQL. It's cleaner and the scanner recognizes it.
+
+### 3.6 No hardcoded IDs or credentials
+
+```apex
+// WRONG — hardcoded Salesforce record ID, rejected
+private static final String DEFAULT_PRICEBOOK_ID = '01s000000000000AAA';
+
+// CORRECT — query for it
+private static Id getStandardPricebookId() {
+  return Test.isRunningTest()
+    ? Test.getStandardPricebookId()
+    : [SELECT Id FROM Pricebook2 WHERE IsStandard = true LIMIT 1].Id;
+}
+```
+
+```apex
+// WRONG — any credential in Apex, immediately rejected
+private static final String API_KEY = 'sk-ant-api03-...';
+
+// CORRECT — use Custom Metadata or Named Credentials
+ohfy_field__AI_Config__mdt config = [
+  SELECT ohfy_field__ApiKey__c FROM ohfy_field__AI_Config__mdt LIMIT 1
+];
+```
+
+### 3.7 @AuraEnabled methods — security requirements
+
+Every `@AuraEnabled` method that the LWC or mobile app calls must validate its inputs.
+
+```apex
+// Required pattern for every @AuraEnabled method
+@AuraEnabled
+public static SyncResult syncVisit(String visitJson) {
+  // 1. Null check inputs
+  if (String.isBlank(visitJson)) {
+    throw new AuraHandledException('visitJson cannot be blank');
+  }
+
+  // 2. Size limit check (prevent DoS via huge payloads)
+  if (visitJson.length() > 32768) {  // 32KB limit
+    throw new AuraHandledException('Payload too large');
+  }
+
+  // 3. Deserialize safely (not JSON.deserializeUntyped unless necessary)
+  OhfyFieldVisitPayload payload;
+  try {
+    payload = (OhfyFieldVisitPayload) JSON.deserialize(
+      visitJson, OhfyFieldVisitPayload.class
+    );
+  } catch (JSONException e) {
+    throw new AuraHandledException('Invalid JSON: ' + e.getMessage());
+  }
+
+  // 4. ID validation
+  if (!isValidSalesforceId(payload.accountId)) {
+    throw new AuraHandledException('Invalid account ID');
+  }
+
+  // 5. Actual work
+  // ...
+}
+
+private static Boolean isValidSalesforceId(String id) {
+  if (String.isBlank(id)) return false;
+  try {
+    Id sfId = Id.valueOf(id);
+    return sfId.getSobjectType() == ohfy__Account__c.SObjectType;
+  } catch (StringException e) {
+    return false;
+  }
+}
+```
+
+### 3.8 Exception handling — no swallowed exceptions
+
+```apex
+// WRONG — swallowed exception, reviewer will look for these
+try {
+  insert order;
+} catch (DmlException e) {
+  // do nothing
+}
+
+// CORRECT — log and surface
+try {
+  insert order;
+} catch (DmlException e) {
+  logger.logException(e, 'OhfyFieldSyncAdapter.syncOrder');
+  throw new AuraHandledException(
+    'Failed to save order: ' + e.getDmlMessage(0)
+  );
+}
+```
+
+### 3.9 Test class requirements (75% coverage minimum for deployment)
+
+Salesforce requires 75% overall code coverage to deploy to production. The Security Review will also look at test quality.
+
+```apex
+@isTest
+private class OhfyFieldSyncAdapterTest {
+
+  // Use @testSetup for data shared across tests — not @isTest methods with direct DML
+  @testSetup
+  static void setupTestData() {
+    Account testAccount = TestDataFactory.createAccount();
+    Product2 testProduct = TestDataFactory.createProduct();
+    // etc.
+  }
+
+  @isTest
+  static void syncVisit_withValidPayload_createsVisitRecord() {
+    // Arrange
+    Account acc = [SELECT Id FROM Account LIMIT 1];
+    String payload = JSON.serialize(new Map<String, Object>{
+      'accountId' => acc.Id,
+      'visitDate' => Datetime.now().format(),
+      'note' => 'Test visit note'
+    });
+
+    // Act
+    Test.startTest();
+    OhfyFieldSyncAdapter.SyncResult result =
+      OhfyFieldSyncAdapter.syncVisit(payload);
+    Test.stopTest();
+
+    // Assert
+    System.assertEquals(true, result.success, 'Sync should succeed');
+    System.assertNotEquals(null, result.recordId, 'Record ID should be returned');
+
+    ohfy_field__Visit__c created = [
+      SELECT Id, ohfy_field__Note__c
+      FROM ohfy_field__Visit__c
+      WHERE Id = :result.recordId
+    ];
+    System.assertEquals('Test visit note', created.ohfy_field__Note__c);
+  }
+
+  @isTest
+  static void syncVisit_withBlankPayload_throwsAuraHandledException() {
+    try {
+      OhfyFieldSyncAdapter.syncVisit('');
+      System.assert(false, 'Should have thrown exception');
+    } catch (AuraHandledException e) {
+      System.assert(e.getMessage().contains('cannot be blank'));
+    }
+  }
+
+  @isTest
+  static void syncVisit_withOversizePayload_throwsAuraHandledException() {
+    String oversizePayload = 'x'.repeat(33000);
+    try {
+      OhfyFieldSyncAdapter.syncVisit(oversizePayload);
+      System.assert(false, 'Should have thrown exception');
+    } catch (AuraHandledException e) {
+      System.assert(e.getMessage().contains('too large'));
+    }
+  }
+}
+```
+
+**Coverage target for Security Review:** 90%+ on all Apex classes. 75% is the deployment floor; reviewers look more favorably on higher coverage.
+
+---
+
+## §4 — Lightning Web Component Requirements
+
+### 4.1 LockerService compliance
+
+Every LWC runs inside Salesforce's LockerService sandbox. Common failures:
+
+```javascript
+// WRONG — direct DOM manipulation, blocked by LockerService
+document.querySelector('.my-class').style.color = 'red';
+
+// CORRECT — use the @api, @track, and template refs
+@track myStyle = 'color: red;';
+// In template: <div style={myStyle}>
+
+// WRONG — accessing window directly in ways LockerService blocks
+window.parent.location; // blocked
+window.opener; // blocked
+
+// WRONG — eval() or Function() constructor, blocked
+const fn = new Function('return 42');
+
+// WRONG — accessing other components' internals across namespace
+const childEl = this.template.querySelector('c-other-component');
+childEl._privateProperty; // blocked
+```
+
+### 4.2 XSS prevention in LWC
+
+```html
+<!-- WRONG — renders raw HTML, XSS risk, rejected -->
+<div lwc:dom="manual" onclick={handleClick}></div>
+<!-- Plus: component.template.querySelector(...).innerHTML = userInput -->
+
+<!-- CORRECT — use data binding which auto-escapes -->
+<div>{userInput}</div>
+
+<!-- For intentional HTML rendering: use lightning-formatted-rich-text
+     which sanitizes the input -->
+<lightning-formatted-rich-text value={sanitizedHtml}></lightning-formatted-rich-text>
+```
+
+### 4.3 Content Security Policy (CSP)
+
+No inline scripts. No `eval()`. No external stylesheets loaded dynamically. All JavaScript must be in `.js` files in the component bundle. External resources must be added to the org's CSP Trusted Sites.
+
+For Ohanafy Field, the LWC components (`ohanafyFieldActivity` and the Admin Console) must not load any external resources at runtime — all dependencies are bundled or come from Salesforce's CDN.
+
+### 4.4 LWC security checklist
+
+- [ ] No `innerHTML` assignments with user data
+- [ ] No `eval()` or `Function()` constructor
+- [ ] No `document.write()`
+- [ ] No cross-namespace DOM access
+- [ ] No synchronous `XMLHttpRequest`
+- [ ] All `@wire` methods handle `error` property
+- [ ] All `@AuraEnabled` calls have error handling
+- [ ] CSP Trusted Sites configured for any external domains
+
+---
+
+## §5 — Mobile App Requirements (React Native)
+
+The React Native app is not reviewed by Salesforce directly, but the **Connected App integration** is. Requirements:
+
+### 5.1 OAuth scope minimization
+
+Request only the OAuth scopes you actually use. The Security Review will reject overly broad scopes.
+
+**Required scopes for Ohanafy Field:**
+- `api` — REST API access to Ohanafy objects
+- `refresh_token` — for offline token refresh
+- `offline_access` — to call the API without user interaction
+
+**Do NOT request:**
+- `full` — too broad; rejected
+- `visualforce` — not needed; rejected if requested
+- `web` — not needed for mobile
+
+### 5.2 Token storage requirements
+
+Security Review verifies the OAuth security model through documentation. Your submission must include:
+
+- Description of how tokens are stored (iOS Keychain via `expo-secure-store`)
+- Description of token refresh mechanism
+- Description of token revocation handling (Force Logout from Admin Console)
+- Confirmation that tokens are never logged, never included in error reports, and never stored in plaintext
+
+### 5.3 PKCE enforcement
+
+The mobile app's OAuth flow must use PKCE (Proof Key for Code Exchange). Non-PKCE mobile OAuth flows are rejected. The `expo-auth-session` implementation in the Product Bible uses PKCE correctly — confirm `usePKCE: true` is present in the `AuthRequest` constructor.
+
+### 5.4 Deep link security
+
+The OAuth redirect URI (`com.ohanafy.field://oauth/callback`) must be validated in the `expo-auth-session` callback to prevent open redirect attacks. The Expo AuthSession library handles this automatically, but document it in your submission.
+
+---
+
+## §6 — Third-Party Library Audit
+
+Every npm package used in LWCs and every external service called from Apex must be disclosed and justified.
+
+### 6.1 Libraries in the managed package (LWC bundles)
+
+For Ohanafy Field, the Admin Console LWC bundles minimal external libraries. Any library bundled into the LWC must:
+- Have no known CVEs (check at `npmjs.com` and `snyk.io`)
+- Be actively maintained (last commit within 12 months)
+- Have a compatible license (MIT, Apache 2.0, BSD — not GPL unless Ohanafy has a commercial license)
+- Not make external network calls of its own
+
+**The Admin Console LWC should have zero bundled third-party libraries.** Use only Salesforce's base components (`lightning-*`) and standard browser APIs.
+
+### 6.2 External services called from Apex
+
+Every external callout from Apex must be declared as a Named Credential or Remote Site Setting.
+
+| Service | How called | Security Review requirement |
+|---|---|---|
+| Anthropic API | From mobile app (not Apex) for v1.0 | Document in submission — not a managed package callout |
+| Labelary API | From mobile app (not Apex) | Same |
+| Any future Apex callouts | Must use Named Credentials | Required for review |
+
+**For v1.0:** No Apex callouts to external services. All AI and ZPL calls are from the React Native app directly. This simplifies the Security Review significantly.
+
+If future versions add Apex callouts (e.g., for the Apex proxy architecture for AI), each must use Salesforce Named Credentials and be declared in the security submission.
+
+### 6.3 External JavaScript resources in LWC
+
+Any JavaScript loaded from an external CDN in a LWC must be declared in the package's `staticresources` instead. The Security Review scanner flags any external script loads from unknown CDNs.
+
+```html
+<!-- WRONG — loading from external CDN -->
+<script src="https://cdn.example.com/library.js"></script>
+
+<!-- CORRECT — bundle in staticresources -->
+<script src={libraryUrl}></script>
+<!-- Where libraryUrl resolves to a Static Resource in the org -->
+```
+
+---
+
+## §7 — Penetration Testing Requirements
+
+The AppExchange Security Review requires a penetration test for any app that handles financial or sensitive business data. Ohanafy Field handles order data and account financial history — a pen test is required.
+
+### 7.1 Salesforce-approved vendors
+
+Salesforce maintains a list of approved penetration testing vendors. You must use one of them — your own internal pen test is not accepted. Current approved vendors (verify current list at `appexchangehelp.salesforce.com`):
+
+- Bishop Fox
+- Coalfire
+- Rapid7
+- WhiteHat Security
+- Veracode
+- Synopsys
+
+**Cost estimate:** $3,000–$8,000 depending on scope and vendor. Budget $5,000.
+
+### 7.2 Pen test scope for Ohanafy Field
+
+The pen test must cover:
+- All `@AuraEnabled` Apex methods
+- The OAuth/Connected App flow
+- The Admin Console Lightning app
+- The Sync Monitor admin actions (retry/discard sync items)
+- Any REST API endpoints exposed by the package
+
+The React Native app itself is typically out of scope for the Salesforce-required pen test (Apple and Google cover that). However, pen testing the API endpoints the mobile app calls is in scope.
+
+### 7.3 Timeline
+
+The pen test takes 2–4 weeks from engagement to report. The report must be submitted with your Security Review application.
+
+**Start the pen test engagement at the same time you start the Security Review submission — not after you think you're ready.** The pen test will find issues that need fixing, which takes time.
+
+---
+
+## §8 — Data Handling Requirements
+
+### 8.1 Data residency
+
+All customer data stays in their Salesforce org. Ohanafy Field does not store any customer data outside of:
+- Their Salesforce org (custom objects in the managed package)
+- Their mobile devices (WatermelonDB, which syncs to/from their Salesforce org)
+
+No Ohanafy-operated databases contain customer data. This must be stated explicitly in the submission and in the privacy policy.
+
+### 8.2 PII handling
+
+Ohanafy Field handles:
+- Business contact names and phone numbers (account contacts) — not consumer PII
+- Visit notes authored by the rep — may contain customer names
+- Order data — financial business data
+
+It does NOT handle:
+- Consumer PII (names, emails, addresses of individual consumers)
+- Payment card data
+- Healthcare data
+
+This must be stated in the AppExchange listing's Data Use section.
+
+### 8.3 Data retention in the mobile app
+
+WatermelonDB data on the device:
+- Is wiped on app uninstall
+- Can be manually cleared by the rep in Settings → Clear Local Data
+- Is cleared and re-synced on every Full Resync (configurable in Admin Console)
+- Is protected by device-level encryption (iOS Data Protection, Android File-Based Encryption)
+
+### 8.4 Encryption in transit
+
+- All Salesforce API calls: HTTPS/TLS 1.2+
+- All Anthropic API calls: HTTPS/TLS 1.2+
+- All Labelary API calls: HTTPS (HTTP is allowed by Labelary but must use HTTPS for this app)
+
+**Note for Security Review:** Update the Labelary API call in `src/zpl/preview.ts` to use `https://api.labelary.com` not `http://`. The review will flag unencrypted HTTP callouts.
+
+---
+
+## §9 — Documentation Requirements
+
+The Security Review requires all of the following documentation to be submitted.
+
+### 9.1 Required documents (must exist before submission)
+
+| Document | Description | Owner |
+|---|---|---|
+| Privacy Policy | What data is collected, how it's used, how it's deleted. Must be hosted at a public URL (e.g., `ohanafy.com/field/privacy`). | Legal / Product |
+| Terms of Service | Governs use of the app. Must be accessible from the app and the AppExchange listing. | Legal |
+| Data Use Disclosure | AppExchange-specific form. Declares data collected, third-party services used, data residency. | Product |
+| Architecture Overview | 1-2 page document describing the system components, data flows, and external integrations. | Engineering |
+| Connected App Security Doc | Description of OAuth flow, token storage, PKCE implementation, token revocation. | Engineering |
+| Third-Party Service Disclosure | List of every external service called by the package or mobile app, with justification. | Engineering |
+| Penetration Test Report | From an approved vendor (see §7). | Security |
+
+### 9.2 Architecture overview template
+
+```markdown
+# Ohanafy Field — Architecture Overview
+(Submitted with AppExchange Security Review)
+
+## System Components
+
+### Managed Package (Salesforce)
+- Custom Objects: [list all ohfy_field__*__c objects]
+- Custom Metadata: [ohfy_field__AI_Config__mdt, ohfy_field__Admin_Config__mdt]
+- Apex Classes: [list all classes with sharing model]
+- LWCs: [list all components]
+- Permission Sets: [list all 6 permission sets + App Admin]
+- Connected App: ohanafy_field (OAuth 2.0 PKCE, scopes: api, refresh_token, offline_access)
+
+### Mobile Application (React Native / Expo)
+- Platform: iOS 16+ and Android 10+
+- Distribution: Apple App Store, Google Play Store
+- Authentication: Salesforce Connected App OAuth 2.0 PKCE
+- Local storage: SQLite (WatermelonDB) — device only, encrypted at rest
+- External calls: Anthropic Claude API (AI features), Labelary API (ZPL preview)
+
+### Data Flow
+1. Rep opens app → authenticates via Salesforce OAuth
+2. App syncs account/product/order data from Salesforce to local SQLite
+3. Rep creates orders/visits offline → stored in SQLite sync queue
+4. On network reconnect → sync queue flushed to Salesforce via REST API
+5. AI features (voice, insights) → direct call from device to Anthropic API
+6. ZPL preview → direct call from device to Labelary API
+7. ZPL print → Bluetooth to Zebra printer (no network involved)
+
+### No shared infrastructure
+Ohanafy does not operate any database or server that stores customer data.
+All customer data resides in their Salesforce org or their mobile devices.
+
+## External Services
+
+| Service | Purpose | Data sent | Auth |
+|---|---|---|---|
+| Anthropic API | AI voice commands and insights | Visit context, voice transcript (no PII) | API key in device SecureStore |
+| Labelary API | ZPL label preview rendering | ZPL string only (no customer data) | None (public API) |
+| Sentry | Crash reporting | Stack traces, device info (no customer data) | DSN key |
+| PostHog | Product analytics | Usage events (no customer data, no PII) | API key |
+
+## Security Controls
+
+| Control | Implementation |
+|---|---|
+| Authentication | Salesforce OAuth 2.0 PKCE |
+| Token storage | iOS Keychain / Android Keystore via expo-secure-store |
+| Biometric lock | expo-local-authentication (FaceID/TouchID/Fingerprint) |
+| Data encryption in transit | HTTPS/TLS 1.2+ for all API calls |
+| Data encryption at rest | Device OS encryption (iOS Data Protection, Android FBE) |
+| Permission enforcement | Salesforce Permission Sets, read at auth time |
+| Audit logging | ohfy_field__Admin_Audit_Log__c (immutable Salesforce object) |
+```
+
+---
+
+## §10 — PMD Static Analysis Setup
+
+PMD (Project Mess Detector) is the static analysis tool Salesforce uses in its automated scanner. Run it locally before every submission to catch issues early.
+
+### 10.1 Install PMD
+
+```bash
+# Install PMD (macOS via Homebrew)
+brew install pmd
+
+# Or download from https://pmd.github.io/ and add to PATH
+
+# Verify
+pmd --version
+```
+
+### 10.2 Salesforce-specific ruleset
+
+Save as `scripts/pmd-ruleset.xml` (full content in Appendix A):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Ohanafy Field Apex Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0">
+
+  <description>Security Review compliance ruleset for Ohanafy Field</description>
+
+  <!-- Salesforce Security Review critical rules -->
+  <rule ref="category/apex/security.xml/ApexSharingViolations" />
+  <rule ref="category/apex/security.xml/ApexSOQLInjection" />
+  <rule ref="category/apex/security.xml/ApexXSSFromURLParam" />
+  <rule ref="category/apex/security.xml/ApexCRUDViolation" />
+  <rule ref="category/apex/security.xml/ApexOpenRedirect" />
+  <rule ref="category/apex/security.xml/ApexInsecureEndpoint" />
+
+  <!-- Performance rules (also flagged in review) -->
+  <rule ref="category/apex/performance.xml/AvoidSoqlInLoops" />
+  <rule ref="category/apex/performance.xml/AvoidDmlStatementsInLoops" />
+  <rule ref="category/apex/performance.xml/AvoidSoslInLoops" />
+
+  <!-- Best practices -->
+  <rule ref="category/apex/bestpractices.xml/AvoidGlobalModifier" />
+  <rule ref="category/apex/bestpractices.xml/DebugsShouldUseLoggingLevel" />
+
+  <!-- Error handling -->
+  <rule ref="category/apex/errorprone.xml/EmptyCatchBlock" />
+  <rule ref="category/apex/errorprone.xml/AvoidHardcodingId" />
+
+</ruleset>
+```
+
+### 10.3 Run PMD
+
+```bash
+# Run PMD on all Apex in the SFDX package
+pmd check \
+  --dir packages/sfdx-package/force-app/main/default/classes/ \
+  --rulesets scripts/pmd-ruleset.xml \
+  --format text \
+  --fail-on-violation
+
+# For CI integration:
+pmd check \
+  --dir packages/sfdx-package/force-app/main/default/classes/ \
+  --rulesets scripts/pmd-ruleset.xml \
+  --format xml \
+  --report-file reports/pmd-results.xml
+```
+
+### 10.4 Add PMD to CI
+
+```yaml
+# Add to .github/workflows/ci.yml
+
+  apex-security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PMD
+        run: |
+          wget https://github.com/pmd/pmd/releases/download/pmd_releases/7.0.0/pmd-dist-7.0.0-bin.zip
+          unzip pmd-dist-7.0.0-bin.zip
+          echo "$PWD/pmd-bin-7.0.0/bin" >> $GITHUB_PATH
+      - name: Run PMD on Apex
+        run: |
+          pmd check \
+            --dir packages/sfdx-package/force-app/main/default/classes/ \
+            --rulesets scripts/pmd-ruleset.xml \
+            --format text \
+            --fail-on-violation
+```
+
+**Zero PMD violations is the target.** The CI gate blocks any merge that introduces PMD violations.
+
+### 10.5 Salesforce Code Analyzer (local)
+
+Salesforce also has their own scanner that goes beyond PMD:
+
+```bash
+# Install Salesforce CLI Scanner plugin
+sf plugins install @salesforce/sfdx-scanner
+
+# Run the full scanner
+sf scanner run \
+  --target packages/sfdx-package/force-app/main/default/classes/ \
+  --category Security \
+  --format table
+
+# Run against specific severity
+sf scanner run \
+  --target packages/sfdx-package/force-app/main/default/ \
+  --severity-threshold 2 \
+  --format csv \
+  --outfile reports/sf-scanner-results.csv
+```
+
+Severity 1 violations (Critical) block submission. Severity 2 violations (High) require written justification if you cannot fix them. Severity 3+ are advisory.
+
+---
+
+## §11 — Pre-Submission Checklist
+
+Complete every item before submitting. This checklist maps to the exact items Salesforce reviewers check.
+
+### Salesforce Partner requirements
+- [ ] Partner Community account active and in good standing
+- [ ] ISV/OEM Partner Agreement signed
+- [ ] Namespace registered (`ohfy_field`)
+- [ ] Package uploaded from packaging org (at least version 1.0)
+- [ ] AppExchange listing created in draft
+
+### Apex code quality
+- [ ] Every Apex class has explicit sharing declaration (`with sharing` or `without sharing`)
+- [ ] All `without sharing` classes have a comment explaining why
+- [ ] Zero SOQL injection vulnerabilities (no string concatenation in SOQL)
+- [ ] Zero SOQL in loops
+- [ ] Zero DML in loops
+- [ ] All `@AuraEnabled` methods validate inputs (null check, size limit, type check)
+- [ ] All `@AuraEnabled` methods handle exceptions and surface human-readable errors
+- [ ] No hardcoded IDs anywhere
+- [ ] No hardcoded credentials anywhere
+- [ ] `WITH SECURITY_ENFORCED` used in all SOQL that accesses user-visible data
+- [ ] Test coverage ≥ 90% across all Apex classes
+- [ ] All test methods use `Test.startTest()` / `Test.stopTest()`
+- [ ] No `@SuppressWarnings` annotations that hide real issues
+
+### PMD and scanner
+- [ ] `pmd check` returns zero violations on the full ruleset
+- [ ] `sf scanner run --category Security` returns zero Severity 1 violations
+- [ ] All Severity 2 violations documented with written justification
+
+### LWC quality
+- [ ] No `innerHTML` assignments with user data
+- [ ] No `eval()` or `Function()` constructor
+- [ ] No synchronous XHR
+- [ ] All external resources are in Static Resources, not CDN links
+- [ ] LockerService compliance verified (test in a scratch org, not just local)
+- [ ] All `@wire` methods handle both `data` and `error` cases
+- [ ] CSP Trusted Sites configured for all external domains
+
+### Mobile app security
+- [ ] OAuth flow uses PKCE (`usePKCE: true` confirmed)
+- [ ] Only required OAuth scopes requested (`api`, `refresh_token`, `offline_access`)
+- [ ] All API calls use HTTPS (no HTTP endpoints)
+- [ ] Labelary call uses `https://api.labelary.com` (not `http://`)
+- [ ] No OAuth tokens logged to Sentry or any analytics service
+- [ ] Token storage documented (iOS Keychain / Android Keystore)
+- [ ] Force Logout flow implemented and tested
+
+### Documentation
+- [ ] Privacy Policy hosted at public URL
+- [ ] Terms of Service hosted at public URL
+- [ ] Architecture Overview document complete (template in §9.2)
+- [ ] Connected App Security document complete
+- [ ] Third-Party Service Disclosure complete
+- [ ] Data Use Disclosure filled in AppExchange Partner Portal
+- [ ] Penetration Test report received from approved vendor
+
+### AppExchange listing content
+- [ ] App name: "Ohanafy Field"
+- [ ] Short description (< 100 chars)
+- [ ] Long description (accurate, no false claims)
+- [ ] Screenshots: at minimum 3 (each role's primary screen recommended)
+- [ ] Demo video (strongly recommended — reviewers watch them)
+- [ ] Supported Editions: specify (Professional, Enterprise, Unlimited)
+- [ ] License type selected (per-user, per-site, or free)
+- [ ] Industries: select Manufacturing + Retail + other applicable
+- [ ] Support contact information
+- [ ] Installation instructions documented
+
+---
+
+## §12 — Submission Process
+
+### 12.1 Submit via Partner Community
+
+1. Log in to `partners.salesforce.com`
+2. Navigate to **AppExchange** → **My Listings** → select Ohanafy Field draft
+3. Click **Start Security Review**
+4. Complete the Security Review Questionnaire (30–60 minutes)
+5. Upload all required documentation
+6. Submit the penetration test report
+7. Provide the Review Org credentials (username/password for the clean org with your package installed)
+8. Pay the $150 submission fee
+9. Submit
+
+### 12.2 During review
+
+- Review timeline: 4–8 weeks from submission
+- Salesforce may send follow-up questions by email — respond within 5 business days or the review is paused
+- You can check status at any time in the Partner Community
+- Do not submit updates to the package during an active review
+
+### 12.3 If rejected
+
+Salesforce sends a rejection with specific findings categorized by severity. For each finding:
+
+1. Understand exactly what the reviewer flagged
+2. Fix the issue in the packaging org and re-run PMD/scanner
+3. Test the fix in the Review Org
+4. Prepare a written response explaining how each finding was addressed
+5. Upload the updated package version
+6. Pay the $150 resubmission fee
+7. Resubmit
+
+**Do not argue with findings.** Even if you believe a finding is incorrect, the fastest path to approval is to fix it. You can request clarification before fixing, but keep it brief.
+
+---
+
+## §13 — Common Rejection Reasons
+
+Based on real AppExchange rejection patterns. Fix all of these proactively.
+
+### Apex rejections (most common)
+
+| Issue | Frequency | Fix |
+|---|---|---|
+| Missing sharing declaration on Apex class | Very common | Add `with sharing` to every class |
+| CRUD/FLS violations — accessing fields without security check | Very common | Add `WITH SECURITY_ENFORCED` to all SOQL |
+| SOQL in for loop | Common | Collect IDs, query outside loop |
+| Hardcoded Salesforce ID | Common | Query for the record ID at runtime |
+| Empty catch block | Common | Log the exception, never swallow it |
+| No null check on @AuraEnabled method inputs | Common | Always validate inputs |
+| Test methods with no assertions | Common | Every `@isTest` method must have `System.assert*` calls |
+| `@SuppressWarnings` hiding real violations | Occasional | Fix the real issue |
+
+### LWC rejections
+
+| Issue | Frequency | Fix |
+|---|---|---|
+| External CDN script in LWC | Common | Move to Static Resource |
+| Unescaped user input in template | Occasional | Use `{variable}` binding, not `innerHTML` |
+| LockerService violation in test | Occasional | Test LWCs in a real scratch org, not just locally |
+
+### Documentation rejections
+
+| Issue | Frequency | Fix |
+|---|---|---|
+| Privacy Policy missing or inaccessible | Very common | Host at a real URL before submission |
+| Data Use Disclosure incomplete | Common | Every field in the Partner Portal form must be filled |
+| Architecture doc missing external service disclosures | Common | List every external service, even Sentry and PostHog |
+| Pen test scope didn't cover all @AuraEnabled methods | Occasional | Ensure pen test scope doc lists all endpoints |
+
+### Mobile / OAuth rejections
+
+| Issue | Frequency | Fix |
+|---|---|---|
+| Non-PKCE OAuth flow | Occasional | Confirm `usePKCE: true` |
+| Overly broad OAuth scopes | Occasional | Remove `full` scope, use only what's needed |
+| Insufficient documentation of token storage | Common | Write the Connected App security doc explicitly |
+| HTTP (not HTTPS) callout | Occasional | Audit every external URL in the codebase |
+
+---
+
+## §14 — Post-Approval Requirements
+
+Approval is not a one-time event. Ongoing requirements:
+
+### Annual security review
+
+AppExchange requires an annual security review refresh for packages that handle sensitive data. Same process, same fee, but typically faster if no major architectural changes.
+
+### Patch versions
+
+Minor bug fix releases (patch versions) typically do not require a new security review. Major versions (new features, new external integrations, new OAuth scopes) require a full re-review.
+
+### CVE monitoring
+
+Ohanafy is responsible for monitoring CVEs in third-party dependencies and patching promptly. Salesforce may reach out if a critical CVE is reported for a library used in your package. You have 30 days to release a patched version or your listing may be suspended.
+
+### AppExchange monitoring
+
+Salesforce monitors AppExchange listings for compliance. Reviews are triggered by:
+- Customer complaints
+- Significant version updates
+- New CVEs in dependencies
+- Changes to data handling disclosures
+
+### Maintain the review org
+
+Keep the review org (clean installation with test credentials) live and accessible. Salesforce's support team uses it to reproduce issues reported by customers.
+
+---
+
+## Appendix A — PMD Ruleset
+
+Save as `scripts/pmd-ruleset.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Ohanafy Field Security Review Ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+           http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>
+    Apex PMD ruleset aligned to Salesforce AppExchange Security Review requirements.
+    Zero violations required before security review submission.
+    This ruleset is also enforced in CI on every push.
+  </description>
+
+  <!-- ═══════════════════════════════════════════
+       SECURITY — Critical. Rejection guaranteed.
+       ═══════════════════════════════════════════ -->
+
+  <!-- Sharing model not declared -->
+  <rule ref="category/apex/security.xml/ApexSharingViolations">
+    <priority>1</priority>
+  </rule>
+
+  <!-- SOQL injection via string concatenation -->
+  <rule ref="category/apex/security.xml/ApexSOQLInjection">
+    <priority>1</priority>
+  </rule>
+
+  <!-- XSS from URL parameters -->
+  <rule ref="category/apex/security.xml/ApexXSSFromURLParam">
+    <priority>1</priority>
+  </rule>
+
+  <!-- XSS from escape-unsafe methods -->
+  <rule ref="category/apex/security.xml/ApexXSSFromEscapeFalse">
+    <priority>1</priority>
+  </rule>
+
+  <!-- CRUD/FLS violations -->
+  <rule ref="category/apex/security.xml/ApexCRUDViolation">
+    <priority>1</priority>
+  </rule>
+
+  <!-- Open redirect vulnerability -->
+  <rule ref="category/apex/security.xml/ApexOpenRedirect">
+    <priority>1</priority>
+  </rule>
+
+  <!-- HTTP callout (not HTTPS) -->
+  <rule ref="category/apex/security.xml/ApexInsecureEndpoint">
+    <priority>1</priority>
+  </rule>
+
+  <!-- Dangerous permissions in Apex -->
+  <rule ref="category/apex/security.xml/ApexDangerousMethods">
+    <priority>1</priority>
+  </rule>
+
+  <!-- ═══════════════════════════════════════════
+       PERFORMANCE — Flagged in security review.
+       ═══════════════════════════════════════════ -->
+
+  <!-- SOQL inside for loop (governor limit risk) -->
+  <rule ref="category/apex/performance.xml/AvoidSoqlInLoops">
+    <priority>1</priority>
+  </rule>
+
+  <!-- DML inside for loop -->
+  <rule ref="category/apex/performance.xml/AvoidDmlStatementsInLoops">
+    <priority>1</priority>
+  </rule>
+
+  <!-- SOSL inside for loop -->
+  <rule ref="category/apex/performance.xml/AvoidSoslInLoops">
+    <priority>1</priority>
+  </rule>
+
+  <!-- ═══════════════════════════════════════════
+       ERROR HANDLING — Required for good review.
+       ═══════════════════════════════════════════ -->
+
+  <!-- Empty catch blocks -->
+  <rule ref="category/apex/errorprone.xml/EmptyCatchBlock">
+    <priority>2</priority>
+  </rule>
+
+  <!-- Hardcoded Salesforce IDs -->
+  <rule ref="category/apex/errorprone.xml/AvoidHardcodingId">
+    <priority>2</priority>
+  </rule>
+
+  <!-- NullPointerException risks -->
+  <rule ref="category/apex/errorprone.xml/ApexCSRF">
+    <priority>2</priority>
+  </rule>
+
+  <!-- ═══════════════════════════════════════════
+       BEST PRACTICES — Advisory but improve score.
+       ═══════════════════════════════════════════ -->
+
+  <!-- Avoid global modifier unless required -->
+  <rule ref="category/apex/bestpractices.xml/AvoidGlobalModifier">
+    <priority>3</priority>
+  </rule>
+
+  <!-- System.debug should use LoggingLevel -->
+  <rule ref="category/apex/bestpractices.xml/DebugsShouldUseLoggingLevel">
+    <priority>3</priority>
+  </rule>
+
+  <!-- Unused local variables -->
+  <rule ref="category/apex/bestpractices.xml/UnusedLocalVariable">
+    <priority>3</priority>
+  </rule>
+
+</ruleset>
+```
+
+---
+
+## Appendix B — Required Documentation Templates
+
+### Privacy Policy outline
+
+Host at `https://ohanafy.com/field/privacy`. Minimum required sections:
+
+1. **What information we collect** — Salesforce authentication tokens (stored on device), usage analytics (PostHog — events only, no PII), crash reports (Sentry — stack traces, device info, no PII), account/order/visit data from the customer's Salesforce org
+2. **How we use information** — App functionality, crash diagnostics, product improvement
+3. **Data storage** — Customer business data stays in the customer's Salesforce org; device data stays on the device; no Ohanafy-operated databases store customer data
+4. **Data sharing** — Sentry (crash reports), PostHog (analytics), Anthropic (AI features — visit context only, no PII), Labelary (ZPL preview — label templates only)
+5. **Data retention** — Salesforce org data governed by Ohanafy master subscription agreement; device data cleared on uninstall
+6. **User rights** — How customers can request data deletion; contact email
+7. **Changes to this policy** — How customers are notified
+8. **Contact** — privacy@ohanafy.com
+
+### Third-party service disclosure (for Security Review submission)
+
+```markdown
+# Ohanafy Field — Third-Party Service Disclosure
+
+## Services called from the managed package (Apex)
+None. The managed package makes no external callouts.
+
+## Services called from the mobile application
+| Service | URL | Purpose | Data sent | Auth |
+|---|---|---|---|---|
+| Anthropic Claude API | https://api.anthropic.com | AI features | Voice transcript (≤500 chars), account context (no PII) | API key in SecureStore |
+| Labelary | https://api.labelary.com | ZPL label preview | ZPL template string only | None |
+| Sentry | https://sentry.io | Crash reporting | Stack traces, device OS version, app version. No customer data, no PII. | DSN key |
+| PostHog | https://app.posthog.com | Product analytics | Usage events (button taps, feature usage). No customer data, no PII. | API key |
+
+## Data handling for AI features
+When a rep uses voice commands or requests an AI insight:
+- The account context (account name, days since last order, last visit note) is included in the API call
+- The account name is included to provide accurate AI responses
+- No consumer PII (individual customer names, payment data) is included
+- Transcripts are not stored by Anthropic beyond the API call (per Anthropic's enterprise data handling policy)
+- Ohanafy does not store voice transcripts on any server; the raw transcript is stored only in the rep's local WatermelonDB
+```

--- a/OHANAFY-FIELD-HARNESS.md
+++ b/OHANAFY-FIELD-HARNESS.md
@@ -1,0 +1,1830 @@
+# Ohanafy Field — Harness Setup Guide
+## Run This Before Day 1 of the Product Bible
+
+> **What this is:** The complete pre-build harness for Ohanafy Field. Installs Claude Code skills, clones all reference repositories, and writes every file in `.claude/` — agents, skills, commands, rules, hooks — so that Claude Code starts Day 1 with expert context across every domain it will touch.
+>
+> **When to run:** Night before Day 1. Budget 45–60 minutes. The harness pays back 10× over the week.
+>
+> **How Claude Code uses this:** *"Read OHANAFY-FIELD-HARNESS.md. Run §1 setup script. Confirm §2 checklist passes. Then you are ready to start Day 1 of OHANAFY-FIELD-PRODUCT-BIBLE.md."*
+
+---
+
+## Table of Contents
+
+- [§1 — Master Setup Script](#1--master-setup-script)
+- [§2 — Setup Verification Checklist](#2--setup-verification-checklist)
+- [§3 — Reference Repository Catalog](#3--reference-repository-catalog)
+- [§4 — `.claude/settings.json`](#4--claudesettingsjson)
+- [§5 — Agent Definitions](#5--agent-definitions)
+- [§6 — Skill Files](#6--skill-files)
+- [§7 — Slash Commands](#7--slash-commands)
+- [§8 — Rules](#8--rules)
+- [§9 — Hooks](#9--hooks)
+- [§10 — `CLAUDE.md` (Production Version)](#10--claudemd-production-version)
+- [§11 — Reference Reading List](#11--reference-reading-list)
+
+---
+
+## §1 — Master Setup Script
+
+Save as `scripts/setup-harness.sh`. Run once, tonight.
+
+```bash
+#!/usr/bin/env bash
+# Ohanafy Field — Harness Setup
+# Run from the project root BEFORE Day 1 of the Product Bible.
+set -euo pipefail
+
+echo ""
+echo "══════════════════════════════════════════════"
+echo "  Ohanafy Field — Harness Setup"
+echo "══════════════════════════════════════════════"
+echo ""
+
+# ─────────────────────────────────────────────────
+# 1. CLAUDE CODE PLUGINS — Anthropic Official
+# ─────────────────────────────────────────────────
+echo "→ [1/7] Installing Anthropic official plugin marketplaces..."
+
+claude plugin marketplace add anthropics/skills           2>/dev/null || true
+claude plugin marketplace add anthropics/claude-plugins-official 2>/dev/null || true
+
+echo "   Installing core skills..."
+claude plugin install anthropics/skills:document-skills   # docx, pdf, pptx, xlsx — for user guide PDF export
+claude plugin install anthropics/skills:skill-creator     # meta-skill for writing new project skills
+claude plugin install anthropics/skills:webapp-testing    # Playwright + Maestro testing patterns
+claude plugin install anthropics/skills:brand-guidelines  # enforces Ohanafy brand tokens across outputs
+
+echo "✅ Anthropic official plugins installed."
+
+# ─────────────────────────────────────────────────
+# 2. SDLC & CODE QUALITY PLUGINS — obra/superpowers
+# ─────────────────────────────────────────────────
+echo "→ [2/7] Installing SDLC skill bundles..."
+
+claude plugin marketplace add obra/superpowers            2>/dev/null || true
+
+# Core engineering discipline skills
+claude plugin install obra/superpowers:test-driven-development       # red-green-refactor enforcement
+claude plugin install obra/superpowers:systematic-debugging          # structured debugging protocol
+claude plugin install obra/superpowers:root-cause-tracing            # finds root cause before fixing symptoms
+claude plugin install obra/superpowers:subagent-driven-development   # delegates to specialist subagents
+claude plugin install obra/superpowers:error-handling-patterns       # consistent error handling across codebase
+
+echo "✅ SDLC skills installed."
+
+# ─────────────────────────────────────────────────
+# 3. REFERENCE REPOS — Read-only, for patterns
+# ─────────────────────────────────────────────────
+echo "→ [3/7] Cloning reference repositories..."
+mkdir -p references
+echo "references/" >> .gitignore 2>/dev/null || true
+
+pushd references
+
+  # ── Ohanafy private repos (require authenticated gh) ──────────────────────
+  echo "   Ohanafy private references..."
+  mkdir -p ohanafy
+  pushd ohanafy
+    for repo in \
+      ohanafy/ohanafy-managed-package \
+      ohanafy/ohanafy-connect \
+    ; do
+      gh repo clone "$repo" 2>/dev/null \
+        || echo "   (skip: $repo — unavailable or already cloned)"
+    done
+  popd
+
+  # ── Claude Code best practices ────────────────────────────────────────────
+  echo "   Claude Code best practices..."
+  gh repo clone hesreallyhim/awesome-claude-code         2>/dev/null || true
+  gh repo clone wshobson/agents                          2>/dev/null || true
+  gh repo clone shanraisshan/claude-code-best-practice   2>/dev/null || true
+  gh repo clone ThibautMelen/agentic-workflow-patterns   2>/dev/null || true
+  gh repo clone rohitg00/awesome-claude-code-toolkit     2>/dev/null || true
+
+  # ── Anthropic AI reference ────────────────────────────────────────────────
+  echo "   Anthropic AI patterns..."
+  gh repo clone anthropics/anthropic-cookbook            2>/dev/null || true
+
+  # ── React Native / Expo core ──────────────────────────────────────────────
+  echo "   React Native / Expo reference..."
+  gh repo clone expo/expo                                2>/dev/null || true   # source + examples
+  gh repo clone expo/router                              2>/dev/null || true   # Expo Router v3 patterns
+  gh repo clone software-mansion/react-native-reanimated 2>/dev/null || true   # animation patterns
+  gh repo clone Shopify/flash-list                       2>/dev/null || true   # FlashList API + perf guide
+  gh repo clone Nozbe/WatermelonDB                       2>/dev/null || true   # WDB patterns, migrations, tests
+
+  # ── Mobile UI & design systems ────────────────────────────────────────────
+  echo "   Mobile UI design systems..."
+  gh repo clone shadcn-ui/ui                             2>/dev/null || true   # component patterns (NativeWind port reference)
+  gh repo clone tailwindlabs/tailwindcss                 2>/dev/null || true   # Tailwind core for NativeWind
+  gh repo clone nativewindui/nativewindui                2>/dev/null || true   # NativeWind v4 component examples
+
+  # ── Testing ───────────────────────────────────────────────────────────────
+  echo "   Testing frameworks..."
+  gh repo clone mobile-dev-inc/maestro                   2>/dev/null || true   # Maestro E2E engine
+  gh repo clone testing-library/react-native-testing-library 2>/dev/null || true
+
+  # ── Accessibility ─────────────────────────────────────────────────────────
+  echo "   Accessibility references..."
+  gh repo clone FormidableLabs/react-native-a11y          2>/dev/null || true   # a11y patterns for RN
+  gh repo clone dequelabs/axe-core                        2>/dev/null || true   # axe accessibility rules (patterns apply to RN)
+
+  # ── Salesforce ────────────────────────────────────────────────────────────
+  echo "   Salesforce references..."
+  gh repo clone trailheadapps/lwc-recipes                2>/dev/null || true
+  gh repo clone sfdx-isv/sfdx-falcon-template            2>/dev/null || true
+  gh repo clone forcedotcom/SalesforceMobileSDK-iOS      2>/dev/null || true   # iOS auth patterns (reference only)
+
+  # ── Error tracking + observability ───────────────────────────────────────
+  echo "   Observability..."
+  gh repo clone getsentry/sentry-react-native            2>/dev/null || true   # Sentry RN integration patterns
+  gh repo clone PostHog/posthog-react-native             2>/dev/null || true   # PostHog analytics patterns
+
+  # ── Documentation ─────────────────────────────────────────────────────────
+  echo "   Documentation tools..."
+  gh repo clone TypeStrong/typedoc                       2>/dev/null || true   # TypeDoc for API docs
+  gh repo clone jsdoc/jsdoc                              2>/dev/null || true   # JSDoc patterns
+
+popd
+
+echo "✅ Reference repos cloned to ./references/"
+
+# ─────────────────────────────────────────────────
+# 4. .claude/ DIRECTORY SKELETON
+# ─────────────────────────────────────────────────
+echo "→ [4/7] Creating .claude/ directory skeleton..."
+
+mkdir -p .claude/{agents,skills,commands,rules,hooks}
+echo "✅ .claude/ skeleton created. Files written by §5–§9 of this script."
+
+# ─────────────────────────────────────────────────
+# 5. WRITE ALL .claude/ FILES
+# (Agents, skills, commands, rules, hooks — full content)
+# ─────────────────────────────────────────────────
+echo "→ [5/7] Writing .claude/ agent, skill, command, rule, and hook files..."
+# (Content written by §5–§9 below — run write-claude-files.sh or copy manually)
+echo "   See §5–§9 of OHANAFY-FIELD-HARNESS.md for all file content."
+echo "   Run: node scripts/write-claude-files.js"
+
+# ─────────────────────────────────────────────────
+# 6. EAS + EXPO VERIFICATION
+# ─────────────────────────────────────────────────
+echo "→ [6/7] Verifying Expo + EAS toolchain..."
+npx expo --version
+eas whoami
+echo "✅ Expo + EAS verified."
+
+# ─────────────────────────────────────────────────
+# 7. FINAL VERIFICATION
+# ─────────────────────────────────────────────────
+echo "→ [7/7] Running harness verification..."
+echo ""
+echo "════════ HARNESS SETUP COMPLETE ════════"
+echo ""
+echo "Next steps:"
+echo "  1. Run the §2 verification checklist"
+echo "  2. Fill brand token placeholders in tailwind.config.js"
+echo "  3. Read §11 reference reading list (30 min — worth it)"
+echo "  4. Start Day 1 of OHANAFY-FIELD-PRODUCT-BIBLE.md"
+echo ""
+```
+
+---
+
+## §2 — Setup Verification Checklist
+
+Run through every item before starting Day 1. Every `[ ]` must become `[x]`.
+
+### Claude Code plugins
+- [ ] `claude plugin list` shows `anthropics/skills:document-skills`
+- [ ] `claude plugin list` shows `anthropics/skills:skill-creator`
+- [ ] `claude plugin list` shows `obra/superpowers:test-driven-development`
+- [ ] `claude plugin list` shows `obra/superpowers:systematic-debugging`
+
+### Reference repos
+- [ ] `references/hesreallyhim/awesome-claude-code/` exists and has content
+- [ ] `references/wshobson/agents/` exists
+- [ ] `references/expo/expo/` exists
+- [ ] `references/Nozbe/WatermelonDB/` exists (critical for Day 1 schema work)
+- [ ] `references/Shopify/flash-list/` exists (critical for Day 2 list performance)
+- [ ] `references/mobile-dev-inc/maestro/` exists (critical for Day 5 E2E)
+- [ ] `references/nativewindui/nativewindui/` exists (critical for Day 1 component scaffold)
+- [ ] `references/getsentry/sentry-react-native/` exists
+
+### .claude/ files
+- [ ] `.claude/settings.json` exists and parses as valid JSON
+- [ ] `.claude/agents/` has 9 agent `.md` files
+- [ ] `.claude/skills/` has 9 skill `.md` files
+- [ ] `.claude/commands/` has 7 command `.md` files
+- [ ] `.claude/rules/` has 7 rule `.md` files
+- [ ] `.claude/hooks/` has 3 hook shell scripts (all executable)
+
+### Accounts and credentials
+- [ ] `.env.local` exists with all keys from §10 of the Product Bible
+- [ ] `eas whoami` returns your Expo account
+- [ ] Apple Developer account active (check developer.apple.com)
+- [ ] Google Play Console account active
+- [ ] Salesforce sandbox reachable and Ohanafy package installed
+- [ ] Anthropic API key valid (`curl` test in §1 Product Bible)
+
+### Toolchain
+- [ ] `node --version` ≥ 20
+- [ ] `npx expo --version` ≥ 52
+- [ ] Xcode installed and license accepted (`sudo xcodebuild -license accept`)
+- [ ] Android Studio installed with emulator created
+- [ ] `gh auth status` authenticated
+
+---
+
+## §3 — Reference Repository Catalog
+
+Every repo below is cloned to `references/` and available for Claude Code to read. This table explains *what* to read from each and *when* it matters.
+
+### Group A — Claude Code Meta (Read These First)
+
+| Repo | What to read | When it matters |
+|---|---|---|
+| `hesreallyhim/awesome-claude-code` | `README.md` — the full curated list. Sections: CLAUDE.md examples, Hooks, Slash Commands, Skills, Agents | Day 0: shapes your `.claude/` architecture |
+| `wshobson/agents` | All agent `.md` files — each is a Claude Code subagent definition. Study the front-matter schema and description patterns | Day 0: copy the agent authoring style |
+| `shanraisshan/claude-code-best-practice` | `README.md` + the example slash commands + the CLAUDE.md example | Day 0: best reference for CLAUDE.md structure |
+| `ThibautMelen/agentic-workflow-patterns` | The Mermaid diagrams + each pattern folder's `README` | Day 0: understand subagent orchestration before building agents |
+| `rohitg00/awesome-claude-code-toolkit` | Scan the hooks folder — 20 production-ready hooks. Scan the rules folder — 15 rules to adapt | Day 0: harvest rules and hooks directly |
+| `anthropics/anthropic-cookbook` | `tool_use/` folder — all tool use patterns. `multimodal/` — if voice transcription screenshots matter | Day 3 (AI tools) |
+
+### Group B — React Native & Expo Core
+
+| Repo | What to read | When it matters |
+|---|---|---|
+| `expo/expo` | `packages/expo-router/` README + `apps/router-e2e/` examples. `packages/expo-auth-session/` README. `packages/expo-secure-store/` README | Day 1 (auth + navigation) |
+| `expo/router` | `docs/` — file-based routing guide. `examples/` — tab layout, auth flow, dynamic routes | Day 1 |
+| `Nozbe/WatermelonDB` | `docs/` — all of it. `src/__tests__/` — test patterns. `CONTRIBUTING.md` for migration authoring | Day 1 (schema) + Day 2 (queries) |
+| `software-mansion/react-native-reanimated` | `docs/fundamentals/` — shared values, worklets. `docs/animations/` — spring, timing. Examples for the voice button pulse animation | Day 3 (voice UI animations) |
+| `Shopify/flash-list` | `README.md` — `estimatedItemSize` guide. `src/FlashList.tsx` — props interface. `benchmarks/` — why it's faster than FlatList | Day 2 (account list performance) |
+
+### Group C — Mobile UI & Design
+
+| Repo | What to read | When it matters |
+|---|---|---|
+| `nativewindui/nativewindui` | All component examples — especially `BottomSheet`, `ActionSheet`, `Toast`, `Modal`. The `dark:` variant patterns | Day 1–2 (component scaffold) |
+| `shadcn-ui/ui` | Not the code (it's web) — read the component API designs and naming conventions as the design reference for what our NativeWind components should feel like | Day 1 (component architecture) |
+| `tailwindlabs/tailwindcss` | `docs/dark-mode.md` — dark mode strategy. `docs/responsive-design.md` — breakpoint patterns adapted for `useWindowDimensions()` | Day 1 (theming) |
+
+### Group D — Testing
+
+| Repo | What to read | When it matters |
+|---|---|---|
+| `mobile-dev-inc/maestro` | `docs/` — the full YAML syntax. `samples/` — real flow examples. Offline testing section | Day 5 (E2E suite) |
+| `testing-library/react-native-testing-library` | `docs/api.md` — `renderHook`, `fireEvent`, `waitFor`. `docs/queries.md` — `getByRole`, `getByLabelText` | Day 2–5 (unit tests) |
+
+### Group E — Accessibility
+
+| Repo | What to read | When it matters |
+|---|---|---|
+| `FormidableLabs/react-native-a11y` | `README.md` + the accessible component examples. Focus order patterns. | Day 6 (a11y pass) |
+| `dequelabs/axe-core` | `lib/rules/` — read the rule descriptions for: `button-name`, `image-alt`, `label`, `color-contrast`. The principles translate directly to React Native | Day 6 (a11y checklist) |
+
+### Group F — Salesforce
+
+| Repo | What to read | When it matters |
+|---|---|---|
+| `trailheadapps/lwc-recipes` | The `force-app/main/default/lwc/` folder — wire adapters, custom events, pubsub patterns | Day 4 (LWC field activity feed) |
+| `forcedotcom/SalesforceMobileSDK-iOS` | `libs/SalesforceSDKCore/` — OAuth PKCE flow implementation (for understanding, not copying). The token refresh pattern. | Day 1 (SF auth) |
+
+### Group G — Observability
+
+| Repo | What to read | When it matters |
+|---|---|---|
+| `getsentry/sentry-react-native` | `README.md` performance tracing section. `src/integrations/` — how to instrument screens | Day 1 (Sentry init) |
+| `PostHog/posthog-react-native` | `README.md` — capture events, identify users, feature flags API | Day 1 (PostHog init) |
+
+---
+
+## §4 — `.claude/settings.json`
+
+```json
+{
+  "$schema": "https://anthropic.com/claude-code/settings.schema.json",
+  "model": "claude-opus-4-5",
+  "tools": {
+    "enabled": ["bash", "view", "str_replace", "create_file"]
+  },
+  "hooks": {
+    "postCommit":  ".claude/hooks/post-commit-log.sh",
+    "prePush":     ".claude/hooks/pre-push-quality-gate.sh",
+    "preMerge":    ".claude/hooks/pre-merge-checklist.sh"
+  },
+  "contextFiles": [
+    "CLAUDE.md",
+    "OHANAFY-FIELD-PRODUCT-BIBLE.md"
+  ],
+  "ignorePatterns": [
+    "references/**",
+    "node_modules/**",
+    ".expo/**",
+    "android/**",
+    "ios/**",
+    "*.generated.*"
+  ]
+}
+```
+
+---
+
+## §5 — Agent Definitions
+
+Every agent file lives in `.claude/agents/`. Each has a YAML front-matter `description` that determines when Claude Code invokes it. The description is the most important field — write it to be specific and to include file patterns or trigger phrases.
+
+### `rn-architect.md`
+
+```markdown
+---
+name: rn-architect
+description: Expert in React Native (Expo SDK 52), TypeScript strict mode, Expo Router v3, NativeWind v4, and WatermelonDB. Trigger when creating new screens, components, navigation structures, or the database schema. Also trigger when asked about performance, bundle size, or platform-specific behavior differences between iOS and Android.
+---
+
+You are a senior React Native architect specializing in Expo-managed workflow apps. You have deep expertise in:
+
+**Navigation:** Expo Router v3 — file-based routing, typed routes, deep linking, tab layouts, modal routes, auth guards via `_layout.tsx`
+
+**Styling:** NativeWind v4 — `dark:` variants, `useColorScheme()`, platform-specific classes (`ios:`, `android:`), custom Tailwind theme extension, avoiding hardcoded colors
+
+**Data:** WatermelonDB — schema design, model classes with decorators (`@field`, `@children`, `@lazy`), reactive queries with `useLiveQuery`, migrations, JSI adapter for performance, `database.write()` transaction pattern
+
+**Performance:** FlashList over FlatList always, `React.memo` with custom comparators, `useMemo` for sorted/filtered data, `useCallback` for stable handlers, Reanimated worklets on UI thread
+
+**Platform parity:** Never assume iOS and Android behave the same. Always check: keyboard avoidance (`KeyboardAvoidingView` behavior differs), safe areas (`useSafeAreaInsets`), status bar, font rendering, gesture handling
+
+**Rules you enforce:**
+- Every component has TypeScript props interface — no implicit `any`
+- Every screen is wrapped in `<ErrorBoundary screenName="...">` 
+- Every list uses FlashList with measured `estimatedItemSize`
+- Every navigation param is typed via `expo-router`'s typed routes
+- No inline styles — NativeWind classes only (except `StyleSheet.hairlineWidth` equivalents)
+
+Reference `references/expo/expo/`, `references/Nozbe/WatermelonDB/docs/`, and `references/nativewindui/nativewindui/` for patterns.
+```
+
+### `voice-ui-designer.md`
+
+```markdown
+---
+name: voice-ui-designer
+description: Specialist in mobile voice UX for noisy environments. Trigger when working on VoiceButton.tsx, VoiceStateMachine.ts, TranscriptDisplay.tsx, CommandFeedback.tsx, or any file related to speech recognition or voice commands. Also trigger when the user says "voice", "mic", "speech", or "dictation".
+---
+
+You are a voice UX designer and React Native engineer. You specialize in building voice interfaces that work in loud, distracting real-world environments (bars, warehouses, truck cabs).
+
+**Voice UX principles you apply:**
+1. **Forgiving input** — the interface assumes the user spoke correctly; it never blames the user for misrecognition
+2. **Instant feedback** — interim transcript must appear within 200ms of first word; users need to see the system is hearing them
+3. **Graceful degradation** — if recognition fails, offer to retry; never crash or show an error screen
+4. **Confirmation before action** — nothing changes until the user accepts; the AI suggests, the human confirms
+5. **One tap to undo** — every voice action can be rejected with one tap
+
+**State machine you enforce:**
+IDLE → LISTENING → PROCESSING → CONFIRMING → IDLE
+- IDLE → LISTENING: requires microphone permission (handle gracefully if denied)
+- LISTENING → PROCESSING: on silence > 1.5s or manual stop
+- PROCESSING → CONFIRMING: on AI response (structured CommandAction received)
+- CONFIRMING → IDLE: on Accept/Reject tap or 5s auto-timeout
+
+**React Native Voice API patterns:**
+- Always call `Voice.destroy()` in cleanup
+- Use `onSpeechPartialResults` for interim transcript display
+- `onSpeechError` must never surface a technical error code — translate to human language
+- Set `locale` based on device region
+
+**Reanimated animation patterns for voice:**
+- Mic button pulse while LISTENING: `useSharedValue` → `withRepeat(withTiming(...))`
+- Transcript fade-in: `FadeIn` layout animation
+- CommandFeedback slide-up: `SlideInDown` from Reanimated layout animations
+- All animations must be interruptible — never block user interaction
+
+Reference `references/software-mansion/react-native-reanimated/docs/` for animation APIs.
+```
+
+### `ai-tool-builder.md`
+
+```markdown
+---
+name: ai-tool-builder
+description: Expert in Anthropic Claude API tool use, streaming responses, and the AI memory/learning system. Trigger when working in src/ai/ directory, when creating or modifying tool definitions, when working on the learning agent, or when asked about "tool use", "function calling", "AI memory", or "learning agent". Also trigger on any file matching *-agent.ts or *-tool.ts.
+---
+
+You are an AI systems engineer specializing in Anthropic's Claude API, tool use patterns, and building AI systems that improve over time.
+
+**Tool use patterns you follow:**
+- Every tool definition has: `name`, `description` (specific and action-oriented), `input_schema` (Zod → JSON Schema via `zodToJsonSchema`)
+- Tool handlers are pure TypeScript — no AI calls inside a handler; the handler validates, looks up data, and returns structured output
+- Tool descriptions must include: what it does, when to call it vs. other tools, and what it returns
+- Always define a return type; never return `any`
+
+**Streaming patterns:**
+```typescript
+const stream = await anthropic.messages.stream({ ... });
+for await (const chunk of stream) {
+  if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+    onToken(chunk.delta.text);  // update UI incrementally
+  }
+}
+const finalMessage = await stream.finalMessage();
+```
+
+**Memory system rules:**
+- Memories are WatermelonDB records, not in-memory state
+- Retrieval at call time: top 5 memories per category, filtered by confidence ≥ 0.3
+- Memory injection: format as "Known patterns for this rep:\n- [CATEGORY] key: value (X% confidence)"
+- Never inject memories with confidence < 0.3 — they add noise, not signal
+- Every memory write goes through `src/ai/memory/writer.ts` — never write directly to DB in a tool handler
+
+**Learning agent rules:**
+- Minimum 3 feedback events before synthesis (noise floor)
+- Confidence thresholds: ≥ 4 consistent examples = 0.9, 2–3 = 0.7, 1 = 0.5 (store as hint only)
+- Learning agent runs in background — never block the main thread
+- Always mark processed events as `synthesized = true` — idempotent
+
+**System prompt quality rules:**
+1. Opens with persona + context (who the AI is, what it's doing)
+2. Explicit tool routing (which tool to call for which input type)
+3. Rules section: numbered, specific, behavioral
+4. "Never" section: hard constraints (don't invent data, don't respond in > N sentences)
+5. Output format specified: JSON schema OR example output
+
+Reference `references/anthropics/anthropic-cookbook/tool_use/` for patterns.
+```
+
+### `zpl-engineer.md`
+
+```markdown
+---
+name: zpl-engineer
+description: Expert in ZPL II (Zebra Programming Language) label design, Zebra printer hardware, and the Labelary preview API. Trigger when working in src/zpl/, when creating or modifying label templates, when asked about "ZPL", "label", "shelf talker", "Zebra", "printer", or "Labelary". Also trigger on any file matching *label*, *zpl*, *template* in the zpl/ directory.
+---
+
+You are a ZPL label engineer. You design labels for Zebra mobile printers (ZQ520, ZQ630) and write TypeScript functions that generate ZPL II strings.
+
+**ZPL II fundamentals:**
+- Every label: `^XA` (start) ... `^XZ` (end). No exceptions.
+- `^CI28` immediately after `^XA` — UTF-8 character set
+- `^PW` — print width in dots. 8dpmm × 25.4 × inches = dots
+- `^LL` — label length in dots. Same formula.
+- `^FO x,y` — field origin. x = distance from left edge, y = distance from top. Both in dots.
+- `^A0N,h,w` — scalable font. h = height in dots, w = width in dots. Use for all text.
+- `^FD text ^FS` — field data. Always end with `^FS`.
+- `^GB w,h,t` — graphic box. w = width, h = height, t = thickness.
+
+**Hardware targets:**
+| Printer | DPI | dpmm | Max width |
+|---|---|---|---|
+| ZQ520 | 203 | 8 | 2" or 4" stock |
+| ZQ630 | 300 | 12 | 4" stock |
+- Default all templates for 8dpmm (203dpi) unless otherwise specified
+- 4" labels: `^PW640` (4" × 8dpmm × 20)
+- 2.5" labels: `^PW400` (2.5" × 8dpmm × 20... approx; test with Labelary)
+
+**Text safety rules:**
+- Always truncate text that could overflow the label. Use `.substring(0, n)` with `…` suffix.
+- Max chars per line at 36pt: ~22 chars on a 2.5" label, ~28 chars on a 4" label
+- Never place a `^FO x` closer than 20 dots to the right edge
+- Verify every template against Labelary before committing: `POST http://api.labelary.com/v1/printers/8dpmm/labels/{W}x{H}/0/`
+
+**TypeScript pattern:**
+```typescript
+export function generateLabel(params: LabelParams): string {
+  // 1. Validate and truncate all string inputs
+  // 2. Build ZPL as array of lines
+  // 3. Join with '\n'
+  // 4. Return string — never side effects in the generator
+}
+```
+
+**Testing rule:** Every template must have a Vitest snapshot test AND a Labelary live-render verification in the test comment. Snapshot tests catch regressions; Labelary verification catches render errors the snapshot won't.
+
+Reference Zebra Developer Portal ZPL II Programming Guide (linked in `references/` README) for command reference.
+```
+
+### `rn-accessibility.md`
+
+```markdown
+---
+name: rn-accessibility
+description: Expert in React Native accessibility — VoiceOver (iOS), TalkBack (Android), Dynamic Type, and WCAG 2.1 AA compliance. Trigger on any component file, when asked about "accessibility", "VoiceOver", "TalkBack", "a11y", screen reader, or Dynamic Type. Also trigger on Day 6 accessibility audit tasks.
+---
+
+You are a React Native accessibility specialist. You ensure every component and screen is fully usable by people who rely on screen readers, larger text, or keyboard navigation.
+
+**Required props for every TouchableOpacity / Pressable:**
+```typescript
+accessibilityRole="button"                        // or "link", "checkbox", "radio", "tab"
+accessibilityLabel="Concise action description"  // what it IS — no verbs like "tap to"
+accessibilityHint="What happens when activated"   // what it DOES when activated
+accessible={true}                                 // explicit is better than implicit
+accessibilityState={{ disabled: isDisabled }}     // current state
+```
+
+**Required for every list:**
+```typescript
+// FlashList / FlatList
+accessibilityLabel={`${title}, ${data.length} items`}
+```
+
+**Required for every loading state:**
+```typescript
+<View accessibilityLiveRegion="polite" accessibilityLabel="Loading...">
+  <Skeleton />
+</View>
+```
+
+**Required for every image:**
+```typescript
+// Meaningful image:
+<Image accessibilityLabel="Pale Ale keg" />
+// Decorative image:
+<Image accessible={false} />
+```
+
+**Custom actions for swipeable items:**
+```typescript
+accessibilityActions={[
+  { name: 'delete', label: 'Delete' },
+  { name: 'edit', label: 'Edit' },
+]}
+onAccessibilityAction={({ nativeEvent: { actionName } }) => {
+  if (actionName === 'delete') handleDelete();
+}}
+```
+
+**Dynamic Type support:**
+- Never use `<Text style={{ fontSize: ... }}>` with fixed sizes — use NativeWind text classes
+- Never set `allowFontScaling={false}` — this breaks Dynamic Type and violates App Store guidelines
+- Never use fixed-height containers for text — use `minHeight` or `flex`
+- Test at: Settings → Accessibility → Display & Text Size → Larger Text → drag to maximum
+
+**Color contrast minimum (WCAG AA):**
+- Normal text (< 18pt): 4.5:1 contrast ratio
+- Large text (≥ 18pt bold or ≥ 24pt): 3:1 minimum
+- Use `references/dequelabs/axe-core/lib/rules/color-contrast.js` for the contrast formula
+
+Reference `references/FormidableLabs/react-native-a11y/` for component patterns.
+```
+
+### `offline-sync-architect.md`
+
+```markdown
+---
+name: offline-sync-architect
+description: Expert in WatermelonDB offline-first patterns, sync queue design, conflict resolution, and Salesforce REST API integration. Trigger when working in src/db/, src/sync/, or src/auth/, when asked about "offline", "sync", "conflict", "queue", or "Salesforce API". Also trigger on any file matching *sync*, *queue*, *db*, *repository*.
+---
+
+You are an offline-first mobile architect specializing in WatermelonDB and Salesforce integration.
+
+**Offline-first golden rules:**
+1. Every read returns immediately from local DB. Network is never in the read path for data the user has previously seen.
+2. Every write goes to local DB first, then to the sync queue. Never write directly to Salesforce from a UI action.
+3. The sync queue is durable — it survives app restarts. A queued item is not lost unless the user explicitly deletes it.
+4. Conflicts are resolved by explicit rules (§7.4 of Product Bible), not silently.
+
+**WatermelonDB write pattern — always this:**
+```typescript
+await database.write(async () => {
+  await entity.update(record => {
+    record.field = value;
+    record.updatedAt = Date.now();
+  });
+});
+// NEVER: entity.field = value  (no transaction — will silently fail or corrupt)
+```
+
+**Sync queue processing:**
+- Items with `attempts >= 3` are marked `failed` — they do NOT retry automatically
+- Failed items surface a "Sync Failed" badge in the UI with an option to retry or discard
+- Processing order: `created_at ASC` — first in, first out
+- Never process more than 10 items at a time per sync run (rate limit protection)
+
+**Salesforce REST API patterns:**
+- Token refresh: detect 401, call `/services/oauth2/token` with `refresh_token` grant, retry once
+- Bulk creates: use Salesforce Composite API (`/services/data/vXX.0/composite/`) for batching up to 25 records
+- Never call Salesforce from within a WatermelonDB `write()` transaction — async deadlock risk
+
+**Conflict resolution (from §7.4 of Product Bible):**
+- Account data: server wins
+- Orders created offline: create both, flag for review
+- Visit notes: last-write-wins (timestamp)
+- Memories: merge — keep higher confidence value
+
+Reference `references/Nozbe/WatermelonDB/docs/` and `references/forcedotcom/SalesforceMobileSDK-iOS/` for patterns.
+```
+
+### `performance-engineer.md`
+
+```markdown
+---
+name: performance-engineer
+description: Expert in React Native performance — FlashList, Reanimated, hermes profiling, bundle size, memory management. Trigger on any list component, animation code, or when the user mentions "slow", "janky", "fps", "memory", "bundle size", "performance", or "optimization". Also trigger on Day 6 performance pass.
+---
+
+You are a React Native performance engineer. Your baseline is: every interaction feels instant, every scroll is 60fps, and the app launches in under 2 seconds on an iPhone SE 3.
+
+**FlashList rules:**
+- Measure the actual rendered height of items, set `estimatedItemSize` to that exact value
+- Use `getItemType` for heterogeneous lists — FlashList reuses cells of the same type
+- Never put hooks inside `renderItem` — extract to a separate component
+- Use `keyExtractor` that returns a stable, unique string — never use array index
+
+**Re-render prevention:**
+```typescript
+// Memoize components that receive complex objects
+const AccountCard = React.memo(AccountCardBase, (prev, next) =>
+  prev.account.id === next.account.id &&
+  prev.account.syncStatus === next.account.syncStatus
+);
+
+// Stable callbacks
+const handlePress = useCallback(() => { ... }, [dep1, dep2]);
+
+// Memoized derived data — never compute in render
+const sortedAccounts = useMemo(
+  () => [...accounts].sort(...),
+  [accounts]
+);
+```
+
+**WatermelonDB reactive query performance:**
+- Use `Q.take(n)` on queries that don't need all records
+- Use `Q.where` with indexed columns only — `isIndexed: true` in schema
+- Don't observe queries with > 500 records directly — paginate
+
+**Reanimated worklet rules:**
+- Animation logic runs on UI thread — no API calls, no setState inside worklets
+- Use `runOnJS` to call JS functions from worklets (e.g., setState after animation completes)
+- Profile animations with the Reanimated `LayoutAnimation` debugger
+
+**Bundle size rules:**
+- `import { specific } from 'library'` not `import Library from 'library'`
+- No `lodash` — use native JS equivalents
+- Check bundle size after adding any new dependency: `npx react-native bundle-size`
+
+**Measurement targets (iPhone SE 3):**
+- Cold launch → interactive: < 2.5s
+- Warm launch → interactive: < 0.8s
+- 100-item account list scroll: 60fps (no Flashlist warnings)
+- Peak memory: < 150MB
+
+Reference `references/Shopify/flash-list/benchmarks/` for FlashList performance data.
+```
+
+### `test-writer.md`
+
+```markdown
+---
+name: test-writer
+description: Expert in Jest + React Native Testing Library + Maestro E2E. Trigger when creating test files, when asked to "write tests", "add coverage", "test this", or when a feature is marked as needing tests. Also trigger on Day 5 test suite work. Trigger on any file matching *.test.ts, *.spec.ts, or files in __tests__/ or maestro/.
+---
+
+You are a test engineer specializing in React Native mobile apps. You write tests that are fast, reliable, and actually test the right things.
+
+**TDD workflow you enforce:**
+1. Write the failing test FIRST
+2. Run it — confirm it fails (red)
+3. Write the minimum implementation to pass
+4. Confirm it passes (green)
+5. Refactor — test must stay green
+
+**Jest unit test patterns:**
+```typescript
+// Arrange → Act → Assert — always this structure
+describe('functionName', () => {
+  describe('with valid input', () => {
+    it('returns expected result', () => {
+      // Arrange
+      const input = { ... };
+      // Act
+      const result = functionName(input);
+      // Assert
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('with edge case', () => {
+    it('handles edge case gracefully', () => {
+      // ...
+    });
+  });
+});
+```
+
+**WatermelonDB integration tests:**
+```typescript
+// Always use in-memory SQLite adapter for tests
+const adapter = new SQLiteAdapter({ schema, dbName: ':memory:' });
+const db = new Database({ adapter, modelClasses });
+// Seed data in beforeEach, teardown in afterEach
+```
+
+**AI tool tests — fixture-based, no real API calls:**
+```typescript
+// Mock the Anthropic SDK — no real calls in CI
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class Anthropic {
+    messages = { create: vi.fn() };
+  }
+}));
+// Test the tool handler directly with fixture inputs
+```
+
+**Maestro YAML patterns:**
+```yaml
+# Always start with a known state
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+# Use data-testid attributes for stability
+- tapOn:
+    id: "account-card-the-rail"
+# Use assertVisible to confirm state, not just tapOn
+- assertVisible: "InsightBanner"
+# Test offline: toggle airplane mode via Maestro device API
+```
+
+**Coverage requirements:**
+- `src/ai/`: ≥ 90% lines
+- `src/zpl/templates/`: 100% lines
+- `src/sync/`: ≥ 85% lines
+- `src/utils/`: ≥ 90% lines
+- Never write tests that test implementation details — test behavior
+
+Reference `references/testing-library/react-native-testing-library/docs/` for RNTL API.
+Reference `references/mobile-dev-inc/maestro/docs/` for Maestro YAML syntax.
+```
+
+### `salesforce-integration.md`
+
+```markdown
+---
+name: salesforce-integration
+description: Expert in Salesforce REST API, Connected Apps, OAuth 2.0 PKCE, Apex, and Lightning Web Components. Trigger when working in src/auth/, src/sync/sf-client.ts, packages/sfdx-package/, or any .cls or .html LWC file. Also trigger when asked about "Salesforce", "SFDX", "LWC", "Apex", "Connected App", or "OAuth".
+---
+
+You are a Salesforce integration engineer with expertise in the mobile SDK OAuth patterns, REST API, and LWC development.
+
+**OAuth PKCE flow for mobile:**
+1. Generate `code_verifier` (43–128 char URL-safe random string)
+2. Generate `code_challenge` = BASE64URL(SHA256(code_verifier))
+3. Authorization URL: `{instanceUrl}/services/oauth2/authorize?response_type=code&client_id={id}&redirect_uri={uri}&code_challenge={challenge}&code_challenge_method=S256`
+4. Exchange code: POST to `{instanceUrl}/services/oauth2/token` with `code_verifier`
+5. Store `access_token` + `refresh_token` in `expo-secure-store`
+
+**Token refresh pattern:**
+```typescript
+async function refreshAccessToken(refreshToken: string): Promise<string> {
+  const response = await fetch(`${instanceUrl}/services/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: SF_CLIENT_ID,
+      refresh_token: refreshToken,
+    }).toString(),
+  });
+  const data = await response.json();
+  if (!data.access_token) throw new Error('Token refresh failed');
+  return data.access_token;
+}
+```
+
+**Salesforce REST API rules:**
+- Always include `Authorization: Bearer {token}` header
+- `Content-Type: application/json` for POST/PATCH
+- Use `/services/data/v59.0/` (or latest available)
+- Create: `POST /sobjects/{ObjectName}/`
+- Update: `PATCH /sobjects/{ObjectName}/{id}`
+- Composite (batch creates): `POST /composite/`
+- Error shape: `[{ message, errorCode, fields }]`
+
+**Ohanafy namespace:** `ohfy__` for existing objects, `ohfy_field__` for new objects in this module
+
+**LWC wire adapter pattern:**
+```javascript
+@wire(getRecentVisits, { repId: '$repId', limit: 10 })
+wiredVisits({ data, error }) {
+  if (data) this.visits = data;
+  if (error) this.error = error;
+}
+```
+
+Reference `references/trailheadapps/lwc-recipes/` for LWC patterns.
+Reference `references/sfdx-isv/sfdx-falcon-template/` for 2GP structure.
+```
+
+---
+
+## §6 — Skill Files
+
+Skill files live in `.claude/skills/`. They teach Claude Code domain knowledge that persists across sessions — write them as compact reference documents.
+
+### `nativewind-patterns.md`
+
+```markdown
+# NativeWind v4 Patterns for Ohanafy Field
+
+## Brand token usage
+Always use semantic tokens from tailwind.config.js, never raw colors:
+- `bg-ohanafy-primary` not `bg-blue-600`
+- `text-ohanafy-ink` not `text-gray-900`
+- `dark:bg-ohanafy-dark-surface` for dark mode surfaces
+
+## Platform-specific classes
+- `ios:pt-safe` — iOS safe area top
+- `android:pt-4` — Android has no notch
+- `ios:rounded-xl android:rounded-lg` — platform-native feel
+
+## Component patterns
+Sheet bottom: `rounded-t-3xl bg-white dark:bg-ohanafy-dark-surface`
+Card: `bg-white dark:bg-ohanafy-dark-surface rounded-2xl shadow-sm p-4`
+Badge: `rounded-full px-2 py-0.5 text-xs font-semibold`
+Section header: `text-xs font-semibold uppercase tracking-wider text-gray-500`
+
+## Responsive (tablet split pane)
+Width check via `useTabletLayout()` hook — NOT via NativeWind breakpoints
+(RN doesn't have CSS media queries; use the custom hook instead)
+
+## Forbidden patterns
+- No `style={{}}` inline styles (exception: StyleSheet.hairlineWidth for borders)
+- No `text-black` or `text-white` (use theme tokens)
+- No fixed pixel dimensions for text containers (use min-height or flex)
+```
+
+### `watermelondb-patterns.md`
+
+```markdown
+# WatermelonDB Patterns for Ohanafy Field
+
+## Always write inside transactions
+```typescript
+await database.write(async () => {
+  await collection.create(record => {
+    record.name = value;
+  });
+});
+```
+Writing outside transactions is silent corruption risk.
+
+## Reactive queries (UI layer)
+```typescript
+// In components: use withObservables HOC or useLiveQuery hook
+const accounts = useLiveQuery(
+  () => database.get<Account>('accounts').query(Q.where('needs_attention', true)),
+  []
+);
+```
+The UI re-renders automatically when the query result changes.
+
+## Non-reactive queries (in sync engine, agents)
+```typescript
+const items = await database.get<SyncQueueItem>('sync_queue')
+  .query(Q.where('status', 'pending'), Q.take(10))
+  .fetch();
+```
+
+## Migration pattern
+```typescript
+// src/db/migrations/index.ts
+import { schemaMigrations, addColumns } from '@nozbe/watermelondb/Schema/migrations';
+export default schemaMigrations({
+  migrations: [
+    {
+      toVersion: 2,
+      steps: [addColumns({ table: 'accounts', columns: [{ name: 'new_field', type: 'string' }] })],
+    },
+  ],
+});
+```
+Always increment `schema.version` AND add a migration. Mismatched versions crash on launch.
+
+## Index strategy
+Index: `sf_id`, `account_id`, `rep_id`, `status`, `sync_status`, `needs_attention`, `created_at`
+Do NOT index: `notes`, `raw_transcript`, `payload_json` (large text fields)
+
+## Batch operations
+```typescript
+await database.write(async () => {
+  await database.batch(
+    ...items.map(item => collection.prepareCreate(r => { r.field = item.value; }))
+  );
+});
+```
+Use `batch` for seeding or bulk updates — orders of magnitude faster than individual creates.
+```
+
+### `claude-tool-use-streaming.md`
+
+```markdown
+# Claude API Tool Use + Streaming Patterns
+
+## Tool definition (TypeScript)
+```typescript
+import { Tool } from '@anthropic-ai/sdk/resources';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const InputSchema = z.object({ transcript: z.string().min(1).max(500) });
+
+export const myTool: Tool = {
+  name: 'tool_name',
+  description: 'What it does. When to call it (specific conditions). What it returns.',
+  input_schema: zodToJsonSchema(InputSchema) as Tool['input_schema'],
+};
+```
+
+## Streaming with tool use
+```typescript
+const stream = await anthropic.messages.stream({
+  model: 'claude-sonnet-4-20250514',
+  max_tokens: 1000,
+  system: SYSTEM_PROMPT,
+  tools: [tool1, tool2],
+  messages: [{ role: 'user', content: userMessage }],
+});
+
+for await (const chunk of stream) {
+  if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+    onTextToken(chunk.delta.text);  // stream to UI
+  }
+}
+
+const message = await stream.finalMessage();
+// Extract tool use block
+const toolUse = message.content.find(b => b.type === 'tool_use');
+if (toolUse?.type === 'tool_use') {
+  const result = await toolHandlers[toolUse.name](toolUse.input);
+  // Build follow-up message with tool_result
+}
+```
+
+## Memory injection template
+```typescript
+const memoriesContext = memories.length > 0
+  ? `\n\nKnown patterns for this rep:\n${memories.map(m =>
+      `- [${m.category}] ${m.key}: ${m.value} (${(m.confidence*100).toFixed(0)}% confidence)`
+    ).join('\n')}`
+  : '';
+
+const systemWithMemory = SYSTEM_PROMPT + memoriesContext;
+```
+
+## Error handling
+```typescript
+try {
+  const response = await anthropic.messages.create({ ... });
+} catch (error) {
+  if (error instanceof Anthropic.APIError) {
+    if (error.status === 529) // overloaded — retry with backoff
+    if (error.status === 400) // bad request — log and surface to user
+  }
+}
+```
+```
+
+### `zpl2-reference.md`
+
+```markdown
+# ZPL II Quick Reference for Ohanafy Field
+
+## Hardware targets
+| Printer | dpmm | Dots per inch | Common label widths |
+|---|---|---|---|
+| ZQ520 | 8 | 203 | 2", 2.5", 4" |
+| ZQ630 | 12 | 300 | 4" |
+
+## Dot conversion
+dots = inches × dpmm × 25.4
+- 2.5" @ 8dpmm = 2.5 × 8 × 25.4 = ~508 dots (use ^PW400 for safe margin)
+- 4" @ 8dpmm = 4 × 8 × 25.4 = ~812 dots (use ^PW640 for safe margin)
+
+## Essential commands
+| Command | Purpose | Example |
+|---|---|---|
+| ^XA | Label start | ^XA |
+| ^XZ | Label end | ^XZ |
+| ^CI28 | UTF-8 charset | ^CI28 |
+| ^PW n | Print width (dots) | ^PW640 |
+| ^LL n | Label length (dots) | ^LL480 |
+| ^FO x,y | Field origin | ^FO30,25 |
+| ^A0N,h,w | Scalable font | ^A0N,36,36 |
+| ^FD text ^FS | Field data | ^FDYellowhammer Pale Ale^FS |
+| ^GB w,h,t | Graphic box (line) | ^GB580,2,2 |
+
+## Font size guide (at 8dpmm)
+| ^A0N height | Approx pt | Use for |
+|---|---|---|
+| 18 | ~7pt | Footer, secondary info |
+| 22 | ~9pt | Body, SKU codes |
+| 28 | ~11pt | Subheadings |
+| 36 | ~14pt | Product names |
+| 48 | ~19pt | Section headers |
+| 54+ | ~21pt+ | Price (most prominent) |
+
+## Labelary preview API
+POST http://api.labelary.com/v1/printers/{dpmm}dpmm/labels/{W}x{H}/{idx}/
+Content-Type: application/x-www-form-urlencoded
+Body: [ZPL string URL-encoded]
+Returns: PNG image
+
+## Safety rules
+1. Truncate all text inputs — never trust external strings
+2. Verify ^FO x coordinates: max x = ^PW value - 20 (margin)
+3. Always include ^CI28 for UTF-8 (special chars in product names)
+4. Test every new template against Labelary before printing on hardware
+```
+
+### `sf-oauth-patterns.md`
+
+```markdown
+# Salesforce OAuth 2.0 PKCE Patterns
+
+## Flow summary
+1. Generate verifier + challenge (PKCE)
+2. Open authorizationEndpoint in system browser (expo-auth-session)
+3. App receives redirect with `code`
+4. Exchange code for tokens at tokenEndpoint
+5. Store tokens in expo-secure-store
+6. Auto-refresh: intercept 401, refresh, retry once
+
+## expo-auth-session boilerplate
+```typescript
+const discovery = {
+  authorizationEndpoint: `${SF_URL}/services/oauth2/authorize`,
+  tokenEndpoint: `${SF_URL}/services/oauth2/token`,
+};
+const request = new AuthSession.AuthRequest({
+  clientId: SF_CLIENT_ID,
+  scopes: ['api', 'refresh_token', 'offline_access'],
+  redirectUri: AuthSession.makeRedirectUri({ scheme: 'com.ohanafy.field' }),
+  usePKCE: true,
+});
+const result = await request.promptAsync(discovery);
+```
+
+## Token storage keys (SecureStore)
+- `sf_access_token`
+- `sf_refresh_token`
+- `sf_instance_url`
+- `anthropic_api_key` (retrieved from SF org settings post-auth)
+
+## Connected App settings (Salesforce)
+- OAuth scopes: api, refresh_token, offline_access
+- Callback URL: com.ohanafy.field://oauth/callback
+- PKCE: enabled (required)
+- IP relaxation: Relax IP restrictions (for mobile clients)
+```
+
+### `rn-performance-patterns.md`
+
+```markdown
+# React Native Performance Patterns
+
+## The FlashList contract
+```typescript
+<FlashList
+  data={items}
+  renderItem={({ item }) => <MemoizedItem item={item} />}  // always memo
+  estimatedItemSize={MEASURED_ITEM_HEIGHT}  // measure once; never guess
+  getItemType={item => item.type}           // for heterogeneous lists
+  keyExtractor={item => item.id}
+  removeClippedSubviews={true}             // default true, be explicit
+/>
+```
+Rule: every list > 10 items uses FlashList. No FlatList in production.
+
+## Measuring estimatedItemSize
+```typescript
+// In development, log the actual height:
+onLayout={({ nativeEvent: { layout: { height } } }) => {
+  if (__DEV__) console.log('ItemHeight:', height);  // remove before shipping
+}}
+// Then set estimatedItemSize to the logged value
+```
+
+## The memo pattern
+```typescript
+const Item = React.memo(ItemBase, (prev, next) =>
+  // Only re-render if these specific fields changed
+  prev.item.id === next.item.id &&
+  prev.item.updatedAt === next.item.updatedAt &&
+  prev.isSelected === next.isSelected
+);
+```
+
+## Avoiding anonymous functions in JSX
+```typescript
+// BAD — creates new function on every render
+<Item onPress={() => navigate(item.id)} />
+
+// GOOD — stable reference
+const handlePress = useCallback(() => navigate(item.id), [item.id]);
+<Item onPress={handlePress} />
+```
+
+## Launch performance
+- Use expo-splash-screen to keep splash visible until DB hydrated
+- Hydrate WatermelonDB before rendering the account list
+- Defer non-critical init (PostHog, learning agent) with setTimeout(fn, 0)
+
+## Memory management
+- Unsubscribe from WatermelonDB observations in useEffect cleanup
+- Destroy Voice in cleanup: `Voice.destroy().then(Voice.removeAllListeners)`
+- Cancel in-flight fetch requests in useEffect cleanup
+```
+
+### `maestro-e2e-patterns.md`
+
+```markdown
+# Maestro E2E Patterns for Ohanafy Field
+
+## Flow file structure
+```yaml
+appId: com.ohanafy.field
+---
+# Comment describing what this flow tests
+- launchApp:
+    clearState: true   # always start clean
+    env:
+      MAESTRO_TEST_MODE: "true"
+```
+
+## Test data strategy
+All E2E tests use seeded test data (via MAESTRO_TEST_MODE env var).
+In test mode, the app loads from a static JSON fixture instead of Salesforce.
+Never use production Salesforce data in E2E tests.
+
+## Stable selectors (in priority order)
+1. `id: "data-testid-value"` — most stable; add data-testid to all testable elements
+2. `text: "Exact text"` — stable if text is static (not from API)
+3. `accessibilityLabel: "Label"` — good; also tests a11y
+4. Avoid: element type selectors (`button`, `text`) — too fragile
+
+## Offline testing
+```yaml
+# Enable airplane mode
+- setLocation:
+    lat: 0
+    lon: 0
+# Or use Maestro's network control
+- stopNetwork
+# ...test offline behavior...
+- startNetwork
+- assertVisible: "Synced ✓"
+```
+
+## Timing
+```yaml
+# Wait for async operations
+- waitForAnimationToEnd
+- waitFor:
+    visible: "Account list"
+    timeout: 3000   # ms
+```
+
+## Screenshot on failure
+Maestro auto-captures screenshots on failure. Check `.maestro/` output directory after failures.
+```
+
+---
+
+## §7 — Slash Commands
+
+Slash commands live in `.claude/commands/`. They give Claude Code repeatable, precise workflows triggered by `/command-name`.
+
+### `/new-screen`
+
+```markdown
+---
+name: new-screen
+description: Scaffolds a new Expo Router screen with all boilerplate — TypeScript, NativeWind, ErrorBoundary, HelpButton, accessibility, dark mode, skeleton state, and empty state. Usage: /new-screen [name] [route-path]
+---
+
+When invoked, scaffold the following for screen `[name]` at `app/[route-path].tsx`:
+
+1. **Screen file** with:
+   - TypeScript props interface
+   - ErrorBoundary wrapper
+   - HelpButton in header right
+   - LoadingSkeleton during data fetch
+   - EmptyState when no data
+   - Dark mode support (NativeWind `dark:` variants)
+   - `accessibilityLabel` on root View
+
+2. **Unit test** at `__tests__/unit/screens/[name].test.tsx` with:
+   - Renders without crashing
+   - Shows skeleton while loading
+   - Shows empty state with no data
+   - Shows content when data present
+
+3. **Maestro flow stub** at `maestro/flows/[name].yaml` with:
+   - launchApp + navigate to this screen
+   - assertVisible of primary content
+   - TODO comment for specific assertions
+
+4. **Help content** — add entry to `src/components/shared/HelpButton.tsx` HelpContent map
+
+Report: file paths created, next step (populate the data hook).
+```
+
+### `/new-ai-tool`
+
+```markdown
+---
+name: new-ai-tool
+description: Scaffolds a new Claude AI tool — Zod schema, tool definition, handler, test with fixtures, and wires it into the tools index. Usage: /new-ai-tool [tool-name] [description]
+---
+
+Scaffold the following for tool `[tool-name]`:
+
+1. **Tool file** at `src/ai/tools/[tool-name].ts`:
+   - Zod InputSchema
+   - Zod OutputSchema
+   - Tool definition (name, description, input_schema)
+   - Handler function (pure TypeScript — no AI calls inside)
+   - Export both the tool and the handler
+
+2. **Test file** at `__tests__/unit/ai/[tool-name].test.ts`:
+   - 5 fixture test cases (happy path, edge case, invalid input, empty input, boundary value)
+   - All use static fixtures — no real Anthropic API calls
+   - Mock the Anthropic SDK
+
+3. **Fixture file** at `__tests__/fixtures/[tool-name]-inputs.ts`:
+   - At least 5 sample inputs with expected outputs
+
+4. **Wire into index** — add export to `src/ai/tools/index.ts`
+
+5. **Update CLAUDE.md** — add a one-line description of the new tool to the "AI Tools" section
+
+Report: what the tool does, its inputs, its outputs, and which agent should call it.
+```
+
+### `/new-zpl-template`
+
+```markdown
+---
+name: new-zpl-template
+description: Creates a new ZPL label template — TypeScript generator, Vitest snapshot test, Labelary preview verification. Usage: /new-zpl-template [name] [width-inches] [height-inches]
+---
+
+Scaffold for template `[name]` at `[W]"×[H]"`:
+
+1. **Template file** at `src/zpl/templates/[name].ts`:
+   - Params interface with JSDoc for each field
+   - Generator function that returns a ZPL string
+   - Input validation and truncation for all string fields
+   - All `^FO x` coordinates verified to be within (`^PW` - 20) dots
+
+2. **Test file** at `__tests__/unit/zpl/[name].test.ts`:
+   - Starts with ^XA, ends with ^XZ
+   - Contains ^CI28
+   - No ^FO x coordinate > (label_width_dots - 20)
+   - Long strings are truncated
+   - Price formatted correctly ($X.XX)
+   - Snapshot test (`.toMatchSnapshot()`)
+
+3. **Labelary verification comment** — add to the test file:
+   ```
+   // Verify with Labelary:
+   // curl -X POST 'http://api.labelary.com/v1/printers/8dpmm/labels/[W]x[H]/0/'
+   //   --data-urlencode '@zpl-string.txt' --output preview.png && open preview.png
+   ```
+
+4. **Add to ZPL engine index** — export from `src/zpl/index.ts`
+
+5. **Add to label selector** — add the template type to `LabelSelector.tsx`
+
+Report: the template's exact dimensions, target printer, and primary use case.
+```
+
+### `/a11y-audit`
+
+```markdown
+---
+name: a11y-audit
+description: Runs an accessibility audit on a screen or component. Checks VoiceOver/TalkBack compliance, tap target sizes, Dynamic Type support, and color contrast. Usage: /a11y-audit [screen-or-component-path]
+---
+
+For the specified file, audit:
+
+1. **Interactive elements** — every TouchableOpacity/Pressable/Button has:
+   - `accessibilityRole`
+   - `accessibilityLabel` (no "tap to" — just what it is)
+   - `accessibilityHint` (what happens)
+   - `accessibilityState` if disabled or selected
+
+2. **Tap targets** — every interactive element:
+   - Minimum 44×44pt (use `hitSlop` if smaller)
+   - Report all elements that may be too small
+
+3. **Images** — every Image has:
+   - `accessibilityLabel` if meaningful
+   - `accessible={false}` if decorative
+
+4. **Lists** — every FlashList/FlatList:
+   - Has `accessibilityLabel` with item count
+   - Items announce their key information
+
+5. **Dynamic Type** — no fixed heights on Text containers, `allowFontScaling` not false
+
+6. **Loading/error states** — have `accessibilityLiveRegion="polite"`
+
+7. **Custom actions** — swipe-to-delete has keyboard/screen reader alternative
+
+Report: a numbered list of violations with file:line and the fix. Severity: high/medium/low.
+```
+
+### `/perf-audit`
+
+```markdown
+---
+name: perf-audit
+description: Audits a screen or component for React Native performance issues — unnecessary re-renders, unoptimized lists, missing memoization, heavy computations in render. Usage: /perf-audit [file-path]
+---
+
+Audit the specified file for:
+
+1. **FlatList** — any FlatList for > 10 items (replace with FlashList)
+2. **Missing React.memo** — components that receive complex object props
+3. **Anonymous functions in JSX** — `onPress={() => fn(args)}` (use useCallback)
+4. **Computed values in render** — array operations (filter, sort, map) without useMemo
+5. **Missing keyExtractor** or using array index as key
+6. **Missing estimatedItemSize** on FlashList
+7. **State that could be derived** — state that duplicates something in a query
+8. **Unsubscribed WatermelonDB observations** — missing cleanup in useEffect
+9. **Heavy synchronous operations on the JS thread** — crypto, large string processing
+
+Report: numbered list of issues with file:line, severity (high/medium/low), and the fix.
+```
+
+### `/handoff`
+
+```markdown
+---
+name: handoff
+description: Generates a session handoff document for the next Claude Code session. Run at the end of every work session. Creates HANDOFF.md with current state, uncommitted changes, and next priorities.
+---
+
+Generate `HANDOFF.md` in the project root with:
+
+1. **Session summary** — date, time, what was accomplished (from recent git log)
+2. **Current branch and status** — `git status` output, any uncommitted changes
+3. **Day N status** — which Product Bible targets are complete, which are not
+4. **Blockers** — any unresolved issues or decisions
+5. **Next 3 priorities** — exactly what the next session should do first
+6. **Files in progress** — any files that are partially implemented (incomplete functions, TODO comments)
+7. **Test status** — last jest run result, any failing tests
+8. **Known issues** — bugs found but not yet fixed
+
+Commit HANDOFF.md with message: `chore: session handoff [date]`
+
+The next session starts with: "Read HANDOFF.md. Confirm you understand the current state. Then proceed."
+```
+
+### `/daily-retro`
+
+```markdown
+---
+name: daily-retro
+description: Fills in today's retrospective in §25 of the Product Bible. Run at end of each day. Usage: /daily-retro [day-number]
+---
+
+1. Read the Day [N] targets from §9 of OHANAFY-FIELD-PRODUCT-BIBLE.md
+2. Check each target against the current codebase
+3. Fill in the Day [N] Retro in §25:
+   - Targets completed: list each with [x]
+   - Targets missed: list each with [ ] and why
+   - Blockers: any unresolved issues
+   - Tomorrow's first two targets: the highest-priority incomplete items
+
+4. Generate a daily build health summary:
+   - Run `npx jest --coverage --silent` → report coverage %
+   - Run `npx tsc --noEmit` → report zero or count of errors
+   - Report total Sentry errors in the last 24 hours (if accessible)
+
+5. Commit the updated Product Bible: `docs: day [N] retro`
+```
+
+---
+
+## §8 — Rules
+
+Rules are standing constraints that Claude Code enforces across all sessions. They fire based on file patterns or always.
+
+### `offline-first.md`
+
+```markdown
+# Rule: Offline First
+
+**Scope:** All files in src/db/, src/sync/, src/hooks/, app/**/*.tsx
+
+Every data read in the render path must be satisfied from WatermelonDB without requiring network access. Network is ONLY permitted in:
+- The sync engine (src/sync/)
+- The AI tools (src/ai/) — these are gracefully hidden if offline
+- Authentication (src/auth/) — on first launch only
+
+**Violations to flag:**
+- Direct fetch() calls inside screen components
+- useQuery() with no offline fallback
+- Loading states that spin indefinitely (no cached data shown while loading)
+- Any component that throws an error when `navigator.onLine === false`
+
+**The test:** mentally simulate airplane mode. If the screen shows an error or spinner forever, it's a violation.
+```
+
+### `typescript-strict.md`
+
+```markdown
+# Rule: TypeScript Strict Mode
+
+**Scope:** All .ts and .tsx files
+
+TypeScript strict mode is non-negotiable. Enforce:
+- No `any` types — use `unknown` + type narrowing, or define the proper interface
+- No `// @ts-ignore` — fix the type error
+- No `as unknown as TargetType` double casting — define a proper type guard
+- No `!` non-null assertions without a comment explaining why it's safe
+- Every function has explicit return type
+- Every component has explicit props interface
+
+**When adding new dependencies:** check if `@types/package-name` is available. If not, write a `.d.ts` declaration file.
+
+**The test:** `npx tsc --noEmit` must exit 0 before every commit.
+```
+
+### `ai-never-invents.md`
+
+```markdown
+# Rule: AI Never Invents Data
+
+**Scope:** All files in src/ai/
+
+The AI layer may:
+- Interpret natural language input
+- Summarize or clean text the user provided
+- Suggest products from the catalog
+- Surface patterns from the user's own history
+- Generate structured output from structured input
+
+The AI layer may NEVER:
+- Create account names, contact names, or addresses
+- Invent product names, SKU codes, or prices not in the product catalog
+- Fabricate historical order data
+- Generate visit notes that weren't dictated by the rep
+- Hallucinate Salesforce record IDs
+
+**Enforcement pattern:**
+Every tool handler that touches account/product data must validate against the local WatermelonDB — not against Claude's knowledge. Claude's knowledge of specific company data is not reliable.
+
+**The test:** every tool handler test should include a fixture with an unknown product name — the handler must return `confidence: 'low'` or an empty result, never a fabricated match.
+```
+
+### `accessibility-mandatory.md`
+
+```markdown
+# Rule: Accessibility Is Mandatory
+
+**Scope:** All .tsx component files
+
+Accessibility is part of the definition of done — not a post-launch task.
+
+Every PR that adds a new interactive element must include:
+- `accessibilityRole`
+- `accessibilityLabel`
+- `accessibilityHint` (unless the action is completely obvious from the label)
+
+Every PR that adds a new list must include:
+- `accessibilityLabel` with item count on the FlashList
+
+Every PR that adds a loading state must include:
+- `accessibilityLiveRegion="polite"` so screen readers announce when content loads
+
+**The test:** Run `/a11y-audit [changed file]` before marking any component PR as done.
+```
+
+### `error-boundaries-everywhere.md`
+
+```markdown
+# Rule: Error Boundaries on Every Screen
+
+**Scope:** All app/**/*.tsx screen files (not components)
+
+Every screen-level component must be wrapped in `<ErrorBoundary screenName="ScreenName">`.
+
+The ErrorBoundary must:
+- Show a human-readable error message (not a technical stack trace)
+- Show a "Try Again" button that resets the error state
+- Log the error to Sentry with the screenName tag
+- Never crash the entire app due to one screen's error
+
+**The test:** throw `new Error('test')` inside the screen's render function. Confirm the ErrorBoundary catches it and shows the fallback UI. Then remove the throw.
+```
+
+### `no-credentials-in-code.md`
+
+```markdown
+# Rule: No Credentials in Code
+
+**Scope:** All files
+
+Zero tolerance. Any API key, token, password, or secret must live in:
+- `.env.local` for local development (gitignored)
+- EAS Secrets for CI/production builds
+
+**Violations that will cause the pre-push hook to fail:**
+- Any string matching `sk-ant-` (Anthropic key)
+- Any string matching `Bearer ` followed by a 40+ char token
+- Any string matching `password` as a variable name with a non-empty string value
+- Any string matching `00D` followed by 15 chars (Salesforce org ID in a string literal)
+
+**The fix:** move to `process.env.EXPO_PUBLIC_*` (public) or SecureStore (private runtime values).
+```
+
+### `tdd-required.md`
+
+```markdown
+# Rule: Test-Driven Development Required
+
+**Scope:** src/ai/tools/, src/zpl/templates/, src/sync/, src/utils/
+
+For every new function in these directories:
+1. Write the failing test FIRST
+2. Confirm it fails (run jest and see the failure)
+3. Implement the function
+4. Confirm it passes
+5. Add edge cases
+
+**Exceptions (not TDD, but still requires tests):**
+- UI components — write tests after implementation, before the PR
+- WatermelonDB model classes — test queries in integration tests
+
+**The pre-push hook checks:** if a new .ts file in the above directories exists without a corresponding .test.ts file, the push is blocked with: "Missing test file for [filename]. Add tests or use /new-ai-tool or /new-zpl-template commands."
+```
+
+---
+
+## §9 — Hooks
+
+### `post-commit-log.sh`
+
+```bash
+#!/usr/bin/env bash
+# Appends significant commits to a daily log for retro and handoff
+
+COMMIT_MSG=$(git log -1 --pretty=%B)
+COMMIT_HASH=$(git log -1 --pretty=%h)
+TIMESTAMP=$(date '+%H:%M')
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Only log feat:, fix:, test:, a11y:, perf:, and docs: commits
+if echo "$COMMIT_MSG" | grep -qE "^(feat|fix|test|a11y|perf|docs|refactor)\("; then
+  LOG_FILE="DAILY_LOG_$(date '+%Y-%m-%d').md"
+
+  if [ ! -f "$LOG_FILE" ]; then
+    echo "# Daily Log — $(date '+%B %d, %Y')" > "$LOG_FILE"
+    echo "" >> "$LOG_FILE"
+  fi
+
+  echo "- [$TIMESTAMP] \`$COMMIT_HASH\` — $COMMIT_MSG" >> "$LOG_FILE"
+fi
+```
+
+### `pre-push-quality-gate.sh`
+
+```bash
+#!/usr/bin/env bash
+# Blocks push if quality gates fail
+
+set -e
+echo "→ Running pre-push quality gate..."
+
+# 1. TypeScript check
+echo "   Checking TypeScript..."
+npx tsc --noEmit || {
+  echo "❌ TypeScript errors found. Fix before pushing."
+  exit 1
+}
+
+# 2. Lint check
+echo "   Checking lint..."
+npx eslint src/ app/ --ext .ts,.tsx --max-warnings 0 || {
+  echo "❌ ESLint warnings/errors found. Fix before pushing."
+  exit 1
+}
+
+# 3. Test check (fast — no coverage on push, only in CI)
+echo "   Running tests..."
+npx jest --passWithNoTests --bail 1 || {
+  echo "❌ Tests failing. Fix before pushing."
+  exit 1
+}
+
+# 4. Credential scan (simple)
+echo "   Scanning for credentials..."
+if git diff HEAD~1..HEAD --name-only | xargs grep -l "sk-ant-\|00D[A-Z0-9]\{15\}" 2>/dev/null; then
+  echo "❌ Possible credential in diff. Check and remove before pushing."
+  exit 1
+fi
+
+echo "✅ Quality gate passed. Pushing."
+```
+
+### `pre-merge-checklist.sh`
+
+```bash
+#!/usr/bin/env bash
+# Verifies a PR is ready to merge
+
+PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+echo "═══════════════════════════════════════"
+echo "  Pre-Merge Checklist: $PR_BRANCH"
+echo "═══════════════════════════════════════"
+echo ""
+
+echo "Required before merge:"
+echo "  [ ] TypeScript: npx tsc --noEmit → 0 errors"
+echo "  [ ] Lint: npx eslint src/ app/ → 0 warnings"
+echo "  [ ] Tests: npx jest --coverage → thresholds met"
+echo "  [ ] New screen/component: /a11y-audit run"
+echo "  [ ] New list: FlashList + estimatedItemSize"
+echo "  [ ] New AI feature: FeedbackCapture component added"
+echo "  [ ] New ZPL template: Labelary verified"
+echo "  [ ] Dark mode: tested on both themes"
+echo "  [ ] Offline: tested in airplane mode"
+echo ""
+
+# Ask for confirmation
+read -p "Have you verified all items above? (y/N): " CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+  echo "❌ Merge blocked. Complete the checklist first."
+  exit 1
+fi
+
+echo "✅ Checklist confirmed. Proceeding with merge."
+```
+
+---
+
+## §10 — `CLAUDE.md` (Production Version)
+
+This is the complete `CLAUDE.md` for the project root. It's loaded at the start of every Claude Code session.
+
+```markdown
+# Ohanafy Field — Claude Code Project Context
+
+## What this is
+A production-quality native mobile app (iOS + Android) for field sales reps at
+beverage distributors. Offline-first, AI-powered, ZPL label printing.
+
+Built on: Expo SDK 52, React Native, TypeScript strict, Expo Router v3,
+NativeWind v4, WatermelonDB, TanStack Query, Zustand, Reanimated v3,
+FlashList, @react-native-voice/voice, Zebra Link-OS (custom Expo module),
+Anthropic Claude Sonnet API, Sentry, PostHog.
+
+## Session startup (required every session)
+1. Read this file completely
+2. Check HANDOFF.md (if exists) for prior session context
+3. Open OHANAFY-FIELD-PRODUCT-BIBLE.md §9 — identify today's day
+4. Read §25 for today's retro — what's done, what's not
+5. State your plan for this session in one sentence
+6. Begin
+
+## Non-negotiables (§0 of Product Bible)
+1. Offline first — every read works in airplane mode
+2. Tests before features (TDD in src/ai/, src/zpl/, src/sync/)
+3. TypeScript strict — zero `any`, zero `@ts-ignore`
+4. Accessibility on every component — VoiceOver/TalkBack
+5. AI never invents data — validates against WatermelonDB
+6. ErrorBoundary on every screen
+7. Feature freeze: Day 6, 5pm. Day 7 is docs + submission only.
+
+## Available agents (delegate to these)
+- `rn-architect` — screen/component scaffold, navigation, WatermelonDB
+- `voice-ui-designer` — voice state machine, mic UI, transcript display
+- `ai-tool-builder` — Claude tool definitions, handlers, memory system
+- `zpl-engineer` — ZPL templates, printer integration, Labelary
+- `rn-accessibility` — VoiceOver, TalkBack, Dynamic Type, tap targets
+- `offline-sync-architect` — WatermelonDB patterns, SF REST, conflict resolution
+- `performance-engineer` — FlashList, Reanimated, bundle size, memory
+- `test-writer` — Jest unit tests, Maestro E2E flows, WDB integration tests
+- `salesforce-integration` — OAuth, REST API, LWC, SFDX
+
+## Available slash commands
+- `/new-screen [name] [route]` — scaffold a complete screen with all boilerplate
+- `/new-ai-tool [name] [desc]` — scaffold AI tool with tests and fixtures
+- `/new-zpl-template [name] [W] [H]` — scaffold ZPL template with validation
+- `/a11y-audit [file]` — accessibility audit with file:line violations
+- `/perf-audit [file]` — performance audit with ranked issues
+- `/handoff` — generate HANDOFF.md for next session
+- `/daily-retro [day]` — fill in §25 retro
+
+## Domain: beverage field sales rep
+Jake Thornton is a field sales rep at Yellowhammer Beverage (beer + Red Bull
+distributor, Birmingham AL). He visits 10 accounts per day, has a Zebra ZQ520
+printer on his belt, and often has no signal in back-of-house areas.
+
+Key vocabulary: account (retailer), visit, order, keg (1/2 bbl = 15.5gal),
+case (24-unit pack), route, territory, tap, depletion, STW, CDA, three-tier.
+
+NEVER say: fermenter, brewhouse, brewhouse, mash, grain bill, hop contracts.
+These are brewery words. Jake works for a distributor, not a brewery.
+
+## Architecture decisions (locked)
+| Decision | Choice |
+|---|---|
+| Framework | Expo SDK 52 + React Native |
+| Navigation | Expo Router v3 (file-based) |
+| Styling | NativeWind v4 (Tailwind in RN) |
+| Local DB | WatermelonDB (SQLite, reactive) |
+| Server state | TanStack Query v5 |
+| Client state | Zustand v4 |
+| Lists | Shopify FlashList (never FlatList for > 10 items) |
+| Animations | React Native Reanimated v3 |
+| Voice | @react-native-voice/voice (on-device) |
+| ZPL printing | Custom Expo module wrapping Zebra Link-OS SDK |
+| AI | Anthropic Claude Sonnet, tool use, streaming |
+| Error tracking | Sentry React Native |
+| Analytics | PostHog React Native |
+| E2E testing | Maestro |
+| Unit testing | Jest + React Native Testing Library |
+| Build/Submit | EAS (Expo Application Services) |
+
+## Code conventions
+- Commits: `feat(scope): description` / `fix(scope):` / `test(scope):` / `a11y(scope):` / `perf(scope):`
+- File names: kebab-case for route files, PascalCase for components
+- DB writes: always inside `database.write(async () => { ... })`
+- AI outputs: always have Accept/Edit/Reject path — never locked outputs
+- Errors: caught, logged to Sentry via `logger.error()`, shown to user with message
+- Imports: named imports from packages; barrel imports from src/ directories
+
+## Reference repos (read for patterns, don't copy verbatim)
+Path: `./references/`
+Key ones: expo/expo, Nozbe/WatermelonDB, Shopify/flash-list,
+nativewindui/nativewindui, mobile-dev-inc/maestro,
+hesreallyhim/awesome-claude-code, wshobson/agents
+
+## Environment
+- Dev: `.env.local` — EXPO_PUBLIC_* for public values, SecureStore for secrets
+- CI/Prod: EAS Secrets
+- Never hardcode any credential, API key, or token in source code
+```
+
+---
+
+## §11 — Reference Reading List
+
+Before starting Day 1, read these documents from the cloned reference repos. Budget 30–45 minutes. It's worth it.
+
+### Priority 1 (read tonight — shapes Day 1 decisions)
+
+| What to read | Path | Time | Why |
+|---|---|---|---|
+| CLAUDE.md examples | `references/hesreallyhim/awesome-claude-code/README.md` → CLAUDE.md section | 10 min | Shows what makes a great CLAUDE.md; improve §10 above |
+| WatermelonDB Quick Start | `references/Nozbe/WatermelonDB/docs/Quick Start.md` | 10 min | The Day 1 schema work will go much faster |
+| NativeWind v4 setup | `references/nativewindui/nativewindui/README.md` | 5 min | Day 1 theming setup nuances |
+| FlashList README | `references/Shopify/flash-list/README.md` → Performance section | 5 min | Understand `estimatedItemSize` before using it |
+
+### Priority 2 (read Day 2 morning — before tackling features)
+
+| What to read | Path | Time | Why |
+|---|---|---|---|
+| Agent authoring patterns | `references/wshobson/agents/` — any 3 agent files | 10 min | See the format; improves our agent quality |
+| obra/superpowers TDD | `references/obra/superpowers/test-driven-development/SKILL.md` | 5 min | The TDD skill will enforce this for us — understand what it enforces |
+| Expo Router file-based routing | `references/expo/router/docs/` | 10 min | Tab layout + auth guard patterns |
+
+### Priority 3 (read Day 3 morning — before AI work)
+
+| What to read | Path | Time | Why |
+|---|---|---|---|
+| Anthropic Cookbook tool use | `references/anthropics/anthropic-cookbook/tool_use/` | 15 min | The gold standard for tool use patterns |
+| Building Effective Agents post | Link: `https://www.anthropic.com/research/building-effective-agents` | 15 min | The 5 patterns our AI system uses |
+
+### Priority 4 (read Day 5 morning — before test suite work)
+
+| What to read | Path | Time | Why |
+|---|---|---|---|
+| Maestro flow syntax | `references/mobile-dev-inc/maestro/docs/` | 15 min | YAML syntax before writing 6 flows |
+| RNTL query guide | `references/testing-library/react-native-testing-library/docs/queries.md` | 10 min | `getByRole` vs `getByLabelText` vs `getByTestId` — which to use when |
+
+### Priority 5 (read Day 6 morning — before a11y audit)
+
+| What to read | Path | Time | Why |
+|---|---|---|---|
+| react-native-a11y README | `references/FormidableLabs/react-native-a11y/README.md` | 10 min | Component-level a11y patterns |
+| axe-core rule descriptions | `references/dequelabs/axe-core/lib/rules/` — `button-name.js`, `label.js`, `color-contrast.js` | 10 min | The rules to apply to every component |
+
+---
+
+**End of Ohanafy Field — Harness Setup Guide**
+
+*Run this before Day 1. When Claude Code opens the project for the first time, it reads this document, executes the setup script, passes the §2 checklist, and then opens the Product Bible with the full context of an expert in every domain it will touch.*
+
+*The harness is not overhead — it's the difference between Claude Code writing generic React Native and Claude Code writing world-class Ohanafy Field.* 🛠️
+```

--- a/OHANAFY-FIELD-PRODUCT-BIBLE.md
+++ b/OHANAFY-FIELD-PRODUCT-BIBLE.md
@@ -1,0 +1,4059 @@
+# Ohanafy Field — Product Engineering Bible v1.0
+
+> **One engineer. One week. One shippable product.**
+>
+> This is not a hackathon slice. This is the complete engineering specification, day-by-day plan, test strategy, AI system design, and operational runbook for shipping Ohanafy Field — a world-class, offline-first, AI-powered field sales application — to the Apple App Store and Google Play Store.
+>
+> **How Claude Code starts every session:**
+> *"Read OHANAFY-FIELD-PRODUCT-BIBLE.md from top to bottom. Load §22 operating procedure. Identify today's day from §9. Report the current day's target and your first action. Do not write code until you've confirmed the target."*
+
+---
+
+## Table of Contents
+
+- [Preamble — What "Shippable" Means](#preamble--what-shippable-means)
+- [§0 — Non-Negotiables](#0--non-negotiables)
+- [§1 — Product Vision & Context](#1--product-vision--context)
+- [§2 — Definition of Done](#2--definition-of-done)
+- [§3 — Technical Architecture](#3--technical-architecture)
+- [§4 — Complete Feature Specification](#4--complete-feature-specification)
+- [§5 — Data Model](#5--data-model)
+- [§6 — AI Intelligence & Learning System](#6--ai-intelligence--learning-system)
+- [§7 — Offline-First Architecture](#7--offline-first-architecture)
+- [§8 — ZPL Printing System](#8--zpl-printing-system)
+- [§9 — 7-Day Engineering Plan](#9--7-day-engineering-plan)
+- [§10 — Development Environment](#10--development-environment)
+- [§11 — CI/CD Pipeline](#11--cicd-pipeline)
+- [§12 — Testing Strategy](#12--testing-strategy)
+- [§13 — Logging, Error Tracking & Observability](#13--logging-error-tracking--observability)
+- [§14 — Accessibility](#14--accessibility)
+- [§15 — Tablet & Large Screen Layouts](#15--tablet--large-screen-layouts)
+- [§16 — Dark Mode & Theming](#16--dark-mode--theming)
+- [§17 — Security & Privacy](#17--security--privacy)
+- [§18 — Performance Targets & Optimization](#18--performance-targets--optimization)
+- [§19 — In-App Onboarding](#19--in-app-onboarding)
+- [§20 — In-App Help System](#20--in-app-help-system)
+- [§21 — App Store Submission](#21--app-store-submission)
+- [§22 — Claude Code Operating Procedure](#22--claude-code-operating-procedure)
+- [§23 — Domain Conventions](#23--domain-conventions)
+- [§24 — Architecture Decision Records](#24--architecture-decision-records)
+- [§25 — Daily Retrospectives](#25--daily-retrospectives)
+- [Appendix A — ZPL Template Library](#appendix-a--zpl-template-library)
+- [Appendix B — AI System Prompts (Production)](#appendix-b--ai-system-prompts-production)
+- [Appendix C — WatermelonDB Schema](#appendix-c--watermelondb-schema)
+- [Appendix D — Salesforce Data Model](#appendix-d--salesforce-data-model)
+- [Appendix E — Test Specification](#appendix-e--test-specification)
+- [Appendix F — User Guide](#appendix-f--user-guide)
+- [Appendix G — In-App Onboarding Script](#appendix-g--in-app-onboarding-script)
+
+---
+
+## Preamble — What "Shippable" Means
+
+Shippable is not "it works on my phone." Every item in this checklist must be true before submission.
+
+### Technical
+- [ ] Zero P0 crashes in 30-minute smoke test on iPhone 15 Pro, iPhone SE 3, iPad Pro 12.9", Samsung Galaxy S24, Samsung Galaxy Tab S9
+- [ ] All 5 core offline flows work in airplane mode
+- [ ] Sync correctly processes a 50-item queue on reconnect with no data loss
+- [ ] Voice commands achieve > 90% correct interpretation on 20-command test suite
+- [ ] ZPL shelf talker prints correctly on ZQ520 (203dpi) and ZQ630 (300dpi)
+- [ ] Unit test coverage ≥ 80% on all business logic packages
+- [ ] E2E test suite covers 100% of named user flows in §4
+- [ ] No unhandled promise rejections (zero in prod build Sentry)
+- [ ] App launch time < 2.5s cold, < 0.8s warm (measured on iPhone SE 3 — slowest target)
+- [ ] All list renders at 60fps (no Flashlist warnings in production)
+- [ ] Memory usage < 150MB peak during full demo path
+- [ ] All TypeScript `strict` mode, zero `any` types, zero `@ts-ignore`
+
+### UX
+- [ ] VoiceOver on iOS: all core flows navigable without sight
+- [ ] TalkBack on Android: all core flows navigable without sight
+- [ ] Dynamic Type (iOS) and font scaling (Android): UI doesn't break at largest accessibility text size
+- [ ] All tap targets ≥ 44×44pt
+- [ ] Keyboard avoidance works on all input screens
+- [ ] Dark mode: full implementation, no hardcoded colors
+- [ ] iPad split-view: master-detail layout at ≥ 768pt width
+- [ ] Android tablet split-view: same threshold
+- [ ] Landscape orientation: all screens usable in landscape
+
+### Product
+- [ ] In-app onboarding: new user reaches their first completed order in < 5 minutes
+- [ ] In-app help: every major screen has contextual help accessible in ≤ 2 taps
+- [ ] User guide: all 7 sections complete, searchable, available offline
+- [ ] AI learning: visit prep insight improves measurably after 3+ corrections
+- [ ] Push notifications: first visit reminder fires correctly
+- [ ] Biometric lock: FaceID/TouchID/Fingerprint works on all target devices
+
+### Store
+- [ ] App Store privacy manifest complete (PrivacyInfo.xcprivacy)
+- [ ] Google Play data safety section complete
+- [ ] App Store screenshots: 6.7" iPhone, 12.9" iPad, 6.1" iPhone (3 screenshots each minimum)
+- [ ] Google Play screenshots: phone + 7" tablet + 10" tablet
+- [ ] App Store Review Guidelines compliance verified
+- [ ] Google Play Policy compliance verified
+- [ ] Bundle ID: com.ohanafy.field
+- [ ] Version: 1.0.0, build 1
+
+---
+
+## §0 — Non-Negotiables
+
+These override every other decision in this document. When a timer runs short, cut features before violating these.
+
+1. **Offline is non-negotiable.** Every core user flow works without connectivity. No exceptions.
+2. **Tests before features.** Write the test, then the implementation. TDD for all business logic.
+3. **TypeScript strict mode everywhere.** `any` types are technical debt that becomes crashes at runtime.
+4. **Accessibility is not a stretch goal.** VoiceOver and TalkBack support is part of the definition of done for every screen.
+5. **AI outputs must be correctable.** Every AI-generated result has an Edit path. No locked AI outputs.
+6. **AI never invents data.** AI can suggest, interpret, summarize. It never invents account names, SKUs, prices, or historical facts.
+7. **Error boundaries on every screen.** An unhandled crash cannot take out the whole app.
+8. **Credentials never in code.** Every secret lives in `.env.local` (dev) or EAS Secrets (CI/prod). Zero exceptions.
+9. **Every commit must pass CI.** Green CI is the gate to merge. Flaky tests are fixed immediately.
+10. **Day 7 is documentation and submission, not features.** Feature freeze is end of Day 6. No new features after that.
+
+---
+
+## §1 — Product Vision & Context
+
+### 1.1 What Ohanafy Field is
+
+A native mobile application (iOS + Android) for field sales representatives at beverage distributors and breweries. Built on top of Ohanafy's Salesforce-native platform, Ohanafy Field is the **field execution layer** that complements the back-office. It is not a mobile CRM — it is a selling tool that happens to sync to a CRM.
+
+**The three things that make it different from every competitor:**
+
+1. **Offline-first, everywhere.** Bar back-of-house, warehouse receiving dock, rural route — no signal is the norm. Ohanafy Field caches everything and works completely offline, syncing automatically the moment connectivity returns.
+
+2. **AI voice assistant.** Reps place orders, log visit notes, and access account intelligence by speaking naturally while their hands are busy. The AI interprets commands, confirms with the rep, and applies them. It learns from corrections over time — the more you use it, the more accurate it gets for your specific patterns.
+
+3. **Print on the spot.** Shelf talkers, product feature cards, and delivery receipts print to a Bluetooth Zebra printer (ZQ520/ZQ630) in seconds. The rep generates professional marketing materials and leaves them with the buyer before the competition even mails a flyer.
+
+### 1.2 Platform context
+
+**Ohanafy** is a Salesforce ISV building a 2GP managed package (`ohfy__` namespace) for the beverage industry. Ohanafy Field is a companion app — a React Native application that authenticates via Salesforce Connected App OAuth 2.0, reads and writes Ohanafy data, and introduces a set of new custom objects (`ohfy_field__` namespace) for field activities.
+
+**Ohanafy Plan** (the companion FP&A product) is the planning layer. Field is the execution layer. They share the same data model and will share the same AI layer over time.
+
+### 1.3 Target users
+
+**Primary user:** Field sales representative at a beverage distributor or brewery. Visits 8–12 accounts per day. Drives 80–150 miles. Has a Zebra ZQ520 or ZQ630 printer on their belt. May have poor signal at most of their accounts.
+
+**Secondary user:** Field sales manager. Reviews rep activity in Salesforce. Gets push notification summaries of team performance. Approves large orders from the app.
+
+**Pilot customer:** Alabama-based beer + Red Bull distributor (Yellowhammer Beverage — fictional name for demo/development). Real pilot contacts are active design partners.
+
+### 1.4 Platform targets
+
+| Platform | Minimum OS | Target devices |
+|---|---|---|
+| iOS | iOS 16.0+ | iPhone SE 3 (smallest/slowest target), iPhone 14/15 series, iPad Pro 11", iPad Pro 12.9", iPad Air |
+| Android | Android 10 (API 29)+ | Samsung Galaxy S series, Samsung Galaxy Tab S9, Zebra TC52/TC57 (enterprise Android) |
+
+---
+
+## §2 — Definition of Done
+
+### Per-feature DoD
+
+A feature is done when:
+1. Implementation complete and reviewed
+2. Unit tests written and green (coverage ≥ 80% for the changed module)
+3. E2E test added to the Maestro flow for this feature
+4. Accessibility labels and hints added (VoiceOver/TalkBack)
+5. Dark mode tested
+6. Tablet layout tested
+7. Offline behavior tested (feature works in airplane mode)
+8. Error state implemented (what happens when it fails)
+9. Loading state implemented (skeleton or spinner)
+10. Empty state implemented (what happens when there's no data)
+
+### Per-day DoD
+
+Each day ends with:
+1. All that day's targets from §9 committed to `main`
+2. CI green
+3. Daily retrospective filled in §25
+4. Sentry showing no new P0 errors
+5. Tomorrow's first two targets reviewed and understood
+
+---
+
+## §3 — Technical Architecture
+
+### 3.1 Stack overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OHANAFY FIELD APP                         │
+│              React Native (Expo SDK 52, TypeScript)          │
+├─────────────────┬───────────────────┬───────────────────────┤
+│   Presentation  │   Business Logic  │     Infrastructure     │
+│                 │                   │                        │
+│  Expo Router v3 │  WatermelonDB     │  EAS Build             │
+│  NativeWind v4  │  (local SQLite)   │  EAS Submit            │
+│  RN Reanimated  │  React Query v5   │  Sentry                │
+│  FlashList      │  Zustand          │  PostHog               │
+│  React Native   │  Zod validation   │  Datadog (optional)    │
+│  Gesture Handler│  date-fns         │                        │
+├─────────────────┼───────────────────┼───────────────────────┤
+│  Native APIs    │  AI Layer         │  External Services     │
+│                 │                   │                        │
+│  expo-speech    │  Anthropic SDK    │  Salesforce (SF)       │
+│  (voice input)  │  Claude Sonnet    │  Labelary (ZPL prev)   │
+│  Zebra Link-OS  │  Tool use         │                        │
+│  (BT printing)  │  Streaming        │                        │
+│  expo-secure-   │  Memory system    │                        │
+│  store          │  (WatermelonDB)   │                        │
+│  expo-local-    │  Learning agents  │                        │
+│  authentication │                   │                        │
+│  expo-notif.    │                   │                        │
+└─────────────────┴───────────────────┴───────────────────────┘
+```
+
+### 3.2 Package decisions (locked — do not debate)
+
+| Decision | Choice | Locked rationale |
+|---|---|---|
+| Framework | **Expo SDK 52 + React Native** | True native iOS/Android; App Store submission; native Bluetooth; native voice |
+| Navigation | **Expo Router v3** | File-based, type-safe, deep-linking, URL-based tab history |
+| Styling | **NativeWind v4** | Tailwind syntax in React Native; Ohanafy brand tokens as Tailwind config |
+| Local DB | **WatermelonDB** | SQLite-backed offline-first DB built for React Native; reactive queries; migrations |
+| Server state | **TanStack Query v5** | Caching + background refresh for Salesforce sync |
+| Client state | **Zustand v4** | Minimal, TypeScript-first; for voice state machine, UI state |
+| List rendering | **Shopify FlashList** | 5–10× faster than FlatList for account lists; virtualized; required for 60fps |
+| Animations | **React Native Reanimated v3** | 60fps animations on JS thread; required for voice pulsing, sync animations |
+| Gestures | **React Native Gesture Handler** | Required peer dep of Reanimated; better swipe interactions |
+| Voice input | **@react-native-voice/voice** | On-device voice recognition; iOS SFSpeechRecognizer + Android SpeechRecognizer |
+| ZPL printing | **Expo Modules (custom)** wrapping Zebra Link-OS SDK | Only way to get Zebra's official iOS/Android SDK in Expo; write once in Day 3 |
+| Auth | **expo-auth-session** + **expo-secure-store** | OAuth 2.0 PKCE flow; secure token storage in iOS Keychain / Android Keystore |
+| Biometrics | **expo-local-authentication** | FaceID, TouchID, Fingerprint — single API |
+| Push | **expo-notifications** | Unified iOS APNs + Android FCM via Expo Push Service |
+| Error tracking | **Sentry React Native** | Crash reporting, performance traces, session replay |
+| Analytics | **PostHog React Native** | Product analytics; self-hosted option; GDPR-friendly |
+| E2E testing | **Maestro** | Best mobile E2E framework; YAML flows; device-independent |
+| Unit testing | **Jest + React Native Testing Library** | Standard RN testing; WatermelonDB has first-class Jest support |
+| CI/CD | **EAS Build + Submit + GitHub Actions** | Native builds in CI; App Store + Play Store submission automation |
+| ZPL preview | **Labelary REST API** | Free, no auth; renders ZPL → PNG for in-app preview |
+
+### 3.3 Monorepo structure
+
+```
+ohanafy-field/
+├── OHANAFY-FIELD-PRODUCT-BIBLE.md   ← this doc
+├── CLAUDE.md                         ← Claude Code session context
+├── package.json                      ← Expo project root
+├── app.json                          ← Expo app config
+├── eas.json                          ← EAS build profiles
+├── tsconfig.json                     ← TypeScript strict config
+├── tailwind.config.js                ← NativeWind + brand tokens
+├── babel.config.js
+├── metro.config.js                   ← WatermelonDB + NativeWind
+├── .env.local                        ← secrets (gitignored)
+├── .env.example                      ← committed; all keys blank
+├── .claude/                          ← Claude Code harness
+│   ├── settings.json
+│   ├── rules/
+│   ├── agents/
+│   ├── skills/
+│   ├── commands/
+│   └── hooks/
+├── .github/
+│   └── workflows/
+│       ├── ci.yml                    ← Jest + type check + Maestro
+│       ├── eas-preview.yml           ← EAS Preview build on PR
+│       └── eas-production.yml        ← EAS Production build on tag
+├── app/                              ← Expo Router file-based routes
+│   ├── _layout.tsx                   ← Root layout (auth guard, theme)
+│   ├── (auth)/
+│   │   ├── _layout.tsx
+│   │   ├── login.tsx                 ← Salesforce OAuth entry
+│   │   └── biometric.tsx             ← Biometric unlock screen
+│   ├── (tabs)/
+│   │   ├── _layout.tsx               ← Tab bar layout
+│   │   ├── index.tsx                 ← Account list (home)
+│   │   ├── route.tsx                 ← Today's route map
+│   │   ├── orders.tsx                ← Order history
+│   │   └── settings.tsx              ← Rep settings + help
+│   ├── account/
+│   │   ├── [id].tsx                  ← Account detail (phone)
+│   │   └── [id]-tablet.tsx           ← Account detail (tablet split)
+│   ├── order/
+│   │   ├── [id].tsx                  ← Order entry / edit
+│   │   └── [id]/confirm.tsx          ← Order confirmation
+│   ├── visit/
+│   │   └── [id].tsx                  ← Visit log / note entry
+│   ├── label/
+│   │   ├── select.tsx                ← Label type selector
+│   │   ├── preview.tsx               ← ZPL preview + print
+│   │   └── history.tsx               ← Print history
+│   ├── guide/
+│   │   ├── _layout.tsx               ← In-app user guide layout
+│   │   ├── index.tsx                 ← Guide table of contents
+│   │   └── [section].tsx             ← Guide sections
+│   └── onboarding/
+│       ├── _layout.tsx
+│       ├── welcome.tsx
+│       ├── connect.tsx               ← Salesforce connection
+│       ├── printer.tsx               ← Zebra printer pairing
+│       └── first-visit.tsx           ← Guided first visit
+├── src/
+│   ├── components/
+│   │   ├── account/
+│   │   │   ├── AccountCard.tsx
+│   │   │   ├── AccountList.tsx
+│   │   │   ├── AccountDetail.tsx
+│   │   │   ├── InsightBanner.tsx
+│   │   │   ├── VisitHistory.tsx
+│   │   │   └── AccountSearch.tsx
+│   │   ├── order/
+│   │   │   ├── OrderEntry.tsx
+│   │   │   ├── LineItem.tsx
+│   │   │   ├── ProductPicker.tsx
+│   │   │   └── OrderSummary.tsx
+│   │   ├── voice/
+│   │   │   ├── VoiceButton.tsx
+│   │   │   ├── TranscriptDisplay.tsx
+│   │   │   ├── CommandFeedback.tsx
+│   │   │   └── VoiceStateMachine.ts
+│   │   ├── zpl/
+│   │   │   ├── LabelSelector.tsx
+│   │   │   ├── LabelPreview.tsx
+│   │   │   └── PrintButton.tsx
+│   │   ├── sync/
+│   │   │   ├── SyncStatusBar.tsx
+│   │   │   ├── OfflineBanner.tsx
+│   │   │   └── SyncQueueIndicator.tsx
+│   │   ├── ai/
+│   │   │   ├── FeedbackCapture.tsx   ← thumbs up/down + correction
+│   │   │   └── MemoryBadge.tsx       ← "customer-calibrated" indicator
+│   │   ├── onboarding/
+│   │   │   ├── CoachMark.tsx
+│   │   │   └── OnboardingStep.tsx
+│   │   └── shared/
+│   │       ├── ErrorBoundary.tsx
+│   │       ├── LoadingSkeleton.tsx
+│   │       ├── EmptyState.tsx
+│   │       ├── Toast.tsx
+│   │       └── HelpButton.tsx
+│   ├── db/
+│   │   ├── schema.ts                 ← WatermelonDB schema (Appendix C)
+│   │   ├── migrations/               ← Versioned migrations
+│   │   ├── models/
+│   │   │   ├── Account.ts
+│   │   │   ├── Product.ts
+│   │   │   ├── Order.ts
+│   │   │   ├── OrderLine.ts
+│   │   │   ├── Visit.ts
+│   │   │   ├── LabelPrint.ts
+│   │   │   ├── SyncQueueItem.ts
+│   │   │   ├── Memory.ts             ← AI memory store
+│   │   │   └── FeedbackEvent.ts      ← AI feedback events
+│   │   └── repositories/
+│   │       ├── accounts.ts
+│   │       ├── orders.ts
+│   │       ├── visits.ts
+│   │       ├── sync-queue.ts
+│   │       └── memories.ts
+│   ├── ai/
+│   │   ├── client.ts                 ← Anthropic SDK singleton
+│   │   ├── tools/
+│   │   │   ├── interpret-order.ts    ← Tool def + handler
+│   │   │   ├── interpret-note.ts
+│   │   │   ├── get-account-intel.ts
+│   │   │   ├── suggest-label.ts
+│   │   │   └── index.ts              ← All tools exported
+│   │   ├── agents/
+│   │   │   ├── command-agent.ts      ← Voice command interpreter
+│   │   │   ├── visit-prep-agent.ts   ← Pre-call intelligence
+│   │   │   ├── note-agent.ts         ← Note cleanup + summarization
+│   │   │   ├── learning-agent.ts     ← Background memory synthesis
+│   │   │   └── index.ts
+│   │   ├── memory/
+│   │   │   ├── retriever.ts          ← Fetch relevant memories for context
+│   │   │   ├── writer.ts             ← Store new memories
+│   │   │   ├── synthesizer.ts        ← Batch synthesize from feedback events
+│   │   │   └── types.ts
+│   │   └── prompts/
+│   │       ├── command.ts
+│   │       ├── visit-prep.ts
+│   │       ├── note-cleanup.ts
+│   │       └── memory-synthesis.ts
+│   ├── sync/
+│   │   ├── engine.ts                 ← Main sync orchestrator
+│   │   ├── sf-client.ts              ← Salesforce REST API client
+│   │   ├── conflict-resolver.ts      ← Conflict resolution logic
+│   │   ├── queue-processor.ts        ← Process sync_queue items
+│   │   └── background-sync.ts        ← Background app refresh handler
+│   ├── zpl/
+│   │   ├── templates/
+│   │   │   ├── shelf-talker.ts
+│   │   │   ├── product-card.ts
+│   │   │   └── delivery-receipt.ts
+│   │   ├── preview.ts                ← Labelary API caller
+│   │   ├── printer.ts                ← Zebra native module wrapper
+│   │   └── index.ts
+│   ├── auth/
+│   │   ├── sf-oauth.ts               ← Salesforce OAuth PKCE flow
+│   │   ├── token-manager.ts          ← Token refresh logic
+│   │   └── biometric.ts              ← Local authentication
+│   ├── hooks/
+│   │   ├── useOfflineStatus.ts
+│   │   ├── useSyncQueue.ts
+│   │   ├── useVoice.ts
+│   │   ├── useAccount.ts
+│   │   ├── useOrder.ts
+│   │   ├── useVisit.ts
+│   │   ├── useMemories.ts
+│   │   ├── useTabletLayout.ts
+│   │   └── useTheme.ts
+│   ├── store/
+│   │   ├── voice-store.ts            ← Zustand: voice state machine
+│   │   ├── sync-store.ts             ← Zustand: sync status
+│   │   └── onboarding-store.ts       ← Zustand: onboarding progress
+│   ├── utils/
+│   │   ├── beverage.ts               ← Domain math (cases→bbl, etc.)
+│   │   ├── format.ts                 ← Currency, date, weight formatters
+│   │   ├── accessibility.ts          ← a11y helper utilities
+│   │   └── logger.ts                 ← Structured logger → Sentry
+│   └── constants/
+│       ├── theme.ts                  ← Brand tokens (Ohanafy colors)
+│       ├── config.ts                 ← App config constants
+│       └── routes.ts                 ← Named route constants
+├── modules/
+│   └── zebra-link-os/                ← Custom Expo native module
+│       ├── ios/
+│       │   └── ZebraLinkOsModule.swift
+│       ├── android/
+│       │   └── ZebraLinkOsModule.kt
+│       ├── src/
+│       │   ├── ZebraLinkOs.ts
+│       │   └── ZebraLinkOs.types.ts
+│       └── index.ts
+├── __tests__/
+│   ├── unit/
+│   │   ├── ai/
+│   │   ├── zpl/
+│   │   ├── sync/
+│   │   └── utils/
+│   └── integration/
+│       ├── db/
+│       └── sync/
+└── maestro/
+    ├── flows/
+    │   ├── onboarding.yaml
+    │   ├── account-visit.yaml        ← The main happy path
+    │   ├── voice-order.yaml
+    │   ├── offline-sync.yaml
+    │   ├── zpl-print.yaml
+    │   └── ai-correction-learning.yaml
+    └── utils/
+        └── seed-data.yaml
+```
+
+### 3.4 Architecture principles
+
+**Offline-first (not offline-capable):** The app works offline by default. Online connectivity is a bonus that enables sync. Not the reverse.
+
+**AI at the edge:** AI calls happen from the device via the Anthropic API directly. No intermediate server. This keeps latency low and architecture simple. The API key is stored in `expo-secure-store` and loaded at runtime — never hardcoded.
+
+**AI API key management:** The Anthropic API key is provisioned per-company (not per-rep). It's stored in Salesforce as a Connected App secret, retrieved during auth flow, and stored in SecureStore on the device. This keeps key management in Salesforce's hands where IT already manages credentials.
+
+**Memory as a first-class object:** AI memories are WatermelonDB records. They sync to Salesforce. They travel with the rep's account. If a rep gets a new phone, their AI memories restore on first sync.
+
+**Never trust AI output for financial data:** AI can interpret a command, suggest a product, or summarize a note. It cannot create or modify orders without explicit rep confirmation. Every AI-generated order change requires a tap to accept.
+
+---
+
+## §4 — Complete Feature Specification
+
+### 4.1 Feature inventory
+
+| ID | Feature | Priority | Day target |
+|---|---|---|---|
+| F01 | Salesforce OAuth 2.0 auth | P0 | Day 1 |
+| F02 | Biometric app lock (FaceID/TouchID/Fingerprint) | P0 | Day 1 |
+| F03 | Account list (offline-first, search, filter) | P0 | Day 2 |
+| F04 | Account detail (history, metrics, contact) | P0 | Day 2 |
+| F05 | Order entry (line items, quantities, voice) | P0 | Day 2 |
+| F06 | Visit logging (notes, voice, photos) | P0 | Day 2 |
+| F07 | Offline sync engine (queue + auto-flush) | P0 | Day 2 |
+| F08 | Voice command — order entry | P0 | Day 3 |
+| F09 | Voice command — visit notes | P0 | Day 3 |
+| F10 | AI visit prep (pre-call insight) | P0 | Day 3 |
+| F11 | AI note cleanup | P1 | Day 3 |
+| F12 | AI selling intelligence (gap analysis) | P1 | Day 3 |
+| F13 | AI memory system (learns from corrections) | P1 | Day 4 |
+| F14 | AI learning agent (background synthesis) | P1 | Day 4 |
+| F15 | ZPL shelf talker generation + print | P0 | Day 4 |
+| F16 | ZPL product card generation + print | P1 | Day 4 |
+| F17 | ZPL delivery receipt generation + print | P1 | Day 4 |
+| F18 | ZPL label preview (Labelary) | P0 | Day 4 |
+| F19 | Push notifications (visit reminders) | P1 | Day 4 |
+| F20 | Today's route view | P1 | Day 5 |
+| F21 | Order history | P1 | Day 5 |
+| F22 | In-app onboarding (first-run wizard) | P0 | Day 5 |
+| F23 | Coach marks (contextual tips, dismissible) | P1 | Day 5 |
+| F24 | In-app user guide (7 sections, searchable) | P0 | Day 5 |
+| F25 | Dark mode (full implementation) | P0 | Day 5 |
+| F26 | Tablet split layout (iPad + Android tablet) | P0 | Day 6 |
+| F27 | VoiceOver / TalkBack full support | P0 | Day 6 |
+| F28 | Performance optimization pass | P0 | Day 6 |
+| F29 | E2E test suite (Maestro) | P0 | Day 6 |
+| F30 | App Store + Play Store submission | P0 | Day 7 |
+
+### 4.2 Feature specs (acceptance criteria)
+
+**F03 — Account List**
+- Renders from WatermelonDB (offline)
+- Search: real-time filter by account name, contact name, city — debounced 200ms
+- Filter: by account type (on-premise / off-premise chain / off-premise indie / convenience) and by "needs attention" (> 21 days since last order)
+- Sort: alphabetical (default), last visit date, last order amount
+- Account card shows: name, account type badge, last order date, last visit note excerpt (1 line), "needs attention" indicator
+- Empty state: "No accounts cached. Connect to sync your territory."
+- Loading skeleton: 6 card-shaped skeletons, 200ms delay before showing (prevents flash)
+- FlashList with `estimatedItemSize={110}`
+- Tablet: account list is the master panel; tapping an account opens detail in the right panel without navigation
+
+**F05 — Order Entry**
+- Launched from account detail
+- Product list loaded from WatermelonDB (offline)
+- Products grouped by category (Beer Kegs / Beer Cases / Energy / Other)
+- Line item: product name, unit label, quantity stepper (+/-), unit price, line total
+- Running order total in sticky header
+- Add product: search/filter dialog that opens from FAB
+- Voice: VoiceButton in bottom right; voice adds/modifies line items
+- Swipe left on line item: delete
+- Save to WatermelonDB immediately; add to sync_queue
+- Confirm screen: shows all items, total, delivery date picker, notes field, "Place Order" CTA
+- Order placed offline shows "Pending Sync" badge
+- Submitted to Salesforce on next sync
+
+**F08 — Voice Command (Order Entry)**
+- Tap mic button: starts listening (VoiceButton state machine)
+- Interim transcript shows in real time as rep speaks
+- Silence for 1.5s or tap again: stop listening, send to AI
+- AI returns CommandAction (ADD_TO_ORDER / MODIFY_QTY / REMOVE_ITEM / UNKNOWN)
+- CommandFeedback card animates in: shows action summary + "Accept" / "Edit" / "Undo" buttons
+- Accept: applies to order, stores FeedbackEvent(type=accepted)
+- Edit: opens inline editor for that line item, stores FeedbackEvent(type=edited, correction=...)
+- Undo: reverts the change, stores FeedbackEvent(type=rejected)
+- FeedbackEvents feed the learning agent (F14)
+- AI must not apply any change until Accept is tapped — optimistic display only
+
+**F10 — AI Visit Prep**
+- Fires when account detail screen loads
+- POST to Anthropic API with account context + relevant memories injected
+- InsightBanner renders with: insight text, suggested SKUs (1–3), urgency indicator
+- Skeleton shimmer while loading; hidden if call takes > 3s (non-blocking)
+- Insight has FeedbackCapture: thumbs up / thumbs down / "Edit insight"
+- Positive feedback reinforces the pattern in memory
+- Negative feedback + edit stores correction for learning agent
+- "customer-calibrated" badge if relevant memories influenced this insight
+- Each insight is stored in WatermelonDB for visit history
+
+**F13 — AI Memory System**
+- `memories` table stores: category, key, value, confidence (0–1), source (user_correction / learning_agent / onboarding), created_at, last_used_at, use_count
+- Memory categories: COMMAND_PATTERN, ACCOUNT_PREFERENCE, PRODUCT_PREFERENCE, TIMING_PATTERN, NOTE_STYLE, INSIGHT_CALIBRATION
+- Memories injected into AI context window at call time (relevant subset only — top 5 by recency + use_count for each category)
+- Memory retriever filters by category and repId — memories are per-rep, not global
+- Memory writer: captures direct corrections, explicit feedback, high-confidence learning outputs
+- Confidence degrades: memories not used in 60 days drop confidence by 0.1/week
+- Memories sync to Salesforce (survive device change)
+- Rep can view, edit, and delete memories in Settings → "AI Memory"
+
+**F15 — ZPL Shelf Talker**
+- Launched from account detail or order entry
+- Product selector: filtered to products in the account's recent orders
+- Template: shelf talker, product card, delivery receipt (see Appendix A)
+- Preview: Labelary API renders ZPL → PNG displayed in-app
+- Print: sends ZPL string to paired Zebra via Zebra Link-OS native module
+- Print log: every print stored in `label_prints` table (product, template, timestamp, printer serial)
+- If no printer paired: shows "Pair a Printer" prompt
+- If Labelary unavailable (offline): shows "Preview requires connection. Print still works." with the raw ZPL in a monospace scroll view as fallback
+
+**F22 — In-App Onboarding**
+- Triggered on first launch after auth
+- Steps: Welcome → Connect Salesforce (already done) → About Your Territory (rep confirms/edits) → Pair Printer (skip option) → First Account Visit (guided tour with coach marks) → Done
+- Coach marks: Tooltip bubbles pointing to UI elements with dismiss on tap
+- Progress: 5-dot indicator; can be skipped at any step
+- Re-launchable from Settings → "Restart Onboarding"
+- Completion stored in SecureStore (survives reinstall = no; that's intentional)
+
+---
+
+## §5 — Data Model
+
+Full WatermelonDB schema is in Appendix C. This section covers the key design decisions.
+
+### 5.1 WatermelonDB overview
+
+WatermelonDB is a SQLite-backed, reactive, offline-first ORM for React Native. Records are observed via reactive queries — the UI re-renders automatically when data changes. This is the right foundation for a sync-heavy app.
+
+```typescript
+// src/db/schema.ts — complete schema (also see Appendix C)
+
+import { appSchema, tableSchema } from '@nozbe/watermelondb';
+
+export default appSchema({
+  version: 1,
+  tables: [
+    tableSchema({
+      name: 'accounts',
+      columns: [
+        { name: 'sf_id', type: 'string', isIndexed: true },
+        { name: 'name', type: 'string', isIndexed: true },
+        { name: 'account_type', type: 'string', isIndexed: true },   // on_premise | off_premise_chain | off_premise_indie | convenience
+        { name: 'channel', type: 'string' },
+        { name: 'territory_id', type: 'string', isIndexed: true },
+        { name: 'contact_name', type: 'string' },
+        { name: 'contact_title', type: 'string' },
+        { name: 'contact_phone', type: 'string' },
+        { name: 'address_street', type: 'string' },
+        { name: 'address_city', type: 'string' },
+        { name: 'address_state', type: 'string' },
+        { name: 'latitude', type: 'number', isOptional: true },
+        { name: 'longitude', type: 'number', isOptional: true },
+        { name: 'last_order_date', type: 'number', isOptional: true },    // Unix timestamp
+        { name: 'last_visit_date', type: 'number', isOptional: true },
+        { name: 'days_since_last_order', type: 'number' },
+        { name: 'ytd_revenue', type: 'number' },
+        { name: 'needs_attention', type: 'boolean', isIndexed: true },    // > 21 days since last order
+        { name: 'synced_at', type: 'number' },                            // last full sync
+        { name: 'is_archived', type: 'boolean' },
+      ],
+    }),
+    tableSchema({
+      name: 'products',
+      columns: [
+        { name: 'sf_id', type: 'string', isIndexed: true },
+        { name: 'name', type: 'string', isIndexed: true },
+        { name: 'category', type: 'string', isIndexed: true },
+        { name: 'unit', type: 'string' },                                  // keg | case
+        { name: 'unit_label', type: 'string' },
+        { name: 'price_per_unit', type: 'number' },
+        { name: 'supplier_id', type: 'string' },
+        { name: 'sku_code', type: 'string' },
+        { name: 'is_active', type: 'boolean' },
+        { name: 'image_url', type: 'string', isOptional: true },
+      ],
+    }),
+    tableSchema({
+      name: 'orders',
+      columns: [
+        { name: 'sf_id', type: 'string', isOptional: true, isIndexed: true },  // null until synced
+        { name: 'account_id', type: 'string', isIndexed: true },               // WDB local id
+        { name: 'account_sf_id', type: 'string' },
+        { name: 'rep_id', type: 'string', isIndexed: true },
+        { name: 'status', type: 'string', isIndexed: true },                   // draft | pending_sync | synced | submitted | cancelled
+        { name: 'order_date', type: 'number' },
+        { name: 'delivery_date', type: 'number', isOptional: true },
+        { name: 'total_amount', type: 'number' },
+        { name: 'notes', type: 'string', isOptional: true },
+        { name: 'sync_status', type: 'string', isIndexed: true },              // pending | syncing | synced | failed
+        { name: 'sync_attempts', type: 'number' },
+        { name: 'created_offline', type: 'boolean' },
+        { name: 'created_at', type: 'number' },
+        { name: 'updated_at', type: 'number' },
+      ],
+    }),
+    tableSchema({
+      name: 'order_lines',
+      columns: [
+        { name: 'order_id', type: 'string', isIndexed: true },
+        { name: 'product_id', type: 'string', isIndexed: true },
+        { name: 'product_sf_id', type: 'string' },
+        { name: 'product_name', type: 'string' },
+        { name: 'quantity', type: 'number' },
+        { name: 'unit', type: 'string' },
+        { name: 'unit_price', type: 'number' },
+        { name: 'line_total', type: 'number' },
+      ],
+    }),
+    tableSchema({
+      name: 'visits',
+      columns: [
+        { name: 'sf_id', type: 'string', isOptional: true, isIndexed: true },
+        { name: 'account_id', type: 'string', isIndexed: true },
+        { name: 'account_sf_id', type: 'string' },
+        { name: 'rep_id', type: 'string', isIndexed: true },
+        { name: 'visit_date', type: 'number', isIndexed: true },
+        { name: 'duration_minutes', type: 'number', isOptional: true },
+        { name: 'note', type: 'string', isOptional: true },
+        { name: 'raw_transcript', type: 'string', isOptional: true },
+        { name: 'ai_insight', type: 'string', isOptional: true },               // what the AI surfaced pre-call
+        { name: 'insight_feedback', type: 'string', isOptional: true },         // accepted | edited | rejected
+        { name: 'order_id', type: 'string', isOptional: true },                 // if an order was placed
+        { name: 'sync_status', type: 'string', isIndexed: true },
+        { name: 'sync_attempts', type: 'number' },
+        { name: 'created_offline', type: 'boolean' },
+      ],
+    }),
+    tableSchema({
+      name: 'label_prints',
+      columns: [
+        { name: 'account_id', type: 'string', isIndexed: true },
+        { name: 'product_id', type: 'string', isOptional: true },
+        { name: 'template_type', type: 'string' },                              // shelf_talker | product_card | delivery_receipt
+        { name: 'product_name', type: 'string' },
+        { name: 'printer_serial', type: 'string', isOptional: true },
+        { name: 'printed_at', type: 'number' },
+        { name: 'zpl_snapshot', type: 'string' },                               // the ZPL string that was printed
+        { name: 'sync_status', type: 'string' },
+      ],
+    }),
+    tableSchema({
+      name: 'sync_queue',
+      columns: [
+        { name: 'operation_type', type: 'string', isIndexed: true },            // CREATE_ORDER | UPDATE_ORDER | CREATE_VISIT | UPDATE_VISIT | CREATE_LABEL_LOG
+        { name: 'entity_type', type: 'string', isIndexed: true },
+        { name: 'entity_id', type: 'string', isIndexed: true },                 // WDB local id
+        { name: 'payload_json', type: 'string' },
+        { name: 'status', type: 'string', isIndexed: true },                    // pending | processing | done | failed
+        { name: 'attempts', type: 'number' },
+        { name: 'last_error', type: 'string', isOptional: true },
+        { name: 'created_at', type: 'number', isIndexed: true },
+        { name: 'processed_at', type: 'number', isOptional: true },
+      ],
+    }),
+    tableSchema({
+      name: 'memories',
+      columns: [
+        { name: 'rep_id', type: 'string', isIndexed: true },
+        { name: 'account_id', type: 'string', isOptional: true, isIndexed: true },  // null = global rep memory
+        { name: 'category', type: 'string', isIndexed: true },                   // COMMAND_PATTERN | ACCOUNT_PREFERENCE | etc.
+        { name: 'key', type: 'string', isIndexed: true },
+        { name: 'value', type: 'string' },                                        // JSON string
+        { name: 'confidence', type: 'number' },                                   // 0.0–1.0
+        { name: 'source', type: 'string' },                                       // user_correction | learning_agent | onboarding
+        { name: 'use_count', type: 'number' },
+        { name: 'last_used_at', type: 'number', isOptional: true },
+        { name: 'created_at', type: 'number' },
+        { name: 'sf_id', type: 'string', isOptional: true },
+        { name: 'sync_status', type: 'string' },
+      ],
+    }),
+    tableSchema({
+      name: 'feedback_events',
+      columns: [
+        { name: 'rep_id', type: 'string', isIndexed: true },
+        { name: 'account_id', type: 'string', isOptional: true, isIndexed: true },
+        { name: 'event_type', type: 'string', isIndexed: true },                  // command_accepted | command_edited | command_rejected | insight_accepted | insight_edited | insight_rejected
+        { name: 'ai_output', type: 'string' },                                    // what the AI produced (JSON)
+        { name: 'user_correction', type: 'string', isOptional: true },            // what the rep changed it to (if edited)
+        { name: 'context_json', type: 'string' },                                 // account context at the time
+        { name: 'created_at', type: 'number', isIndexed: true },
+        { name: 'synthesized', type: 'boolean', isIndexed: true },                // has learning agent processed this?
+      ],
+    }),
+  ],
+});
+```
+
+### 5.2 WatermelonDB model classes (pattern — all follow this)
+
+```typescript
+// src/db/models/Account.ts
+import { Model, field, date, readonly, children } from '@nozbe/watermelondb/decorators';
+import type { Query, Relation } from '@nozbe/watermelondb';
+import Order from './Order';
+import Visit from './Visit';
+
+export default class Account extends Model {
+  static table = 'accounts';
+  static associations = {
+    orders: { type: 'has_many' as const, foreignKey: 'account_id' },
+    visits: { type: 'has_many' as const, foreignKey: 'account_id' },
+  };
+
+  @field('sf_id') sfId!: string;
+  @field('name') name!: string;
+  @field('account_type') accountType!: 'on_premise' | 'off_premise_chain' | 'off_premise_indie' | 'convenience';
+  @field('contact_name') contactName!: string;
+  @field('last_order_date') lastOrderDateTs!: number | null;
+  @field('days_since_last_order') daysSinceLastOrder!: number;
+  @field('needs_attention') needsAttention!: boolean;
+  @field('ytd_revenue') ytdRevenue!: number;
+  @readonly @date('created_at') createdAt!: Date;
+
+  @children('orders') orders!: Query<Order>;
+  @children('visits') visits!: Query<Visit>;
+
+  get lastOrderDate(): Date | null {
+    return this.lastOrderDateTs ? new Date(this.lastOrderDateTs) : null;
+  }
+}
+```
+
+---
+
+## §6 — AI Intelligence & Learning System
+
+### 6.1 Architecture summary
+
+```
+                    ┌─────────────────────────────────┐
+                    │         AI CALL PIPELINE         │
+                    │                                  │
+User input (voice)  │  1. Retrieve relevant memories   │
+       ↓            │     from WatermelonDB (< 5ms)    │
+Voice recognition   │                                  │
+(on-device)         │  2. Build context window:        │
+       ↓            │     - System prompt              │
+Transcript text     │     - Account context            │
+       ↓            │     - Top 5 memories per cat.    │
+AI Agent call  →→→  │     - Recent FeedbackEvents      │
+                    │                                  │
+Claude API          │  3. Call Claude Sonnet           │
+(Anthropic)         │     with tool_use                │
+       ↓            │                                  │
+Tool result         │  4. Tool handler executes        │
+       ↓            │     (pure TypeScript, no AI)     │
+Structured output   │                                  │
+       ↓            │  5. Return CommandResponse       │
+Display to rep      └─────────────────────────────────┘
+       ↓
+Rep feedback (Accept / Edit / Reject)
+       ↓
+FeedbackEvent stored in WatermelonDB
+       ↓
+Learning agent runs (background, daily)
+       ↓
+New/updated Memory records written
+       ↓
+Next AI call is more accurate
+```
+
+### 6.2 Memory categories and examples
+
+| Category | Key pattern | Value example | Source |
+|---|---|---|---|
+| `COMMAND_PATTERN` | `"couple kegs means"` | `{"quantity": 2, "unit": "keg"}` | user_correction |
+| `COMMAND_PATTERN` | `"pale ale abbreviation"` | `{"maps_to_product_id": "pale-ale-half-bbl"}` | user_correction |
+| `ACCOUNT_PREFERENCE` | `"acct-the-rail:typical_keg_quantity"` | `{"kegs_per_order": 2, "confidence_source": "3 orders"}` | learning_agent |
+| `ACCOUNT_PREFERENCE` | `"acct-the-rail:visit_timing"` | `{"preferred_day": "tuesday", "preferred_hour": 9}` | learning_agent |
+| `PRODUCT_PREFERENCE` | `"rep:top_skus_by_frequency"` | `["pale-ale-half-bbl","modelo-especial-case","red-bull-sf-24pk"]` | learning_agent |
+| `NOTE_STYLE` | `"rep:preferred_note_length"` | `{"sentences": 2, "include_next_steps": true}` | learning_agent |
+| `INSIGHT_CALIBRATION` | `"insight:days_threshold_for_stale"` | `{"days": 28, "calibrated_from": 5}` | learning_agent |
+| `TIMING_PATTERN` | `"rep:productive_visit_window"` | `{"days": ["MON","TUE","WED"], "hours": [8,9,10]}` | learning_agent |
+
+### 6.3 Learning agent
+
+The learning agent runs in the background once per day (triggered by expo-background-fetch or a manual "Refresh AI" tap in Settings). It processes all unprocessed FeedbackEvents and synthesizes new/updated Memory records.
+
+```typescript
+// src/ai/agents/learning-agent.ts
+
+export async function runLearningAgent(repId: string): Promise<LearningResult> {
+  const database = getDatabase();
+
+  // Fetch unprocessed feedback events for this rep
+  const events = await database
+    .get<FeedbackEvent>('feedback_events')
+    .query(
+      Q.where('rep_id', repId),
+      Q.where('synthesized', false),
+      Q.sortBy('created_at', Q.asc),
+    )
+    .fetch();
+
+  if (events.length < 3) {
+    // Not enough signal yet — wait for more events
+    return { processed: 0, memoriesCreated: 0, memoriesUpdated: 0 };
+  }
+
+  // Group by event_type for batch processing
+  const commandEdits = events.filter(e => e.eventType === 'command_edited');
+  const insightEdits = events.filter(e => e.eventType === 'insight_edited');
+  const rejections = events.filter(e =>
+    e.eventType.endsWith('_rejected') && events.filter(
+      e2 => e2.eventType.replace('rejected', 'accepted') && e2.contextJson === e.contextJson
+    ).length === 0
+  );
+
+  const results: LearningResult = { processed: 0, memoriesCreated: 0, memoriesUpdated: 0 };
+
+  // Process command edits — look for patterns
+  if (commandEdits.length >= 2) {
+    const commandPatterns = await synthesizeCommandPatterns(commandEdits);
+    for (const pattern of commandPatterns) {
+      await upsertMemory(database, repId, 'COMMAND_PATTERN', pattern.key, pattern.value, pattern.confidence);
+      results.memoriesCreated++;
+    }
+  }
+
+  // Process insight edits — calibrate the insight engine
+  if (insightEdits.length >= 2) {
+    const calibrations = await synthesizeInsightCalibrations(insightEdits);
+    for (const cal of calibrations) {
+      await upsertMemory(database, repId, 'INSIGHT_CALIBRATION', cal.key, cal.value, cal.confidence);
+      results.memoriesUpdated++;
+    }
+  }
+
+  // Mark all processed events as synthesized
+  await database.write(async () => {
+    for (const event of events) {
+      await event.update(e => { e.synthesized = true; });
+    }
+  });
+
+  results.processed = events.length;
+  return results;
+}
+
+async function synthesizeCommandPatterns(
+  edits: FeedbackEvent[]
+): Promise<Array<{ key: string; value: string; confidence: number }>> {
+  // Call Claude with all the edits and ask it to identify the pattern
+  const response = await anthropic.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 500,
+    system: MEMORY_SYNTHESIS_PROMPT,
+    messages: [{
+      role: 'user',
+      content: `Identify command interpretation patterns from these corrections:\n\n${
+        edits.map(e => `Input: "${JSON.parse(e.contextJson).transcript}" → AI said: ${e.aiOutput} → Rep corrected to: ${e.userCorrection}`).join('\n')
+      }\n\nReturn only JSON array of patterns.`,
+    }],
+  });
+
+  const text = response.content[0].type === 'text' ? response.content[0].text : '[]';
+  try {
+    return JSON.parse(text.replace(/```json|```/g, '').trim());
+  } catch {
+    return [];
+  }
+}
+```
+
+### 6.4 Memory retrieval at call time
+
+```typescript
+// src/ai/memory/retriever.ts
+
+export async function getRelevantMemories(
+  repId: string,
+  accountId: string | null,
+  categories: MemoryCategory[],
+  limit = 5,
+): Promise<Memory[]> {
+  const database = getDatabase();
+  const queries: Q.Condition[] = [
+    Q.where('rep_id', repId),
+    Q.where('category', Q.oneOf(categories)),
+    Q.where('confidence', Q.gte(0.3)),    // only confident memories
+  ];
+
+  // Account-specific memories ranked higher
+  const accountMemories = accountId
+    ? await database.get<Memory>('memories')
+        .query(...queries, Q.where('account_id', accountId))
+        .fetch()
+    : [];
+
+  const globalMemories = await database.get<Memory>('memories')
+    .query(...queries, Q.where('account_id', null))
+    .fetch();
+
+  // Combine: account-specific first, then global; sort by recency + use_count
+  const all = [...accountMemories, ...globalMemories]
+    .sort((a, b) => {
+      const scoreA = a.confidence * (1 + Math.log1p(a.useCount)) * (a.lastUsedAt || 0);
+      const scoreB = b.confidence * (1 + Math.log1p(b.useCount)) * (b.lastUsedAt || 0);
+      return scoreB - scoreA;
+    })
+    .slice(0, limit);
+
+  // Increment use_count for retrieved memories
+  await database.write(async () => {
+    for (const mem of all) {
+      await mem.update(m => {
+        m.useCount += 1;
+        m.lastUsedAt = Date.now();
+      });
+    }
+  });
+
+  return all;
+}
+
+export function memoriesToContextString(memories: Memory[]): string {
+  if (memories.length === 0) return '';
+  return `\n\nKnown patterns for this rep:\n${
+    memories.map(m => `- [${m.category}] ${m.key}: ${m.value} (confidence: ${(m.confidence * 100).toFixed(0)}%)`).join('\n')
+  }`;
+}
+```
+
+### 6.5 AI feedback capture component
+
+```typescript
+// src/components/ai/FeedbackCapture.tsx
+
+interface FeedbackCaptureProps {
+  aiOutput: string;
+  context: AccountContext;
+  eventType: FeedbackEventType;
+  onAccept: () => void;
+  onEdit: (correction: string) => void;
+  onReject: () => void;
+}
+
+export function FeedbackCapture({ aiOutput, context, eventType, onAccept, onEdit, onReject }: FeedbackCaptureProps) {
+  const { saveFeedback } = useFeedback();
+
+  const handleAccept = async () => {
+    await saveFeedback({
+      eventType: eventType.replace(/_.+/, '_accepted') as FeedbackEventType,
+      aiOutput,
+      contextJson: JSON.stringify(context),
+    });
+    onAccept();
+  };
+
+  const handleEdit = async (correction: string) => {
+    await saveFeedback({
+      eventType: eventType.replace(/_.+/, '_edited') as FeedbackEventType,
+      aiOutput,
+      userCorrection: correction,
+      contextJson: JSON.stringify(context),
+    });
+    onEdit(correction);
+  };
+
+  const handleReject = async () => {
+    await saveFeedback({
+      eventType: eventType.replace(/_.+/, '_rejected') as FeedbackEventType,
+      aiOutput,
+      contextJson: JSON.stringify(context),
+    });
+    onReject();
+  };
+
+  return (
+    <View className="flex-row gap-2 mt-2">
+      <TouchableOpacity
+        accessibilityLabel="Accept AI suggestion"
+        className="flex-1 bg-green-500 rounded-lg py-3 items-center"
+        onPress={handleAccept}
+      >
+        <Text className="text-white font-semibold">Accept</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityLabel="Edit AI suggestion"
+        className="flex-1 bg-amber-500 rounded-lg py-3 items-center"
+        onPress={() => onEdit('')}   // triggers inline editor
+      >
+        <Text className="text-white font-semibold">Edit</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityLabel="Reject AI suggestion"
+        className="flex-1 bg-red-500 rounded-lg py-3 items-center"
+        onPress={handleReject}
+      >
+        <Text className="text-white font-semibold">Reject</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+```
+
+---
+
+## §7 — Offline-First Architecture
+
+### 7.1 Principle: offline is the default state
+
+The app boots from WatermelonDB every time — never from the network. Network is only used for initial seed (first launch) and sync (periodic + on-reconnect). This means cold launch always works regardless of connectivity.
+
+### 7.2 Connectivity detection
+
+```typescript
+// src/hooks/useOfflineStatus.ts
+import NetInfo from '@react-native-community/netinfo';
+import { useState, useEffect } from 'react';
+import { useSyncStore } from '../store/sync-store';
+
+export function useOfflineStatus() {
+  const [isOnline, setIsOnline] = useState<boolean | null>(null);
+  const { triggerSync } = useSyncStore();
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener(state => {
+      const online = state.isConnected && state.isInternetReachable;
+      const wasOffline = isOnline === false;
+      setIsOnline(!!online);
+
+      // Just came back online — trigger sync immediately
+      if (wasOffline && online) {
+        triggerSync('reconnect');
+      }
+    });
+    return unsubscribe;
+  }, [isOnline]);
+
+  return { isOnline: isOnline ?? false, isChecking: isOnline === null };
+}
+```
+
+### 7.3 Sync engine
+
+```typescript
+// src/sync/engine.ts
+
+export type SyncTrigger = 'app_foreground' | 'reconnect' | 'manual' | 'background';
+
+export async function runSync(trigger: SyncTrigger): Promise<SyncResult> {
+  const syncStore = useSyncStore.getState();
+  if (syncStore.isSyncing) return { status: 'already_running' };
+
+  syncStore.setSyncing(true, trigger);
+  logger.info({ trigger }, 'Sync started');
+
+  try {
+    // Phase 1: Pull from Salesforce (server → local)
+    const pullResult = await pullFromSalesforce();
+
+    // Phase 2: Push from local queue (local → server)
+    const pushResult = await pushQueueToSalesforce();
+
+    const result: SyncResult = {
+      status: 'success',
+      pulled: pullResult.count,
+      pushed: pushResult.succeeded,
+      failed: pushResult.failed,
+      duration: Date.now() - syncStore.syncStartedAt!,
+    };
+
+    syncStore.setSyncResult(result);
+    logger.info(result, 'Sync completed');
+    return result;
+
+  } catch (error) {
+    const result: SyncResult = { status: 'error', error: String(error) };
+    syncStore.setSyncResult(result);
+    Sentry.captureException(error, { tags: { trigger } });
+    return result;
+  } finally {
+    syncStore.setSyncing(false);
+  }
+}
+
+async function pushQueueToSalesforce(): Promise<{ succeeded: number; failed: number }> {
+  const database = getDatabase();
+  const pending = await database
+    .get<SyncQueueItem>('sync_queue')
+    .query(Q.where('status', 'pending'), Q.where('attempts', Q.lt(3)))
+    .fetch();
+
+  let succeeded = 0;
+  let failed = 0;
+
+  for (const item of pending) {
+    try {
+      await database.write(async () => {
+        await item.update(i => { i.status = 'processing'; });
+      });
+
+      await processSyncItem(item);
+
+      await database.write(async () => {
+        await item.update(i => {
+          i.status = 'done';
+          i.processedAt = Date.now();
+        });
+      });
+      succeeded++;
+
+    } catch (error) {
+      await database.write(async () => {
+        await item.update(i => {
+          i.status = i.attempts >= 2 ? 'failed' : 'pending';
+          i.attempts += 1;
+          i.lastError = String(error);
+        });
+      });
+      failed++;
+      logger.warn({ itemId: item.id, error }, 'Sync item failed');
+    }
+  }
+
+  return { succeeded, failed };
+}
+```
+
+### 7.4 Conflict resolution
+
+| Scenario | Resolution | Rationale |
+|---|---|---|
+| Account data changed on both server and device | Server wins — overwrite local | Server is source of truth for account data |
+| Order created offline, same order created online | Create both — flag for rep review | Can't silently discard an order |
+| Visit note edited offline and online | Last-write-wins with timestamp | Notes rarely edited from two places |
+| Product catalog updated server-side | Server wins — refresh local | Catalog is read-only on device |
+| Memory record: local newer than server | Local wins | Learning happened on this device; preserve it |
+| Memory record: server newer than local | Merge — keep higher confidence value | Another device may have more usage data |
+
+### 7.5 Background sync (iOS + Android)
+
+```typescript
+// src/sync/background-sync.ts
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as TaskManager from 'expo-task-manager';
+
+const BACKGROUND_SYNC_TASK = 'ohanafy-field-background-sync';
+
+TaskManager.defineTask(BACKGROUND_SYNC_TASK, async () => {
+  try {
+    const result = await runSync('background');
+    return result.status === 'success'
+      ? BackgroundFetch.BackgroundFetchResult.NewData
+      : BackgroundFetch.BackgroundFetchResult.NoData;
+  } catch {
+    return BackgroundFetch.BackgroundFetchResult.Failed;
+  }
+});
+
+export async function registerBackgroundSync() {
+  await BackgroundFetch.registerTaskAsync(BACKGROUND_SYNC_TASK, {
+    minimumInterval: 15 * 60,    // 15 minutes minimum (OS may defer)
+    stopOnTerminate: false,
+    startOnBoot: true,
+  });
+}
+```
+
+---
+
+## §8 — ZPL Printing System
+
+### 8.1 Native module for Zebra Link-OS
+
+The Zebra Link-OS SDK is an official iOS/Android SDK from Zebra Technologies. We wrap it in a custom Expo native module.
+
+```typescript
+// modules/zebra-link-os/src/ZebraLinkOs.types.ts
+export interface ZebraPrinter {
+  address: string;    // Bluetooth MAC address or IP
+  name: string;
+  model: string;      // e.g., "ZQ520"
+  connectionType: 'bluetooth' | 'wifi';
+}
+
+export interface PrintResult {
+  success: boolean;
+  error?: string;
+  printerSerial?: string;
+}
+
+export interface ZebraLinkOsInterface {
+  discoverPrinters(timeout?: number): Promise<ZebraPrinter[]>;
+  connectPrinter(address: string): Promise<boolean>;
+  disconnectPrinter(): Promise<void>;
+  printZpl(zpl: string): Promise<PrintResult>;
+  getPrinterStatus(): Promise<'ready' | 'not_ready' | 'disconnected'>;
+  calibrateMedia(): Promise<boolean>;
+}
+```
+
+```swift
+// modules/zebra-link-os/ios/ZebraLinkOsModule.swift
+// Wraps ZebraLink.framework (bundled in this module)
+import ExpoModulesCore
+import ZebraLink
+
+public class ZebraLinkOsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ZebraLinkOs")
+
+    AsyncFunction("discoverPrinters") { (timeout: Int, promise: Promise) in
+      // MFiBluetoothDeviceDiscoverer implementation
+    }
+
+    AsyncFunction("printZpl") { (zpl: String, promise: Promise) in
+      guard let conn = self.currentConnection else {
+        promise.reject("NOT_CONNECTED", "No printer connected")
+        return
+      }
+      conn.open()
+      defer { conn.close() }
+      let zplData = zpl.data(using: .utf8)!
+      conn.write(zplData)
+      promise.resolve(["success": true, "printerSerial": conn.serial ?? ""])
+    }
+  }
+}
+```
+
+### 8.2 Fallback: no hardware
+
+When no Zebra printer is available or paired:
+1. Show "Preview" mode — Labelary renders the label as PNG
+2. Show a "Send to Printer" button that opens the system share sheet (PDF of the label)
+3. For the iOS simulator / Android emulator: always use fallback mode
+
+```typescript
+// src/zpl/printer.ts
+import * as ZebraLinkOs from '../../modules/zebra-link-os';
+
+export async function printLabel(zpl: string, accountId: string, productName: string): Promise<PrintResult> {
+  const isSimulator = Platform.OS === 'ios'
+    ? !Device.isDevice
+    : !Device.isDevice;
+
+  if (isSimulator) {
+    return simulatePrint(zpl, productName);
+  }
+
+  const status = await ZebraLinkOs.getPrinterStatus();
+  if (status !== 'ready') {
+    throw new Error(`Printer not ready: ${status}`);
+  }
+
+  return ZebraLinkOs.printZpl(zpl);
+}
+
+async function simulatePrint(zpl: string, productName: string): Promise<PrintResult> {
+  // In simulator/emulator: show a preview modal and return success
+  // This allows testing the full flow without hardware
+  showToast(`[SIMULATED] Printing label for ${productName}`);
+  return { success: true, printerSerial: 'SIMULATOR' };
+}
+```
+
+### 8.3 ZPL templates
+
+Full templates with TypeScript implementations are in Appendix A. Quick reference:
+
+| Template | Size | Use case | Parameters |
+|---|---|---|---|
+| `shelf-talker` | 2.5"×1.5" | Retail shelf price/promo | name, sku, price, promoLine? |
+| `product-card` | 4"×3" | Feature display, cooler door | name, tagline, abv?, serving, keyFacts[], sku |
+| `delivery-receipt` | 4"×6" | Delivery confirmation, signature | account, date, rep, lines[], total |
+| `route-sheet` | 4"×6" | Daily account list (print at start of day) | repName, date, accounts[] |
+
+---
+
+## §9 — 7-Day Engineering Plan
+
+Claude Code reads the current day's plan every morning. Do not skip ahead or work on tomorrow's tasks without completing today's.
+
+### Commitment before Day 1 starts
+
+Run these commands before writing any code. If any fail, fix them first.
+
+```bash
+# 1. Expo CLI installed
+npx expo --version   # >= 51.x
+
+# 2. EAS CLI installed and logged in
+eas whoami           # should show your Expo account
+
+# 3. Apple Developer account
+# Go to developer.apple.com — confirm active membership + team access
+# Create app ID: com.ohanafy.field
+
+# 4. Google Play Developer account
+# Go to play.google.com/console — confirm active publisher account
+# Create application: Ohanafy Field
+
+# 5. Accounts needed (set up tonight before Day 1):
+# - Expo.dev account (EAS)
+# - Sentry.io account (free tier OK)
+# - PostHog.com account (free tier OK, or self-hosted)
+# - Apple Developer Program ($99/yr — must be active)
+# - Google Play Console ($25 one-time)
+# - Anthropic API key (for AI features)
+# - Labelary (no account needed — free API)
+# - Salesforce sandbox access (Ohanafy managed package installed)
+# - Zebra ZQ520 or ZQ630 (for printing tests)
+```
+
+---
+
+### Day 1 — Foundation (Monday)
+
+**Theme: "Every subsequent day builds on this. If Day 1 is wrong, everything is wrong."**
+
+**Morning (3 hrs): Project scaffold + design system**
+
+```bash
+# Create the Expo project
+npx create-expo-app@latest ohanafy-field \
+  --template expo-template-blank-typescript
+cd ohanafy-field
+
+# Install all Day 1 dependencies at once
+npx expo install \
+  expo-router \
+  expo-auth-session \
+  expo-secure-store \
+  expo-local-authentication \
+  expo-notifications \
+  expo-background-fetch \
+  expo-task-manager \
+  @react-native-community/netinfo \
+  react-native-gesture-handler \
+  react-native-reanimated \
+  @shopify/flash-list \
+  nativewind \
+  zustand \
+  @tanstack/react-query \
+  zod
+
+# WatermelonDB (needs special setup)
+npm install @nozbe/watermelondb
+npx expo install @nozbe/watermelondb
+
+# Error tracking + analytics
+npx expo install @sentry/react-native
+npm install posthog-react-native
+
+# Testing
+npm install --save-dev jest @testing-library/react-native \
+  @testing-library/jest-native \
+  jest-expo
+```
+
+**Targets by end of Day 1:**
+
+| Target | Test |
+|---|---|
+| Expo project runs in simulator | `npx expo start` — opens without errors |
+| Expo Router navigation: auth → home → settings | Navigate between all 3 tabs manually |
+| NativeWind configured with Ohanafy brand tokens | Brand color renders on a sample button |
+| WatermelonDB initialized — schema created, all tables exist | Run `db.adapter.query(...)` in dev console returns empty arrays |
+| Salesforce OAuth PKCE flow completes | Token stored in SecureStore; `sf-client.ts` returns user info |
+| Biometric lock screen works | FaceID/TouchID prompts on app foreground |
+| Sentry initialized — error reports appear in dashboard | `Sentry.captureMessage('test')` shows in Sentry |
+| EAS build profile configured | `eas build --platform ios --profile preview` succeeds (or queued) |
+| GitHub Actions CI runs | Push to `main` → CI green |
+| `CLAUDE.md` committed | Claude Code can read session context |
+
+**Day 1 deep-dives:**
+
+**Salesforce OAuth:**
+```typescript
+// src/auth/sf-oauth.ts
+import * as AuthSession from 'expo-auth-session';
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+const SF_INSTANCE_URL = process.env.EXPO_PUBLIC_SF_INSTANCE_URL!;
+const SF_CLIENT_ID = process.env.EXPO_PUBLIC_SF_CLIENT_ID!;
+const SF_REDIRECT_URI = AuthSession.makeRedirectUri({ scheme: 'com.ohanafy.field' });
+
+export async function loginWithSalesforce(): Promise<SFTokens> {
+  const discovery = {
+    authorizationEndpoint: `${SF_INSTANCE_URL}/services/oauth2/authorize`,
+    tokenEndpoint: `${SF_INSTANCE_URL}/services/oauth2/token`,
+  };
+
+  const request = new AuthSession.AuthRequest({
+    clientId: SF_CLIENT_ID,
+    scopes: ['api', 'refresh_token', 'offline_access'],
+    redirectUri: SF_REDIRECT_URI,
+    usePKCE: true,
+  });
+
+  const result = await request.promptAsync(discovery);
+
+  if (result.type !== 'success') {
+    throw new Error(`OAuth failed: ${result.type}`);
+  }
+
+  const tokenResponse = await AuthSession.exchangeCodeAsync(
+    { code: result.params.code, redirectUri: SF_REDIRECT_URI, clientId: SF_CLIENT_ID, extraParams: { code_verifier: request.codeVerifier! } },
+    discovery,
+  );
+
+  await SecureStore.setItemAsync('sf_access_token', tokenResponse.accessToken!);
+  await SecureStore.setItemAsync('sf_refresh_token', tokenResponse.refreshToken!);
+  await SecureStore.setItemAsync('sf_instance_url', SF_INSTANCE_URL);
+
+  return { accessToken: tokenResponse.accessToken!, refreshToken: tokenResponse.refreshToken!, instanceUrl: SF_INSTANCE_URL };
+}
+```
+
+**WatermelonDB setup:**
+```typescript
+// src/db/index.ts
+import { Database } from '@nozbe/watermelondb';
+import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite';
+import schema from './schema';
+import migrations from './migrations';
+import Account from './models/Account';
+import Product from './models/Product';
+import Order from './models/Order';
+import OrderLine from './models/OrderLine';
+import Visit from './models/Visit';
+import Memory from './models/Memory';
+import FeedbackEvent from './models/FeedbackEvent';
+import SyncQueueItem from './models/SyncQueueItem';
+import LabelPrint from './models/LabelPrint';
+
+const adapter = new SQLiteAdapter({
+  schema,
+  migrations,
+  jsi: Platform.OS !== 'web',    // JSI for better performance on device
+  onSetUpError: error => Sentry.captureException(error),
+});
+
+export const database = new Database({
+  adapter,
+  modelClasses: [Account, Product, Order, OrderLine, Visit, Memory, FeedbackEvent, SyncQueueItem, LabelPrint],
+});
+```
+
+**NativeWind brand tokens:**
+```javascript
+// tailwind.config.js
+module.exports = {
+  content: ['./app/**/*.{js,ts,jsx,tsx}', './src/**/*.{js,ts,jsx,tsx}'],
+  presets: [require('nativewind/preset')],
+  theme: {
+    extend: {
+      colors: {
+        'ohanafy': {
+          primary:   '#FILL_FROM_BRAND_GUIDE',
+          secondary: '#FILL_FROM_BRAND_GUIDE',
+          accent:    '#FILL_FROM_BRAND_GUIDE',
+          ink:       '#FILL_FROM_BRAND_GUIDE',
+          bg:        '#FILL_FROM_BRAND_GUIDE',
+        },
+        'offline':  '#6B7280',
+        'sync':     '#F59E0B',
+        'success':  '#16A34A',
+        'warning':  '#D97706',
+        'danger':   '#DC2626',
+      },
+      fontFamily: {
+        heading: ['FILL_FROM_BRAND_GUIDE', 'system-ui'],
+        body:    ['FILL_FROM_BRAND_GUIDE', 'system-ui'],
+      },
+    },
+  },
+};
+```
+
+---
+
+### Day 2 — Core Features (Tuesday)
+
+**Theme: "Every rep feature that matters offline, working end-to-end."**
+
+**Targets by end of Day 2:**
+
+| Target | Test |
+|---|---|
+| Account list renders from WatermelonDB (airplane mode) | Enable airplane mode. Account list loads instantly. |
+| Account search filters correctly | Type "Rail" → only The Rail shows |
+| "Needs attention" filter works | 5 seeded accounts; 2 flagged; filter shows 2 |
+| Account detail renders all fields + last visit | Navigate to The Rail; all data present |
+| Order entry: add line items, stepper works | Add 2 kegs Pale Ale; total updates |
+| Order entry: swipe to delete works | Swipe left on a line; line removed |
+| Order confirm screen renders + saves to WatermelonDB | Confirm order; `status = 'pending_sync'` in DB |
+| Visit note entry: text input, save | Log "Tap issue on lager" note; appears in visit history |
+| Sync queue: order appears when created offline | Create order offline; sync_queue has 1 pending item |
+| Sync engine: flushes queue and creates SF record on reconnect | Turn off airplane mode; order appears in SF sandbox |
+| ErrorBoundary renders fallback without crashing | Throw deliberate error; error boundary catches it |
+| LoadingSkeleton shows on all list screens | Slow network: skeleton visible for 200ms+ before data |
+| EmptyState shows on account list with no data | Clear DB; open account list; empty state shown |
+
+**Order entry performance note:**
+
+The order entry screen must be tested at 50+ line items without jank. Use FlashList with `estimatedItemSize` tuned to actual item height. Run `npx react-native-performance-ui` to verify.
+
+---
+
+### Day 3 — Voice + AI (Wednesday)
+
+**Theme: "The rep never needs to type again."**
+
+**Targets by end of Day 3:**
+
+| Target | Test |
+|---|---|
+| Voice recognition initializes on device | Tap mic; speech indicator shows; speak; transcript appears |
+| Interim transcript displays in real time | Words appear as spoken (no post-processing delay) |
+| Voice state machine transitions correctly | IDLE → LISTENING → PROCESSING → CONFIRMING → IDLE |
+| Voice command adds items to order | Say "add 2 kegs pale ale"; CommandFeedback appears |
+| Accept button applies the change | Tap Accept; order line added |
+| Edit button opens inline editor | Tap Edit; quantity field focused |
+| Reject button reverts | Tap Reject; no change to order |
+| FeedbackEvent stored on each action | Check WatermelonDB `feedback_events` table after each action |
+| Visit prep AI insight appears on account open | Open The Rail; InsightBanner appears within 3 seconds |
+| InsightBanner skeleton shows while loading | Slow API: shimmer visible until result arrives |
+| InsightBanner hides if AI takes > 3 seconds | Simulate slow API; banner doesn't appear (non-blocking) |
+| Voice note: "Note [text]" creates visit note | Say "note the lager tap is still intermittent"; note saved |
+| AI note cleanup: transcript cleaned to CRM-quality | Filler words ("um", "uh") removed from saved note |
+| Memories table: empty on fresh install | `SELECT COUNT(*) FROM memories WHERE rep_id = 'me'` returns 0 |
+| Memory writer: stores correction on Edit | Edit a voice command; check memories table for new entry |
+
+**Voice command state machine (Zustand):**
+
+```typescript
+// src/store/voice-store.ts
+import { create } from 'zustand';
+
+type VoiceState = 'idle' | 'requesting_permission' | 'listening' | 'processing' | 'confirming' | 'error';
+
+interface VoiceAction {
+  type: 'ADD_TO_ORDER';
+  items: OrderLineItem[];
+  summary: string;
+} | {
+  type: 'LOG_NOTE';
+  note: string;
+  rawTranscript: string;
+} | {
+  type: 'UNKNOWN';
+  transcript: string;
+};
+
+interface VoiceStore {
+  state: VoiceState;
+  transcript: string;
+  interimTranscript: string;
+  action: VoiceAction | null;
+  error: string | null;
+
+  startListening: () => Promise<void>;
+  stopListening: () => void;
+  setTranscript: (t: string, isInterim: boolean) => void;
+  setAction: (action: VoiceAction) => void;
+  reset: () => void;
+  setError: (e: string) => void;
+}
+```
+
+---
+
+### Day 4 — ZPL, Learning & Push (Thursday)
+
+**Theme: "Print something physical. The AI gets smarter. The rep gets a reminder."**
+
+**Targets by end of Day 4:**
+
+| Target | Test |
+|---|---|
+| Zebra module compiles on both iOS and Android | `eas build --platform all --profile preview` succeeds |
+| Printer discovery returns paired Zebra | On device: tap "Find Printers"; ZQ520 appears in list |
+| Zebra connection + print: shelf talker prints | Tap Print; ZQ520 prints the label |
+| Labelary preview renders correctly | Open label preview; PNG visible before printing |
+| Shelf talker ZPL correct for 8dpmm/2.5×1.5" | Print on ZQ520; label fits, text readable at 2ft |
+| Product card ZPL correct for 8dpmm/4×3" | Print on ZQ520 or ZQ630; label fits |
+| Delivery receipt ZPL correct for 8dpmm/4×6" | Print on ZQ520 or ZQ630; all line items present |
+| Label print stored in `label_prints` table | Print a label; check WDB for the entry |
+| Offline ZPL preview fallback: raw ZPL shown | Enable airplane mode; open preview; ZPL text shown |
+| Learning agent: runs and creates memory records | Seed 5 command edits; run agent; check memories table |
+| Learning agent: memory count increases over time | Run agent 3 times with different edits; memories grow |
+| Memory badge: "customer-calibrated" shown on insight | Seed 1 account memory; open that account; badge shows |
+| Push notification: visit reminder fires | Set account reminder for 1 min from now; notification fires |
+| Push notification: tap opens correct account | Tap notification; account detail screen opens |
+| AI memory Settings screen: shows all memories | Open Settings → AI Memory; memories listed |
+| Delete memory works | Delete a memory; it's gone from DB and list |
+
+**ZPL render quality check (mandatory):**
+
+```bash
+# Test every ZPL template against Labelary before considering Day 4 done
+curl -X POST http://api.labelary.com/v1/printers/8dpmm/labels/2.5x1.5/0/ \
+  -H "Accept: image/png" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "$(node -e "const {generateShelfTalker} = require('./src/zpl/templates/shelf-talker'); console.log(generateShelfTalker({productName:'Pale Ale',skuCode:'YH-PA-HB',pricePerCase:142}))")" \
+  --output /tmp/shelf-talker-test.png && open /tmp/shelf-talker-test.png
+```
+
+---
+
+### Day 5 — Tests, Onboarding & Help (Friday)
+
+**Theme: "A rep can pick it up and know what to do. A test suite can tell us when we broke something."**
+
+**Targets by end of Day 5:**
+
+| Target | Test |
+|---|---|
+| Unit tests: ≥ 80% coverage on `src/ai/`, `src/zpl/`, `src/sync/` | `npx jest --coverage` → meets threshold |
+| Unit tests: all AI tool handlers tested with fixtures | `npx jest src/ai/tools/` — all pass |
+| Unit tests: all ZPL templates tested with snapshots | `npx jest src/zpl/` — all pass, snapshots committed |
+| Unit tests: sync engine pure functions tested | `npx jest src/sync/` — all pass |
+| E2E: onboarding flow completes | Maestro: `maestro test maestro/flows/onboarding.yaml` |
+| E2E: account-visit.yaml — full happy path | Maestro: `maestro test maestro/flows/account-visit.yaml` |
+| E2E: voice-order.yaml | Maestro: passes |
+| E2E: offline-sync.yaml | Maestro: passes |
+| E2E: zpl-print.yaml (preview mode if no printer) | Maestro: passes |
+| Onboarding wizard: 5 steps complete end-to-end | Go through all 5 steps; "Done" reaches home screen |
+| Coach marks: shown on first visit to each screen | Fresh install; coach marks appear on home and account detail |
+| Coach marks: dismissed and not shown again | Dismiss a mark; re-open app; mark does not reappear |
+| User guide: all 7 sections accessible | Open Guide in tabs; all sections load (offline) |
+| User guide: search works | Search "voice"; relevant sections shown |
+| User guide: renders offline | Enable airplane mode; open guide; all sections load |
+| Dark mode: all screens look correct | System dark mode on; no white flashes, no invisible text |
+
+**Maestro E2E example (account-visit.yaml):**
+
+```yaml
+# maestro/flows/account-visit.yaml
+appId: com.ohanafy.field
+---
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"     # Uses seeded test data, no real SF call
+
+# Login (mocked in test mode)
+- tapOn: "Sign in with Salesforce"
+- assertVisible: "My Accounts"
+
+# Navigate to The Rail
+- tapOn: "The Rail"
+- assertVisible: "InsightBanner"       # AI insight loaded
+- assertVisible: "Pale Ale"            # Suggested SKU visible
+
+# Start an order
+- tapOn: "New Order"
+- assertVisible: "Order Entry"
+
+# Add item via stepper
+- tapOn: "Pale Ale"
+- tapOn:
+    id: "qty-stepper-increase"
+- tapOn:
+    id: "qty-stepper-increase"
+- assertVisible: "2 × 1/2 bbl"
+
+# Confirm order
+- tapOn: "Confirm Order"
+- assertVisible: "Order Saved"
+- assertVisible: "Pending Sync"
+
+# Verify sync badge
+- tapOn: "Back"
+- assertVisible: "1 item pending"
+
+# Simulate reconnect (test mode: manual trigger)
+- tapOn:
+    id: "debug-trigger-sync"
+- assertVisible: "Synced ✓"
+```
+
+---
+
+### Day 6 — Tablet, Accessibility & Performance (Saturday)
+
+**Theme: "World-class means it works everywhere, for everyone."**
+
+**Targets by end of Day 6:**
+
+| Target | Test |
+|---|---|
+| iPad split layout: account list + detail side-by-side | iPad simulator ≥ 768pt: two panels visible |
+| iPad: tapping account opens detail in right panel (no full navigation) | Tap account; detail replaces right panel without nav transition |
+| Android tablet split layout: same threshold | Android tablet simulator: same behavior |
+| iPad: landscape mode, all screens usable | Rotate iPad; no content clipped or hidden |
+| Android tablet: landscape mode | Same |
+| VoiceOver (iOS): account list announces item count | VoiceOver on; swipe to account list; count announced |
+| VoiceOver: order entry navigable | Step through order entry with VoiceOver; all elements announced |
+| VoiceOver: voice button accessible | VoiceOver: element reads "Microphone, button, double-tap to start voice command" |
+| TalkBack (Android): same core flows | Android emulator with TalkBack; same coverage |
+| Dynamic Type (iOS): largest size doesn't clip | iOS Accessibility → Text Size → largest; all screens usable |
+| Performance: account list scroll 60fps | Flipper / Perf Monitor: no dropped frames during fast scroll |
+| Performance: cold launch < 2.5s (iPhone SE 3) | Stopwatch: cold launch from icon to interactive home |
+| Performance: warm launch < 0.8s | Second launch (app in memory): time to interactive |
+| Memory: peak < 150MB during full demo path | Instruments: memory usage through full account visit flow |
+| No Hermes JS errors | Production build: zero red-box errors |
+| Feature freeze: no new features after 5pm | All remaining PRs are bug fixes, tests, or docs only |
+
+**Tablet layout implementation:**
+
+```typescript
+// src/hooks/useTabletLayout.ts
+import { useWindowDimensions } from 'react-native';
+
+export function useTabletLayout() {
+  const { width } = useWindowDimensions();
+  return {
+    isTablet: width >= 768,
+    isMediumTablet: width >= 1024,
+    isLargeTablet: width >= 1280,
+    splitPaneLeftWidth: Math.min(360, width * 0.35),
+  };
+}
+```
+
+```typescript
+// app/(tabs)/index.tsx — tablet-aware account list
+import { useTabletLayout } from '../../src/hooks/useTabletLayout';
+import { View } from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+
+export default function AccountListScreen() {
+  const { isTablet } = useTabletLayout();
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handleSelectAccount = (id: string) => {
+    if (isTablet) {
+      setSelectedAccountId(id);  // show in right panel
+    } else {
+      router.push(`/account/${id}`);  // navigate (phone)
+    }
+  };
+
+  if (isTablet) {
+    return (
+      <View className="flex-1 flex-row">
+        <View style={{ width: splitPaneLeftWidth }} className="border-r border-gray-200">
+          <AccountList onSelectAccount={handleSelectAccount} selectedId={selectedAccountId} />
+        </View>
+        <View className="flex-1">
+          {selectedAccountId ? (
+            <AccountDetail accountId={selectedAccountId} />
+          ) : (
+            <EmptyState message="Select an account" />
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  return <AccountList onSelectAccount={handleSelectAccount} />;
+}
+```
+
+**Accessibility patterns:**
+
+```typescript
+// Every interactive element must have these:
+<TouchableOpacity
+  accessible={true}
+  accessibilityLabel="Add Pale Ale to order"   // human-readable label
+  accessibilityHint="Double-tap to add one keg of Pale Ale to the current order"  // what happens
+  accessibilityRole="button"
+  accessibilityState={{ disabled: isLoading }}
+  onPress={handleAdd}
+>
+  <Text>Add</Text>
+</TouchableOpacity>
+
+// Lists must announce count:
+<FlashList
+  accessibilityLabel={`Account list, ${accounts.length} accounts`}
+  ...
+/>
+
+// Loading states must be announced:
+{isLoading && (
+  <View accessibilityLiveRegion="polite" accessibilityLabel="Loading accounts">
+    <LoadingSkeleton />
+  </View>
+)}
+```
+
+---
+
+### Day 7 — Documentation, Polish & Submission (Sunday)
+
+**Theme: "Shipped."**
+
+**Morning (4 hrs): Final bug fixes + submission prep**
+
+```bash
+# Run the full test suite one more time
+npx jest --coverage
+maestro test maestro/flows/
+
+# Run TypeScript strict check
+npx tsc --noEmit
+
+# Run ESLint
+npx eslint src/ app/ --ext .ts,.tsx
+
+# Check for any console.log (none in production)
+grep -r "console\.log" src/ app/ | grep -v "// allowed"
+
+# Build production iOS
+eas build --platform ios --profile production
+
+# Build production Android
+eas build --platform android --profile production
+```
+
+**Afternoon (4 hrs): Store submission**
+
+See §21 for the full App Store and Google Play submission checklist.
+
+**Targets by end of Day 7:**
+
+| Target | Done? |
+|---|---|
+| iOS production build passes in EAS | |
+| Android production build passes in EAS | |
+| All Preamble checklist items checked off | |
+| App Store metadata complete | |
+| App Store screenshots uploaded (6 sets) | |
+| Privacy Manifest complete | |
+| App submitted to App Store Review | |
+| Google Play metadata complete | |
+| Google Play screenshots uploaded | |
+| Data Safety form complete | |
+| App submitted to Google Play Review | |
+| User guide PDF exported and hosted | |
+| CHANGELOG.md v1.0.0 written | |
+| README.md complete | |
+
+---
+
+## §10 — Development Environment
+
+### 10.1 Machine requirements
+
+- Mac (required for iOS builds) — Apple Silicon preferred
+- macOS 14.0+
+- Xcode 16.0+
+- Android Studio Hedgehog+
+- Node.js 20.x
+- npm 10.x or pnpm 9.x
+
+### 10.2 `.env.local` (never commit)
+
+```bash
+# Salesforce
+EXPO_PUBLIC_SF_INSTANCE_URL=https://ohanafy--dev.sandbox.my.salesforce.com
+EXPO_PUBLIC_SF_CLIENT_ID=3MVG9...your_connected_app_client_id...
+
+# Anthropic AI
+ANTHROPIC_API_KEY=sk-ant-...
+# NOTE: This is fetched from Salesforce at auth time and stored in SecureStore.
+# The above is for local development only.
+
+# Observability
+SENTRY_DSN=https://...@sentry.io/...
+EXPO_PUBLIC_POSTHOG_API_KEY=phc_...
+EXPO_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+
+# Test data (development only)
+EXPO_PUBLIC_USE_SEED_DATA=true
+```
+
+### 10.3 `CLAUDE.md` (session context for Claude Code)
+
+```markdown
+# Ohanafy Field — Claude Code Session Context
+
+## What this is
+A production-quality React Native (Expo) mobile app for field sales reps at beverage
+distributors and breweries. Offline-first, AI-powered, ZPL label printing.
+Targeting App Store + Google Play v1.0.0.
+
+## Session start
+1. Read OHANAFY-FIELD-PRODUCT-BIBLE.md §9 to find today's day
+2. Read today's targets
+3. Check which targets are incomplete (look for [ ] in §25 today's retro)
+4. Report your plan, then start
+
+## Non-negotiables (§0)
+Offline first. Tests before features. TypeScript strict. Accessibility always.
+AI never invents data. Feature freeze Day 6 5pm.
+
+## Stack
+Expo SDK 52, TypeScript strict, Expo Router v3, NativeWind v4,
+WatermelonDB, TanStack Query v5, Zustand, Reanimated v3, FlashList,
+@react-native-voice/voice, Zebra Link-OS (custom Expo module),
+Anthropic Claude Sonnet, Sentry, PostHog
+
+## Conventions
+- All components: TypeScript strict, no `any`, accessibility labels on every interactive element
+- All AI outputs: have Accept/Edit/Reject path — never locked
+- All WatermelonDB writes: inside `database.write(async () => { ... })`
+- All Salesforce API calls: via `src/sync/sf-client.ts` (handles token refresh)
+- All errors: caught, logged to Sentry, shown to user with a helpful message
+- All new features: unit test + E2E Maestro flow before marking done
+
+## Domain: beverage field sales
+Rep = Jake. Accounts = bars/stores he visits. Orders = cases/kegs placed.
+Depletions, STW, CDA, three-tier — see §23 for full vocabulary.
+NEVER use brewery language (fermenter, brewhouse, etc.) — Jake is a distributor rep.
+
+## AI key management
+The Anthropic API key is retrieved from Salesforce after OAuth and stored in SecureStore.
+In development: use `ANTHROPIC_API_KEY` from `.env.local`.
+Never hardcode. Never log the key.
+
+## Testing
+Unit: `npx jest`
+E2E: `maestro test maestro/flows/[flow].yaml`
+Type check: `npx tsc --noEmit`
+Lint: `npx eslint src/ app/ --ext .ts,.tsx`
+
+## Git convention
+feat(screen): add account search
+fix(sync): retry failed queue items correctly
+test(ai): add fixture tests for order interpretation
+a11y(account): add VoiceOver labels to account card
+perf(list): optimize FlashList estimatedItemSize
+```
+
+---
+
+## §11 — CI/CD Pipeline
+
+### 11.1 GitHub Actions workflows
+
+**`ci.yml` — runs on every push and PR:**
+
+```yaml
+name: CI
+on:
+  push:
+    branches: ['*']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest   # macos for native module compilation
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - uses: expo/expo-github-action@v8
+        with: { eas-version: latest, token: ${{ secrets.EXPO_TOKEN }} }
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npx eslint src/ app/ --ext .ts,.tsx --max-warnings 0
+      - run: npx jest --ci --coverage --coverageThreshold '{"global":{"lines":80}}'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  maestro-e2e:
+    runs-on: macos-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - name: Install Maestro
+        run: curl -fsSL "https://get.maestro.mobile.dev" | bash
+      - name: Build Expo for iOS Simulator
+        run: eas build --platform ios --profile test --local
+      - name: Run Maestro flows
+        run: ~/.maestro/bin/maestro test maestro/flows/
+        env:
+          MAESTRO_TEST_MODE: "true"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+**`eas-preview.yml` — builds a preview on every PR:**
+
+```yaml
+name: EAS Preview Build
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: expo/expo-github-action@v8
+        with: { eas-version: latest, token: ${{ secrets.EXPO_TOKEN }} }
+      - run: npm ci
+      - name: Build preview
+        run: eas build --platform all --profile preview --non-interactive
+      - name: Comment PR with build links
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '📱 Preview builds ready. Install via EAS dashboard.'
+            })
+```
+
+**`eas-production.yml` — production build on version tag:**
+
+```yaml
+name: EAS Production Build + Submit
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-and-submit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: expo/expo-github-action@v8
+        with: { eas-version: latest, token: ${{ secrets.EXPO_TOKEN }} }
+      - run: npm ci
+      - name: Build production
+        run: eas build --platform all --profile production --non-interactive
+      - name: Submit to stores
+        run: eas submit --platform all --latest --non-interactive
+```
+
+### 11.2 `eas.json`
+
+```json
+{
+  "cli": { "version": ">= 7.0.0" },
+  "build": {
+    "test": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": true,
+        "buildConfiguration": "Debug"
+      },
+      "android": {
+        "buildType": "apk"
+      },
+      "env": {
+        "EXPO_PUBLIC_USE_SEED_DATA": "true"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "ios": {
+        "buildConfiguration": "Release"
+      },
+      "android": {
+        "buildType": "app-bundle"
+      },
+      "env": {
+        "EXPO_PUBLIC_USE_SEED_DATA": "false"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "daniel@ohanafy.com",
+        "ascAppId": "FILL_IN_FROM_ASC",
+        "appleTeamId": "FILL_IN_FROM_APPLE_DEV"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./google-service-account.json",
+        "track": "internal"
+      }
+    }
+  }
+}
+```
+
+---
+
+## §12 — Testing Strategy
+
+### 12.1 Test pyramid
+
+```
+                    ┌─────────────┐
+                    │  E2E (Maestro)│
+                    │  6 flows     │
+                   ┌┴─────────────┴┐
+                   │ Integration    │
+                   │ (Jest, WDB)   │
+                   │ 15 test files  │
+                  ┌┴───────────────┴┐
+                  │  Unit (Jest)    │
+                  │  AI tools       │
+                  │  ZPL templates  │
+                  │  Sync engine    │
+                  │  Business logic │
+                  │  40+ test files │
+                  └─────────────────┘
+```
+
+### 12.2 Coverage targets
+
+| Package | Line coverage | Branch coverage |
+|---|---|---|
+| `src/ai/tools/` | ≥ 90% | ≥ 85% |
+| `src/ai/memory/` | ≥ 85% | ≥ 80% |
+| `src/zpl/templates/` | 100% | ≥ 90% |
+| `src/sync/` | ≥ 85% | ≥ 80% |
+| `src/utils/` | ≥ 90% | ≥ 85% |
+| `src/db/repositories/` | ≥ 80% | ≥ 75% |
+| `src/components/` (logic only) | ≥ 70% | ≥ 65% |
+
+### 12.3 Test patterns
+
+**AI tool handler tests (fixture-based — no real API calls in CI):**
+
+```typescript
+// __tests__/unit/ai/interpret-order.test.ts
+import { describe, it, expect, vi } from 'jest';
+import { createInterpretOrderTool } from '../../../src/ai/tools/interpret-order';
+import { demoCatalog } from '../../../src/data/test-fixtures/catalog';
+
+// Mock the Anthropic SDK
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = {
+      create: vi.fn(),
+    };
+  },
+}));
+
+describe('interpretOrderTool', () => {
+  const tool = createInterpretOrderTool();
+
+  describe('keg orders', () => {
+    it('interprets "2 kegs pale ale" correctly', async () => {
+      const result = await tool.handler({
+        transcript: '2 kegs pale ale',
+        currentOrder: [],
+        productCatalog: demoCatalog,
+      });
+      expect(result.itemsToAdd).toHaveLength(1);
+      expect(result.itemsToAdd[0]).toMatchObject({
+        productId: 'pale-ale-half-bbl',
+        quantity: 2,
+        unit: 'keg',
+      });
+      expect(result.confidence).toBe('high');
+    });
+
+    it('interprets "couple kegs" as quantity 2', async () => {
+      const result = await tool.handler({
+        transcript: 'couple kegs pale ale',
+        currentOrder: [],
+        productCatalog: demoCatalog,
+      });
+      expect(result.itemsToAdd[0].quantity).toBe(2);
+    });
+
+    it('returns low confidence for unknown product', async () => {
+      const result = await tool.handler({
+        transcript: 'add 3 kegs of whatever',
+        currentOrder: [],
+        productCatalog: demoCatalog,
+      });
+      expect(result.confidence).toBe('low');
+    });
+
+    it('does not modify currentOrder directly', async () => {
+      const currentOrder = [{ productId: 'bud-light-case', quantity: 1, unit: 'case' as const }];
+      const original = [...currentOrder];
+      await tool.handler({ transcript: 'add 2 kegs pale ale', currentOrder, productCatalog: demoCatalog });
+      expect(currentOrder).toEqual(original);  // immutable
+    });
+  });
+
+  describe('Red Bull orders', () => {
+    it('interprets "case of red bull sugarfree" correctly', async () => {
+      const result = await tool.handler({
+        transcript: 'a case of red bull sugarfree',
+        currentOrder: [],
+        productCatalog: demoCatalog,
+      });
+      expect(result.itemsToAdd[0].productId).toBe('red-bull-sf-24pk');
+      expect(result.itemsToAdd[0].unit).toBe('case');
+    });
+  });
+});
+```
+
+**ZPL template snapshot tests:**
+
+```typescript
+// __tests__/unit/zpl/shelf-talker.test.ts
+import { generateShelfTalker } from '../../../src/zpl/templates/shelf-talker';
+
+describe('generateShelfTalker', () => {
+  it('generates valid ZPL II structure', () => {
+    const zpl = generateShelfTalker({
+      productName: 'Yellowhammer Pale Ale',
+      skuCode: 'YH-PA-HB',
+      pricePerCase: 142.00,
+    });
+    expect(zpl).toMatch(/^\^XA/);
+    expect(zpl).toMatch(/\^XZ$/);
+    expect(zpl).toContain('^CI28');     // UTF-8 charset
+    expect(zpl).toContain('^PW400');    // 2.5" × 8dpmm × 20 = width command
+    expect(zpl).toMatchSnapshot();      // visual regression
+  });
+
+  it('does not overflow 2.5" width (all ^FO x < 380)', () => {
+    const zpl = generateShelfTalker({
+      productName: 'A Very Long Product Name That Might Overflow',
+      skuCode: 'VL-PROD-HB',
+      pricePerCase: 999.99,
+    });
+    const xCoords = [...zpl.matchAll(/\^FO(\d+),/g)].map(m => parseInt(m[1]));
+    expect(Math.max(...xCoords)).toBeLessThan(380);
+  });
+
+  it('truncates product name > 22 chars to prevent overflow', () => {
+    const zpl = generateShelfTalker({
+      productName: 'This Name Is Way Too Long For The Label',
+      skuCode: 'TN-TOO-LONG',
+      pricePerCase: 50.00,
+    });
+    expect(zpl).not.toContain('This Name Is Way Too Long For The Label');
+  });
+});
+```
+
+**Sync engine integration tests:**
+
+```typescript
+// __tests__/integration/sync/queue-processor.test.ts
+import { Database } from '@nozbe/watermelondb';
+import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite';
+import { processQueueItem } from '../../../src/sync/queue-processor';
+import schema from '../../../src/db/schema';
+import { mockSfClient } from '../../mocks/sf-client';
+
+describe('processQueueItem — CREATE_ORDER', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    const adapter = new SQLiteAdapter({ schema, dbName: ':memory:' });
+    db = new Database({ adapter, modelClasses: [...allModels] });
+    await seedTestData(db);
+  });
+
+  it('creates order in Salesforce and updates local sync_status', async () => {
+    mockSfClient.createRecord.mockResolvedValue({ id: 'SF_ORDER_001' });
+
+    const queueItem = await db.get('sync_queue').find('local_order_001');
+    await processQueueItem(queueItem, db, mockSfClient);
+
+    const order = await db.get('orders').find('local_order_001');
+    expect(order.syncStatus).toBe('synced');
+    expect(order.sfId).toBe('SF_ORDER_001');
+    expect(mockSfClient.createRecord).toHaveBeenCalledWith('ohfy_field__Order__c', expect.any(Object));
+  });
+
+  it('increments attempts on Salesforce API failure', async () => {
+    mockSfClient.createRecord.mockRejectedValue(new Error('SF timeout'));
+
+    const queueItem = await db.get('sync_queue').find('local_order_001');
+    await expect(processQueueItem(queueItem, db, mockSfClient)).rejects.toThrow();
+
+    const updated = await db.get('sync_queue').find('local_order_001');
+    expect(updated.attempts).toBe(1);
+    expect(updated.lastError).toContain('SF timeout');
+    expect(updated.status).toBe('pending');  // retryable
+  });
+});
+```
+
+### 12.4 E2E Maestro flows (all required)
+
+| Flow | File | What it covers |
+|---|---|---|
+| Onboarding | `onboarding.yaml` | Welcome → SF connect → printer pair → first visit guided |
+| Account visit (main happy path) | `account-visit.yaml` | List → detail → AI insight → order → confirm → sync |
+| Voice order | `voice-order.yaml` | Voice command → order add → accept → reject → edit |
+| Offline sync | `offline-sync.yaml` | Create order offline → reconnect → sync → SF record exists |
+| ZPL print | `zpl-print.yaml` | Select label → preview → print (simulated) → history entry |
+| AI correction learning | `ai-correction-learning.yaml` | Make 3 corrections → run learning agent → insight improves |
+
+---
+
+## §13 — Logging, Error Tracking & Observability
+
+### 13.1 Structured logger
+
+```typescript
+// src/utils/logger.ts
+import * as Sentry from '@sentry/react-native';
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+interface LogContext {
+  [key: string]: unknown;
+}
+
+class Logger {
+  private isDev = __DEV__;
+
+  private log(level: LogLevel, message: string, context?: LogContext) {
+    if (this.isDev) {
+      const emoji = { debug: '🔵', info: '🟢', warn: '🟡', error: '🔴' }[level];
+      console[level === 'debug' ? 'log' : level](`${emoji} [${level.toUpperCase()}] ${message}`, context ?? '');
+    }
+
+    if (level === 'error') {
+      Sentry.captureMessage(message, { level, extra: context });
+    } else if (level === 'warn') {
+      Sentry.addBreadcrumb({ message, level, data: context });
+    }
+  }
+
+  debug(context: LogContext, message: string) { this.log('debug', message, context); }
+  info(context: LogContext, message: string)  { this.log('info',  message, context); }
+  warn(context: LogContext, message: string)  { this.log('warn',  message, context); }
+  error(context: LogContext | Error, message: string) {
+    if (context instanceof Error) {
+      Sentry.captureException(context);
+      this.log('error', message, { error: context.message });
+    } else {
+      this.log('error', message, context);
+    }
+  }
+}
+
+export const logger = new Logger();
+```
+
+### 13.2 Sentry configuration
+
+```typescript
+// app/_layout.tsx — root layout
+import * as Sentry from '@sentry/react-native';
+
+Sentry.init({
+  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN!,
+  environment: __DEV__ ? 'development' : 'production',
+  tracesSampleRate: __DEV__ ? 1.0 : 0.2,    // 20% of production sessions traced
+  enableAutoSessionTracking: true,
+  integrations: [
+    Sentry.reactNativeTracingIntegration(),
+  ],
+  beforeSend(event) {
+    // Scrub any accidental PII
+    if (event.request?.data) {
+      delete event.request.data.sf_access_token;
+      delete event.request.data.anthropic_api_key;
+    }
+    return event;
+  },
+});
+```
+
+### 13.3 PostHog analytics events
+
+```typescript
+// src/utils/analytics.ts
+import PostHog from 'posthog-react-native';
+
+export const analytics = new PostHog(
+  process.env.EXPO_PUBLIC_POSTHOG_API_KEY!,
+  { host: process.env.EXPO_PUBLIC_POSTHOG_HOST }
+);
+
+// Capture events — all business events go through here
+export const events = {
+  accountVisitStarted: (accountId: string, accountType: string) =>
+    analytics.capture('account_visit_started', { accountId, accountType }),
+
+  orderCreated: (accountId: string, totalAmount: number, itemCount: number, createdOffline: boolean) =>
+    analytics.capture('order_created', { accountId, totalAmount, itemCount, createdOffline }),
+
+  voiceCommandUsed: (action: string, confidence: string, accepted: boolean) =>
+    analytics.capture('voice_command_used', { action, confidence, accepted }),
+
+  labelPrinted: (templateType: string, printerModel: string, success: boolean) =>
+    analytics.capture('label_printed', { templateType, printerModel, success }),
+
+  aiFeedbackGiven: (feedbackType: string, featureName: string) =>
+    analytics.capture('ai_feedback_given', { feedbackType, featureName }),
+
+  syncCompleted: (trigger: string, pushed: number, pulled: number, duration: number) =>
+    analytics.capture('sync_completed', { trigger, pushed, pulled, duration }),
+
+  learningAgentRan: (memoriesCreated: number, memoriesUpdated: number, eventsProcessed: number) =>
+    analytics.capture('learning_agent_ran', { memoriesCreated, memoriesUpdated, eventsProcessed }),
+};
+```
+
+### 13.4 Error boundary (every screen)
+
+```typescript
+// src/components/shared/ErrorBoundary.tsx
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import * as Sentry from '@sentry/react-native';
+import { logger } from '../../utils/logger';
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  screenName: string;
+}
+
+interface State { hasError: boolean; error: Error | null; }
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    logger.error(error, `ErrorBoundary caught error on ${this.props.screenName}`);
+    Sentry.captureException(error, { extra: { componentStack: info.componentStack } });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <View className="flex-1 items-center justify-center p-6">
+          <Text className="text-2xl font-bold text-ink mb-2">Something went wrong</Text>
+          <Text className="text-gray-500 text-center mb-6">
+            {this.state.error?.message ?? 'An unexpected error occurred'}
+          </Text>
+          <TouchableOpacity
+            className="bg-ohanafy-primary rounded-xl px-6 py-3"
+            onPress={() => this.setState({ hasError: false, error: null })}
+            accessibilityLabel="Try again"
+          >
+            <Text className="text-white font-semibold">Try Again</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+```
+
+---
+
+## §14 — Accessibility
+
+### 14.1 iOS VoiceOver requirements
+
+Every screen must be navigable using VoiceOver with a Bluetooth keyboard or swipe-only. Test checklist for each screen:
+
+- [ ] All interactive elements are focusable (swiping reaches every button)
+- [ ] Every button has `accessibilityLabel` (describes the action) + `accessibilityHint` (describes what happens)
+- [ ] Every image has `accessibilityLabel` or `accessible={false}` if decorative
+- [ ] Dynamic content changes are announced (`accessibilityLiveRegion="polite"`)
+- [ ] Custom actions (swipe-to-delete) have `accessibilityActions` alternatives
+- [ ] Modal and sheet focus is trapped correctly when open
+- [ ] Tab order is logical (matches visual order on screen)
+
+### 14.2 Android TalkBack requirements
+
+Same as VoiceOver. Additionally:
+- [ ] `contentDescription` prop used where native Android requires it
+- [ ] Focus order verified via Android Accessibility Scanner
+- [ ] Double-tap triggers same as single-tap action
+
+### 14.3 Dynamic type support
+
+```typescript
+// src/constants/theme.ts
+// All font sizes must scale with system preferences
+import { PixelRatio } from 'react-native';
+
+export const scaledFontSize = (size: number) =>
+  size * PixelRatio.getFontScale();
+
+// In NativeWind config: enable `allowsFontScaling` globally
+// In all Text components: allowFontScaling={true} (default — don't override)
+// Ensure containers use flexWrap or minHeight, never fixed height
+```
+
+### 14.4 Minimum tap target enforcement
+
+All tappable elements must be at least 44×44pt. Use this wrapper for small icons:
+
+```typescript
+// src/components/shared/TapTarget.tsx
+export function TapTarget({ children, onPress, accessibilityLabel, ...props }: TapTargetProps) {
+  return (
+    <TouchableOpacity
+      hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+      style={{ minWidth: 44, minHeight: 44, alignItems: 'center', justifyContent: 'center' }}
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+      accessible={true}
+      {...props}
+    >
+      {children}
+    </TouchableOpacity>
+  );
+}
+```
+
+---
+
+## §15 — Tablet & Large Screen Layouts
+
+### 15.1 Breakpoints
+
+| Width | Mode | Layout |
+|---|---|---|
+| < 768pt | Phone portrait | Single column, full-screen navigation |
+| 768–1023pt | Tablet portrait / small tablet | Split pane (35% / 65%) |
+| ≥ 1024pt | Tablet landscape / large tablet | Split pane (30% / 70%), wider detail |
+
+### 15.2 Split pane screens
+
+| Screen | Phone behavior | Tablet behavior |
+|---|---|---|
+| Home (account list) | Full screen list | Left: list; Right: detail or empty state |
+| Order entry | Full screen modal | Right panel slide-over, list stays visible |
+| Visit log | Full screen | Inline in right panel |
+| Label preview | Full screen modal | Right panel, product list stays left |
+| Settings | Full screen tab | Split: settings categories left, content right |
+
+### 15.3 iPad-specific considerations
+
+- Use `UIUserInterfaceIdiom` detection for true iPad-specific layouts
+- Support Split View and Slide Over (don't lock to portrait)
+- Support Sidecar / Stage Manager (test at window sizes 320–1366pt)
+- Keyboard shortcuts for power users: ⌘+N for new order, ⌘+F for search
+
+---
+
+## §16 — Dark Mode & Theming
+
+### 16.1 Implementation
+
+NativeWind v4 supports `dark:` variants. The system color scheme drives dark mode — no manual toggle (follow system preference).
+
+```typescript
+// app/_layout.tsx
+import { useColorScheme } from 'nativewind';
+
+export default function RootLayout() {
+  const { colorScheme } = useColorScheme();
+  // colorScheme is 'light' | 'dark' | null
+  // NativeWind handles dark: variants automatically
+}
+```
+
+```javascript
+// tailwind.config.js — dark mode colors
+theme: {
+  extend: {
+    colors: {
+      'ohanafy': {
+        // Light mode
+        primary: '#HEX_LIGHT',
+        bg: '#FFFFFF',
+        ink: '#111827',
+        surface: '#F9FAFB',
+        border: '#E5E7EB',
+
+        // Dark mode counterparts defined in dark: variants
+        'dark-bg': '#0F172A',
+        'dark-ink': '#F1F5F9',
+        'dark-surface': '#1E293B',
+        'dark-border': '#334155',
+      }
+    }
+  }
+}
+```
+
+### 16.2 Dark mode testing checklist
+
+Run through every screen with system dark mode enabled:
+
+- [ ] No white flashes on navigation
+- [ ] No hardcoded white/black colors anywhere in components (all use theme tokens)
+- [ ] StatusBar color changes appropriately
+- [ ] Zebra print preview: PNG from Labelary still readable
+- [ ] InsightBanner banner color: readable in both modes
+- [ ] SyncStatusBar: visible in both modes
+- [ ] Offline banner: visible in both modes
+- [ ] Error states: visible in both modes
+
+---
+
+## §17 — Security & Privacy
+
+### 17.1 Credential storage
+
+| Credential | Storage | Notes |
+|---|---|---|
+| Salesforce access token | expo-secure-store (iOS Keychain / Android Keystore) | Encrypted at rest |
+| Salesforce refresh token | expo-secure-store | Same |
+| Anthropic API key | expo-secure-store (retrieved from SF at login) | Never in code or logs |
+| Rep biometric preference | expo-secure-store | Encrypted |
+| Printer last-connected address | expo-secure-store | Minor sensitivity |
+
+**Rule: Zero credentials in `AsyncStorage`, `MMKV`, or any unencrypted store.**
+
+### 17.2 Biometric app lock
+
+```typescript
+// src/auth/biometric.ts
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export async function promptBiometric(): Promise<boolean> {
+  const hasHardware = await LocalAuthentication.hasHardwareAsync();
+  const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+
+  if (!hasHardware || !isEnrolled) {
+    // Fall back to PIN/password on devices without biometrics
+    return promptPinFallback();
+  }
+
+  const result = await LocalAuthentication.authenticateAsync({
+    promptMessage: 'Unlock Ohanafy Field',
+    cancelLabel: 'Use PIN',
+    fallbackLabel: 'Enter PIN',
+    disableDeviceFallback: false,
+  });
+
+  return result.success;
+}
+```
+
+### 17.3 Data privacy
+
+**What is stored on device:**
+- Account names, addresses, contacts — business data, no personal consumer data
+- Visit notes authored by the rep
+- Order history
+- AI memories — rep patterns, no customer PII beyond account name
+
+**What is transmitted:**
+- All device-to-Salesforce communication is over HTTPS/TLS 1.3
+- All device-to-Anthropic communication is over HTTPS (official SDK)
+- No data is shared with third parties beyond Sentry (error reports, scrubbed of tokens) and PostHog (analytics, no PII)
+
+**iOS Privacy Manifest (PrivacyInfo.xcprivacy):**
+
+Required for App Store submission. Declare:
+- `NSPrivacyAccessedAPICategoryFileTimestamp` — file system access for WatermelonDB
+- `NSPrivacyAccessedAPICategoryDiskSpace` — SQLite operations
+- `NSPrivacyAccessedAPICategoryUserDefaults` — expo-secure-store
+- No advertising identifiers used
+
+---
+
+## §18 — Performance Targets & Optimization
+
+### 18.1 Targets (measured on iPhone SE 3 — slowest target)
+
+| Metric | Target | Measured via |
+|---|---|---|
+| Cold launch to interactive | < 2.5s | Manual stopwatch |
+| Warm launch to interactive | < 0.8s | Manual stopwatch |
+| Account list scroll: frame rate | 60fps sustained | Flipper Performance Monitor |
+| Account list: 100 accounts render | < 300ms | `console.time` in development |
+| Order entry: 50 line items | No dropped frames during scroll | Flipper |
+| Voice → interim transcript | < 200ms latency | Observed by user |
+| AI command interpretation | < 1.5s (p95) | Sentry performance |
+| AI visit prep | < 3s (p95) — non-blocking | Sentry performance |
+| App memory peak | < 150MB | Xcode Instruments |
+| App bundle size (iOS IPA) | < 50MB download | EAS build output |
+| App bundle size (Android AAB) | < 40MB download | EAS build output |
+
+### 18.2 Critical optimization patterns
+
+**FlashList for all scrollable lists:**
+```typescript
+// CORRECT — uses FlashList, estimatedItemSize tuned to actual item height
+<FlashList
+  data={accounts}
+  renderItem={({ item }) => <AccountCard account={item} />}
+  estimatedItemSize={110}          // measure real rendered height once
+  keyExtractor={item => item.id}
+  getItemType={item => item.accountType}   // for heterogeneous lists
+/>
+
+// WRONG — never use FlatList for lists > 10 items
+<FlatList ... />
+```
+
+**Memoize expensive computations:**
+```typescript
+// Memoize anything that depends on WatermelonDB observations
+const sortedAccounts = useMemo(
+  () => [...accounts].sort((a, b) => a.name.localeCompare(b.name)),
+  [accounts]
+);
+
+// Memoize rendered components if parent re-renders frequently
+const AccountCardMemo = React.memo(AccountCard, (prev, next) =>
+  prev.account.id === next.account.id && prev.account.updatedAt === next.account.updatedAt
+);
+```
+
+**WatermelonDB query optimization:**
+```typescript
+// CORRECT — indexed query, specific fields
+const urgentAccounts = await database
+  .get<Account>('accounts')
+  .query(
+    Q.where('needs_attention', true),
+    Q.where('is_archived', false),
+    Q.sortBy('last_order_date', Q.asc),
+    Q.take(50),
+  )
+  .fetch();
+
+// WRONG — fetches everything, filters in JS
+const all = await database.get<Account>('accounts').query().fetch();
+const urgent = all.filter(a => a.needsAttention);
+```
+
+---
+
+## §19 — In-App Onboarding
+
+### 19.1 First-run wizard
+
+5 steps. Skippable (but we track skip events in PostHog). Re-launchable from Settings.
+
+| Step | Screen | What happens |
+|---|---|---|
+| 1 | Welcome | Hero illustration, tagline, "Get Started" CTA |
+| 2 | Connect (already done) | Shows connected Salesforce org, rep name, territory |
+| 3 | Your Territory | Map view with territory marker, account count, first sync starts in background |
+| 4 | Pair Your Printer | Bluetooth scan for Zebra printers. "Skip for now" always available |
+| 5 | Guided First Visit | Opens The first account in the list with coach marks pointing to: InsightBanner, VoiceButton, Print Label, Sync indicator |
+
+### 19.2 Coach marks system
+
+```typescript
+// src/components/onboarding/CoachMark.tsx
+interface CoachMarkProps {
+  id: string;           // unique ID — stored in SecureStore when dismissed
+  target: React.RefObject<View>;
+  title: string;
+  body: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export function CoachMark({ id, target, title, body, position }: CoachMarkProps) {
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  useEffect(() => {
+    SecureStore.getItemAsync(`coach_mark_${id}`).then(val => {
+      if (val === 'dismissed') setIsDismissed(true);
+    });
+  }, [id]);
+
+  const dismiss = async () => {
+    await SecureStore.setItemAsync(`coach_mark_${id}`, 'dismissed');
+    setIsDismissed(true);
+    analytics.capture('coach_mark_dismissed', { id });
+  };
+
+  if (isDismissed) return null;
+
+  return (
+    <CoachMarkOverlay target={target} position={position} onDismiss={dismiss}>
+      <Text className="font-bold text-white mb-1">{title}</Text>
+      <Text className="text-white text-sm">{body}</Text>
+      <TouchableOpacity onPress={dismiss} accessibilityLabel="Dismiss tip">
+        <Text className="text-white underline text-sm mt-2">Got it</Text>
+      </TouchableOpacity>
+    </CoachMarkOverlay>
+  );
+}
+```
+
+### 19.3 Coach mark inventory
+
+| ID | Screen | Target element | Message |
+|---|---|---|---|
+| `insight_banner` | Account detail | InsightBanner | "Your AI briefing — surfaces the most important thing to know before you walk in. Tap thumbs up if it helped." |
+| `voice_button` | Account detail | VoiceButton | "Say what you need — 'add 2 kegs pale ale', 'note the tap issue', 'what did I order last time?'" |
+| `sync_status` | Home | SyncStatusBar | "This shows items waiting to sync. Ohanafy Field always works offline — this count will clear when you get signal." |
+| `print_label` | Account detail | Print Label button | "Print a shelf talker or receipt directly to your Zebra printer. No office trip required." |
+| `needs_attention` | Home | Filter button | "Tap 'Needs Attention' to see accounts you haven't visited in 21+ days." |
+
+---
+
+## §20 — In-App Help System
+
+### 20.1 Structure
+
+The user guide is embedded in the app and works offline. It lives at `app/guide/` and renders from static MDX content bundled at build time.
+
+7 sections:
+1. Getting Started (account management, first sync)
+2. Account Visits (pre-call prep, logging visits, notes)
+3. Taking Orders (adding items, voice ordering, confirming)
+4. Voice Commands (what you can say, tips for accuracy)
+5. Label Printing (printer setup, templates, troubleshooting)
+6. AI Features (how the AI learns, reviewing memories, giving feedback)
+7. Troubleshooting (offline issues, sync problems, printer problems)
+
+Full content is in Appendix F.
+
+### 20.2 Contextual help
+
+Every screen has a `?` button (top-right) that opens a bottom sheet with:
+- 3-5 bullet points about what this screen does
+- A link to the relevant guide section
+- A "Contact Support" link (mailto: → prefills with device/OS/version info)
+
+```typescript
+// src/components/shared/HelpButton.tsx
+interface HelpButtonProps {
+  section: GuideSection;
+  tips: string[];
+}
+
+export function HelpButton({ section, tips }: HelpButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <TapTarget
+        onPress={() => setIsOpen(true)}
+        accessibilityLabel={`Help for this screen`}
+        accessibilityHint="Opens tips and link to user guide"
+      >
+        <Text className="text-gray-400 text-lg">?</Text>
+      </TapTarget>
+
+      <BottomSheet isVisible={isOpen} onClose={() => setIsOpen(false)}>
+        <Text className="font-bold text-ink text-lg mb-3">Tips</Text>
+        {tips.map((tip, i) => (
+          <Text key={i} className="text-gray-600 mb-2">• {tip}</Text>
+        ))}
+        <TouchableOpacity
+          onPress={() => router.push(`/guide/${section}`)}
+          accessibilityLabel={`Open user guide section: ${section}`}
+        >
+          <Text className="text-ohanafy-primary font-semibold mt-2">Read the full guide →</Text>
+        </TouchableOpacity>
+      </BottomSheet>
+    </>
+  );
+}
+```
+
+---
+
+## §21 — App Store Submission
+
+### 21.1 Apple App Store checklist
+
+**Before submitting:**
+- [ ] Bundle ID: `com.ohanafy.field` created in Apple Developer Portal
+- [ ] App ID capabilities: Push Notifications, Background Modes (Background Fetch), Bluetooth Always (for printer), Bluetooth Peripheral
+- [ ] Provisioning profile: Distribution (App Store) profile created and downloaded
+- [ ] Certificates: Distribution certificate active in Apple Developer Portal
+- [ ] Privacy Manifest (`PrivacyInfo.xcprivacy`) committed to the Expo project
+- [ ] `app.json` has correct `bundleIdentifier`, `buildNumber`, `version`
+
+**App Store Connect metadata:**
+- [ ] App name: "Ohanafy Field"
+- [ ] Subtitle: "Beverage Field Sales"
+- [ ] Category: Business
+- [ ] Description (4000 chars max) — see Appendix F §6 for draft
+- [ ] Keywords (100 chars max): "field sales, beverage, distributor, offline, voice, ZPL, Zebra, CRM, Salesforce"
+- [ ] Privacy Policy URL: required for B2B apps (host on ohanafy.com)
+- [ ] Support URL: support.ohanafy.com
+
+**Screenshots required:**
+- 6.7" iPhone (1290×2796): 3–10 screenshots
+- 6.1" iPhone (1179×2556): same images are usually reused
+- 12.9" iPad Pro (2048×2732): 3–10 screenshots
+- Screenshots must show real app UI (no mockups)
+- Screenshots to capture: Home, Account Detail with InsightBanner, Voice active, Order Entry, Label Preview, Sync complete
+
+**Review notes (required for Bluetooth apps):**
+> "This app connects to Zebra ZQ520/ZQ630 Bluetooth label printers to print shelf talkers and delivery receipts in the field. The Bluetooth permission is required solely for printer communication. The app does not use Bluetooth for location tracking or any other purpose. Test reviewer note: you can test core app functionality without a printer paired — all features except physical printing are available."
+
+**App Review test account:**
+Create a sandbox Salesforce account with:
+- Username: `appreview@ohanafy.field.test`
+- Password: `OhanafyReview2026!`
+- Pre-populated with 5 test accounts and 10 products
+
+### 21.2 Google Play checklist
+
+**Before submitting:**
+- [ ] `applicationId`: `com.ohanafy.field` set in `app.json`
+- [ ] Keystore generated and backed up securely
+- [ ] `google-service-account.json` generated for EAS Submit
+- [ ] Target SDK: 34 (Android 14)
+
+**Play Console metadata:**
+- [ ] App name: "Ohanafy Field"
+- [ ] Short description (80 chars): "Offline field sales for beverage reps — voice orders, AI insights, ZPL printing"
+- [ ] Full description (4000 chars)
+- [ ] Category: Business
+- [ ] Data safety form complete (see below)
+
+**Data Safety form:**
+| Data type | Collected? | Shared? | Purpose |
+|---|---|---|---|
+| Location | No | No | — |
+| Contacts | No | No | — |
+| Financial info (order amounts) | Yes | No | App functionality |
+| App activity (events, orders) | Yes | No | App functionality |
+| Crash logs | Yes | With Sentry (service provider) | Analytics |
+| App interactions | Yes | With PostHog (service provider) | Analytics |
+| Device ID | Yes (Sentry) | With Sentry | Crash reporting |
+
+**Screenshots required:**
+- Phone (16:9 or 9:16): at least 2 screenshots
+- 7" tablet: at least 2
+- 10" tablet: at least 2
+
+### 21.3 TestFlight distribution (iOS)
+
+```bash
+# Tag the production release
+git tag v1.0.0
+git push --tags
+
+# This triggers eas-production.yml which builds + submits to TestFlight
+
+# Monitor in App Store Connect
+# Internal testers: available in ~15 minutes
+# External testers: available after Apple review (~1-3 days)
+```
+
+---
+
+## §22 — Claude Code Operating Procedure
+
+### 22.1 Session startup protocol
+
+Every Claude Code session:
+
+1. Read this document (`OHANAFY-FIELD-PRODUCT-BIBLE.md`)
+2. Check the daily retro in §25 for today's date — what's incomplete?
+3. Read `CLAUDE.md` for session context
+4. State today's targets and your first planned action
+5. Confirm: "I will not write any feature not in §4's feature inventory"
+6. Begin
+
+### 22.2 TDD workflow
+
+For every new function or module:
+
+```
+Step 1: Write the test (describe → it → expect)
+Step 2: Run the test — confirm it FAILS (red)
+Step 3: Write the minimum implementation to make it pass
+Step 4: Run the test — confirm it PASSES (green)
+Step 5: Refactor if needed — test must stay green
+Step 6: Add edge case tests (empty input, null, large values)
+Step 7: Run coverage check — confirm it meets threshold
+```
+
+Do not proceed to step 3 until step 2 has been confirmed.
+
+### 22.3 Component development workflow
+
+For every new UI component:
+
+```
+Step 1: Write the TypeScript interface (props, return type)
+Step 2: Write the unit test for any logic inside the component
+Step 3: Add accessibility labels to the spec
+Step 4: Implement the component
+Step 5: Test in light mode, dark mode, and tablet layout
+Step 6: Test VoiceOver (iOS) or TalkBack (Android)
+Step 7: Test at largest Dynamic Type size
+```
+
+### 22.4 AI feature development workflow
+
+For every new AI capability:
+
+```
+Step 1: Write the system prompt (see Appendix B for patterns)
+Step 2: Test the prompt manually with 10 sample inputs
+Step 3: Identify failure modes — what inputs break it?
+Step 4: Add guardrails to the prompt for known failure modes
+Step 5: Write Zod schema for the tool input and output
+Step 6: Implement the tool handler (pure TypeScript — no AI inside the handler)
+Step 7: Write fixture tests for the handler
+Step 8: Wire the tool into the relevant agent
+Step 9: Add FeedbackCapture to the UI surface
+Step 10: Confirm feedback events are written to WatermelonDB
+```
+
+### 22.5 Commit conventions
+
+```
+feat(account): add account search with debounce
+fix(sync): handle SF session expiry during queue flush
+test(ai): add fixture tests for keg quantity interpretation
+a11y(order): add VoiceOver labels to line item stepper
+perf(list): tune FlashList estimatedItemSize to 110
+chore(deps): bump expo-secure-store to 13.0.0
+docs(guide): add troubleshooting section for printer pairing
+```
+
+### 22.6 When stuck
+
+If stuck on a problem for > 20 minutes:
+
+1. Write the problem in a comment at the top of the file: `// STUCK: [description]`
+2. Write two alternative approaches, even if they feel incomplete
+3. Pick the simpler one and implement it partially
+4. Flag it in the daily retro as "needs revisit"
+
+Do not spend more than 45 minutes on any single problem without taking an alternative path. Progress on the overall day's targets is more valuable than perfection on one feature.
+
+### 22.7 Code quality gates (run before every commit)
+
+```bash
+# These must all pass before committing
+npx tsc --noEmit            # TypeScript strict check
+npx eslint src/ app/        # Linting
+npx jest --passWithNoTests  # Tests (at minimum, no new failures)
+```
+
+---
+
+## §23 — Domain Conventions
+
+### 23.1 Vocabulary — field sales rep (Jake Thornton)
+
+This is a **field sales rep at a beverage distributor**, not a brewery. Use distributor vocabulary.
+
+**Core terms:**
+- **Account**: a retail account the rep calls on (bar, restaurant, grocery store, c-store)
+- **Visit**: a physical account call — logged with notes and outcomes
+- **Order**: cases or kegs placed with the wholesaler during a visit
+- **Route**: the rep's daily sequence of accounts
+- **Territory**: geographic area assigned to this rep (e.g., Birmingham South)
+- **Cases**: the unit of measure for packaged product (bottles, cans, cartons)
+- **Keg / 1/2 bbl**: draft beer unit — 15.5 gallons; most common
+- **1/6 bbl**: sixth-barrel keg — 5.16 gallons; common for craft accounts
+- **Depletion**: how much the retailer actually sold to consumers (reported back)
+- **STW**: ship-to-wholesaler — when the supplier delivers to Yellowhammer's warehouse
+- **Back-of-house**: the stockroom and cooler — where reps physically walk accounts
+- **Facing**: a product's shelf slots at retail; "gaining facings" = more shelf space
+- **Shelf gap**: an out-of-stock position visible at the shelf level
+- **CDA**: customer development agreement — cash the distributor pays to develop an account
+- **Chain program**: negotiated promo deal with a chain retailer (Publix, Kroger, etc.)
+- **Days-on-hand (DOH)**: inventory / daily depletion rate — 14 DOH = 2 weeks of stock
+- **Tap**: draft beer dispense system; keg connects to tap line
+
+**DO NOT USE (these are brewery words — Jake doesn't work at a brewery):**
+- Fermenter, brite tank, brewhouse, cellar, packaging line
+- Hop contracts, grain bill, yeast generations, mash
+- "Tank capacity" as a rep constraint
+
+### 23.2 Account types
+
+| Type constant | Description | Examples |
+|---|---|---|
+| `on_premise` | Sold where consumed | Bars, restaurants, hotels, stadiums |
+| `off_premise_chain` | Packaged product, chain retail | Publix, Kroger, Walmart, Target |
+| `off_premise_indie` | Packaged product, independent | Local package stores, boutique grocers |
+| `convenience` | Single-serve, grab-and-go | Circle K, RaceTrac, Wawa |
+
+### 23.3 Product units
+
+| Unit constant | Label | Typical products |
+|---|---|---|
+| `keg_half` | 1/2 bbl (15.5 gal) | All major beer brands |
+| `keg_sixth` | 1/6 bbl (5.16 gal) | Craft beers, limited draft |
+| `case_24` | 24 × 12oz | Cans and bottles |
+| `case_12` | 12 × 12oz | Some craft SKUs |
+| `case_4pk` | 6 × 4pk (24 units) | Red Bull 4-packs |
+| `single` | Individual unit | Rarely ordered; mostly for reporting |
+
+---
+
+## §24 — Architecture Decision Records
+
+Append new ADRs here as decisions are made. Never modify or delete existing ADRs.
+
+**ADR-001: React Native (Expo) over PWA**
+- Date: Day 1
+- Decision: Ship as Expo React Native, not a Next.js PWA
+- Rationale: Native Bluetooth (Zebra printing), native speech recognition (better accuracy), App Store/Play Store distribution, better offline performance (SQLite vs IndexedDB), native biometric auth, native push notifications
+- Trade-off: Longer build times, no instant web deploy; accepted
+
+**ADR-002: WatermelonDB over other RN offline solutions**
+- Date: Day 1
+- Decision: WatermelonDB for local data store
+- Rationale: SQLite-backed (not IndexedDB); reactive queries that power reactive UI; designed for RN; migrations system; better performance than Realm at scale; more permissive license than Realm
+- Alternatives considered: Realm (licensing concerns), expo-sqlite direct (too low-level), MMKV (no structured queries)
+
+**ADR-003: Claude Sonnet for all AI features**
+- Date: Day 1
+- Decision: claude-sonnet-4-20250514 for all features
+- Rationale: Sufficient intelligence for beverage domain tool use; fast enough for voice loop; cost-effective for per-rep API usage model
+- Review trigger: If voice command p95 latency > 2s; switch to Haiku for voice, Sonnet for prep
+
+**ADR-004: Zebra Link-OS via custom Expo module**
+- Date: Day 3
+- Decision: Write a thin Expo native module wrapping Zebra's official iOS/Android SDK
+- Rationale: Zebra's SDK is the official, supported path; community packages are unmaintained; thin wrapper takes < 4 hours and gives us full SDK access
+- Alternatives considered: react-native-bluetooth-escpos-printer (generic, not officially Zebra-supported), BLE raw writes (too low-level, ZPL requires connection protocol)
+
+**ADR-005: AI API called directly from device**
+- Date: Day 1
+- Decision: Device calls Anthropic API directly; no intermediate server
+- Rationale: Simplifies architecture; reduces latency; AI key is per-company and stored in SecureStore; acceptable for B2B use case where companies manage their own keys
+- Trade-off: API key in device memory (mitigated by SecureStore); accepted for B2B context
+
+---
+
+## §25 — Daily Retrospectives
+
+Fill in at end of each day. Be honest. If a target was missed, say why.
+
+### Day 1 Retro
+- Targets completed: [ ]
+- Targets missed: [ ]
+- Blockers encountered:
+- What Claude Code did well:
+- Where Claude Code needed correction:
+- Decisions made (add to §24 if architectural):
+- Tomorrow's first two targets:
+
+### Day 2 Retro
+(same format)
+
+### Day 3 Retro
+(same format)
+
+### Day 4 Retro
+(same format)
+
+### Day 5 Retro
+(same format)
+
+### Day 6 Retro
+(same format — also run the full Preamble checklist tonight)
+
+### Day 7 Retro
+- Submitted to App Store: Y/N
+- Submitted to Google Play: Y/N
+- What still needs work post-launch:
+- Version 1.0.1 backlog (list 3 highest priority items):
+
+---
+
+# Appendix A — ZPL Template Library (Production-Ready)
+
+## A.1 Shelf Talker (2.5" × 1.5", 8 dpmm = 203 dpi)
+
+ZQ520/ZQ630 most common template. Used at on-premise and off-premise shelf level.
+
+```typescript
+// src/zpl/templates/shelf-talker.ts
+
+export interface ShelfTalkerParams {
+  productName: string;         // Max 22 chars before truncation (enforced)
+  skuCode: string;
+  pricePerCase: number;
+  promoLine?: string;          // Optional — e.g. "New Arrival!" Max 28 chars
+  distributor?: string;        // Defaults to "Yellowhammer Beverage"
+}
+
+const MAX_PRODUCT_NAME = 22;
+const MAX_PROMO_LINE = 28;
+const LABEL_WIDTH_PW = 400;    // 2.5" × 8dpmm × 20 = 400 dots (approx)
+const LABEL_HEIGHT_LL = 240;   // 1.5" × 8dpmm × 20 = 240 dots
+
+export function generateShelfTalker(params: ShelfTalkerParams): string {
+  const name = params.productName.length > MAX_PRODUCT_NAME
+    ? params.productName.substring(0, MAX_PRODUCT_NAME - 1) + '…'
+    : params.productName;
+
+  const promo = params.promoLine
+    ? (params.promoLine.length > MAX_PROMO_LINE
+        ? params.promoLine.substring(0, MAX_PROMO_LINE - 1) + '…'
+        : params.promoLine)
+    : null;
+
+  const price = `$${params.pricePerCase.toFixed(2)}`;
+  const dist = params.distributor ?? 'Yellowhammer Beverage';
+
+  return [
+    '^XA',
+    '^CI28',               // UTF-8 encoding
+    `^PW${LABEL_WIDTH_PW}`,
+    `^LL${LABEL_HEIGHT_LL}`,
+    '',
+    // Product name — large bold
+    `^FO20,18^A0B,0,0^BY3`,   // Reset
+    `^FO20,18^A0N,36,36^FD${name}^FS`,
+    // SKU code — small gray
+    `^FO20,62^A0N,20,20^FD${params.skuCode}^FS`,
+    // Price — largest element
+    `^FO20,90^A0N,54,54^FD${price}^FS`,
+    // Promo line (if present)
+    ...(promo ? [`^FO20,152^A0N,22,22^FD${promo}^FS`] : []),
+    // Distributor — small footer
+    `^FO20,${LABEL_HEIGHT_LL - 26}^A0N,16,16^FD${dist}^FS`,
+    '',
+    '^XZ',
+  ].join('\n');
+}
+```
+
+## A.2 Product Feature Card (4" × 3", 8 dpmm)
+
+Used for new product launches, seasonal features, cooler door placement.
+
+```typescript
+// src/zpl/templates/product-card.ts
+
+export interface ProductCardParams {
+  productName: string;       // Max 28 chars
+  tagline: string;           // Max 40 chars
+  abv?: number;              // Optional — omit for Red Bull, NA beverages
+  servingSize: string;       // e.g. "1/2 bbl keg" or "24 × 8.4oz"
+  keyFacts: string[];        // 2-3 items, max 38 chars each
+  skuCode: string;
+  distributor?: string;
+}
+
+const CARD_WIDTH_PW = 640;
+const CARD_HEIGHT_LL = 480;
+
+export function generateProductCard(params: ProductCardParams): string {
+  const name = params.productName.substring(0, 28);
+  const tagline = params.tagline.substring(0, 40);
+  const facts = params.keyFacts.slice(0, 3).map(f => f.substring(0, 38));
+  const dist = params.distributor ?? 'Yellowhammer Beverage';
+
+  let yPos = 25;
+  const lines: string[] = [
+    '^XA',
+    '^CI28',
+    `^PW${CARD_WIDTH_PW}`,
+    `^LL${CARD_HEIGHT_LL}`,
+    '',
+  ];
+
+  // Product name
+  lines.push(`^FO30,${yPos}^A0N,48,48^FD${name}^FS`);
+  yPos += 62;
+
+  // Tagline
+  lines.push(`^FO30,${yPos}^A0N,26,26^FD${tagline}^FS`);
+  yPos += 40;
+
+  // Divider
+  lines.push(`^FO30,${yPos}^GB580,2,2^FS`);
+  yPos += 18;
+
+  // ABV + serving size
+  if (params.abv !== undefined) {
+    lines.push(`^FO30,${yPos}^A0N,22,22^FDABV: ${params.abv.toFixed(1)}%   ${params.servingSize}^FS`);
+  } else {
+    lines.push(`^FO30,${yPos}^A0N,22,22^FD${params.servingSize}^FS`);
+  }
+  yPos += 38;
+
+  // Key facts
+  for (const fact of facts) {
+    lines.push(`^FO30,${yPos}^A0N,22,22^FD\u2022 ${fact}^FS`);
+    yPos += 34;
+  }
+
+  yPos += 10;
+  lines.push(`^FO30,${yPos}^GB580,2,2^FS`);
+  yPos += 15;
+
+  // SKU + distributor footer
+  lines.push(`^FO30,${yPos}^A0N,18,18^FDSKU: ${params.skuCode}   ${dist}^FS`);
+
+  lines.push('', '^XZ');
+  return lines.join('\n');
+}
+```
+
+## A.3 Delivery Receipt (4" × 6", 8 dpmm)
+
+Account manager signs this on delivery. Replaces paper receipt books.
+
+```typescript
+// src/zpl/templates/delivery-receipt.ts
+
+export interface DeliveryReceiptParams {
+  accountName: string;        // Max 30 chars
+  deliveryDate: string;       // "April 25, 2026"
+  repName: string;
+  orderNumber: string;
+  lines: Array<{
+    productName: string;      // Max 28 chars
+    quantity: number;
+    unit: string;             // "keg" | "case"
+    unitPrice: number;
+  }>;
+  totalAmount: number;
+  distributor?: string;
+}
+
+export function generateDeliveryReceipt(params: DeliveryReceiptParams): string {
+  const dist = params.distributor ?? 'Yellowhammer Beverage';
+  let y = 20;
+  const w = 640;
+  const lines: string[] = [
+    '^XA', '^CI28', `^PW${w}`, '^LL960', '',
+  ];
+
+  const push = (cmd: string) => lines.push(cmd);
+
+  // Header
+  push(`^FO30,${y}^A0N,34,34^FD${dist}^FS`); y += 46;
+  push(`^FO30,${y}^A0N,22,22^FDDelivery Receipt^FS`); y += 30;
+  push(`^FO30,${y}^A0N,20,20^FD${params.deliveryDate}   Order #${params.orderNumber}^FS`); y += 32;
+
+  // Account name
+  push(`^FO30,${y}^GB580,2,2^FS`); y += 14;
+  push(`^FO30,${y}^A0N,28,28^FD${params.accountName.substring(0, 30)}^FS`); y += 40;
+  push(`^FO30,${y}^GB580,2,2^FS`); y += 14;
+
+  // Line items
+  for (const line of params.lines) {
+    const lineTotal = (line.quantity * line.unitPrice).toFixed(2);
+    const productShort = line.productName.substring(0, 28);
+    push(`^FO30,${y}^A0N,20,20^FD${line.quantity}× ${line.unit} ${productShort}^FS`);
+    push(`^FO500,${y}^A0N,20,20^FD$${lineTotal}^FS`);
+    y += 32;
+  }
+
+  // Total
+  y += 8;
+  push(`^FO30,${y}^GB580,2,2^FS`); y += 14;
+  push(`^FO30,${y}^A0N,28,28^FDTOTAL^FS`);
+  push(`^FO460,${y}^A0N,28,28^FD$${params.totalAmount.toFixed(2)}^FS`);
+  y += 55;
+
+  // Signature line
+  push(`^FO30,${y}^GB360,2,2^FS`); y += 12;
+  push(`^FO30,${y}^A0N,18,18^FDReceived by (signature)^FS`); y += 40;
+  push(`^FO30,${y}^GB360,2,2^FS`); y += 12;
+  push(`^FO30,${y}^A0N,18,18^FDPrinted name^FS`); y += 42;
+
+  // Rep
+  push(`^FO30,${y}^A0N,18,18^FDDelivered by: ${params.repName}^FS`);
+
+  lines.push('', '^XZ');
+  return lines.join('\n');
+}
+```
+
+## A.4 ZPL validation utility
+
+```typescript
+// src/zpl/validator.ts
+
+export interface ZplValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export function validateZpl(zpl: string, widthInches: number, heightInches: number, dpmm = 8): ZplValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Must start and end correctly
+  if (!zpl.trimStart().startsWith('^XA')) errors.push('Missing ^XA (label start)');
+  if (!zpl.trimEnd().endsWith('^XZ')) errors.push('Missing ^XZ (label end)');
+
+  // Extract ^PW and verify
+  const pwMatch = zpl.match(/\^PW(\d+)/);
+  if (pwMatch) {
+    const pwDots = parseInt(pwMatch[1]);
+    const expectedMax = Math.ceil(widthInches * dpmm * 25.4);
+    if (pwDots > expectedMax) {
+      errors.push(`^PW${pwDots} exceeds label width (max ${expectedMax} for ${widthInches}" at ${dpmm}dpmm)`);
+    }
+  }
+
+  // Check all ^FO x coordinates are within label width
+  const foCoords = [...zpl.matchAll(/\^FO(\d+),/g)].map(m => parseInt(m[1]));
+  const maxX = Math.ceil(widthInches * dpmm * 25.4);
+  const overflowX = foCoords.filter(x => x > maxX - 20);
+  if (overflowX.length > 0) {
+    warnings.push(`${overflowX.length} field(s) near or beyond right edge: x=${overflowX.join(', ')}`);
+  }
+
+  // Must have ^CI28 for UTF-8 support
+  if (!zpl.includes('^CI28')) {
+    warnings.push('Missing ^CI28 (UTF-8 charset) — special characters may not render');
+  }
+
+  return { isValid: errors.length === 0, errors, warnings };
+}
+```
+
+---
+
+# Appendix B — AI System Prompts (Production-Ready)
+
+## B.1 Voice command interpreter
+
+```
+You are the AI voice assistant for Ohanafy Field, a mobile sales app for beverage distributor reps.
+
+The rep (Jake) is currently visiting an account. He has spoken a voice command. His hands may be busy.
+You are interpreting his speech to take an action in the app.
+
+You have access to these tools:
+- interpret_order_command: when the rep is adding, changing, or removing items from an order
+- interpret_note_command: when the rep is dictating a visit note, observation, or follow-up action
+- get_account_intelligence: when the rep asks about the account history, past orders, or contact info
+- suggest_label_for_product: when the rep wants to print a shelf talker, product card, or receipt
+
+## Routing rules
+- "add [product]", "put [qty] [product]", "[qty] of [product]", "a case of [product]" → interpret_order_command
+- "note [text]", "log [text]", "remember [text]", "write down [text]" → interpret_note_command
+- "when did I last order", "what did I order", "who's the contact" → get_account_intelligence
+- "print", "shelf talker", "label", "receipt" → suggest_label_for_product
+
+## Response rules
+1. Call exactly one tool. Never chain two tools in one turn.
+2. Respond to the rep in 1–2 sentences maximum.
+3. Be specific: "Added 2 kegs Pale Ale — total now $347." not "Done!"
+4. Use beverage vocabulary: keg, case, tap, facing, account.
+5. If the command is ambiguous, make the most reasonable interpretation and confirm it.
+   Never ask the rep to repeat themselves — they're in a noisy bar.
+6. If the command is completely uninterpretable (< 1% of cases): respond "Didn't catch that clearly — want to try again?"
+
+## What you NEVER do
+- Invent product names not in the provided catalog
+- Create or modify an order without explicit tool call and subsequent rep confirmation
+- Mention that you are Claude or that you are an AI
+- Respond in more than 2 sentences
+```
+
+## B.2 Visit prep (pre-call intelligence)
+
+```
+You are the pre-call intelligence agent for Ohanafy Field.
+
+A field sales rep is about to walk into an account. Your job is to surface the single most
+actionable insight that will improve this sales call.
+
+## Input
+You will receive:
+- Account name, type, and basic info
+- Days since last order
+- Last 3 visit notes
+- Current open orders
+- Top SKUs by order frequency (last 6 months)
+- Relevant AI memories for this rep + account (if any)
+
+## Output — strict JSON only
+{
+  "insight": "string — max 120 chars. One thing. Be specific. Connect dots across data points.",
+  "suggestedItems": ["sku_id_1", "sku_id_2"],    // 1-3 SKU IDs, or empty array
+  "talkingPoints": ["string", "string"],           // 2-3 items, max 70 chars each
+  "urgency": "high" | "medium" | "low",
+  "calibrated": boolean    // true if memories influenced this insight
+}
+
+## Urgency guide
+- high: 28+ days since last order, or last note flagged a problem, or open complaint
+- medium: 14-28 days, healthy account but could use a nudge
+- low: < 14 days, active account
+
+## Insight quality rules
+1. ONE insight. Not "here are 3 things." One.
+2. It must be specific to THIS account's data. "They haven't ordered in 5 weeks" is specific.
+   "Try to upsell" is not.
+3. Connect dots: if the last note mentions a tap problem AND the account hasn't reordered,
+   those facts belong together in the insight.
+4. If memories exist that calibrate this insight, use them. Flag calibrated = true.
+5. The insight text will be shown on a phone screen — write for 2 seconds of reading.
+
+## Return JSON only. No preamble. No explanation. No markdown.
+```
+
+## B.3 Note cleanup agent
+
+```
+You are a note cleanup agent for a beverage distributor field sales CRM.
+
+A field sales rep has just dictated a voice note. The raw transcript may contain:
+- Filler words ("um", "uh", "like", "you know")
+- Repetitions ("add, uh add two kegs")
+- Voice recognition errors ("Pale Ale" may have been heard as "pale tail")
+- Fragmented sentences (speaking while walking)
+
+Your job: clean the transcript into a professional 2-3 sentence CRM note.
+
+## Rules
+1. Remove all filler words
+2. Fix obvious speech recognition errors using context (product names, beverage terms)
+3. Preserve ALL factual observations — do not summarize away specifics
+4. Past tense: "discussed" not "discussing"
+5. Include next steps if mentioned: "will follow up on X" or "draft tech needed"
+6. Maximum 3 sentences. Minimum 1.
+7. Return the cleaned note text only — no explanation, no preamble, no quotes.
+
+## Examples
+Input:  "um so I talked to Marcus and he said the uh the lager tap is uh it's been fixed actually
+         and he wants to uh he's interested in the summer seasonal early commitment thing"
+Output: "Spoke with Marcus — lager tap issue has been resolved. He expressed interest in
+         the summer seasonal early commitment program."
+
+Input:  "note check back on pale tail display in two weeks"
+Output: "Follow up in two weeks to check on Pale Ale display placement."
+
+## Return the cleaned note only.
+```
+
+## B.4 Memory synthesis prompt
+
+```
+You are a learning agent for an AI sales assistant. You analyze patterns in a rep's
+feedback on AI suggestions to identify durable rules that should be remembered.
+
+You will receive a list of feedback events — cases where the rep edited or rejected
+an AI output. Each event has: the original AI output, what the rep changed it to,
+and the context.
+
+Your job: identify 1-3 durable patterns from these events that should be stored as
+AI memories to improve future accuracy.
+
+## Return JSON array only:
+[
+  {
+    "key": "brief_pattern_name",
+    "value": "what_the_pattern_means",
+    "confidence": 0.0-1.0,
+    "category": "COMMAND_PATTERN" | "ACCOUNT_PREFERENCE" | "NOTE_STYLE" | "INSIGHT_CALIBRATION"
+  }
+]
+
+## Rules
+1. Only return patterns with confidence > 0.5
+2. Only return patterns that appear in 2+ events (not one-offs)
+3. Be specific: "couple kegs = 2 units" is good. "rep prefers accuracy" is not.
+4. Confidence 0.9+ requires 4+ consistent examples; 0.7+ requires 2-3; below 0.7 only for directional hints.
+5. If no clear patterns emerge: return empty array [].
+6. Return JSON only. No explanation.
+```
+
+---
+
+# Appendix C — WatermelonDB Schema
+
+Full schema is in `src/db/schema.ts` — defined in §5 of this document. Reproduced here for quick reference as an entity-relationship summary.
+
+```
+accounts ─────────────────────────────────────────────
+  id (WDB local)
+  sf_id → ohfy__Account__c.Id
+  name, account_type, territory_id
+  contact_name, contact_title, contact_phone
+  address_street, address_city, address_state
+  latitude, longitude
+  last_order_date, last_visit_date, days_since_last_order
+  ytd_revenue, needs_attention, is_archived
+
+orders ──── belongs_to accounts ───────────────────────
+  sf_id → ohfy_field__Order__c.Id (null until synced)
+  account_id, account_sf_id
+  rep_id, status, sync_status, sync_attempts
+  order_date, delivery_date, total_amount, notes
+  created_offline
+
+order_lines ──── belongs_to orders ────────────────────
+  order_id, product_id, product_sf_id
+  product_name, quantity, unit, unit_price, line_total
+
+visits ──── belongs_to accounts ───────────────────────
+  sf_id → ohfy_field__Visit__c.Id (null until synced)
+  account_id, account_sf_id, rep_id
+  visit_date, duration_minutes
+  note, raw_transcript
+  ai_insight, insight_feedback
+  order_id (optional link to order placed this visit)
+  sync_status, sync_attempts, created_offline
+
+label_prints ──── belongs_to accounts ─────────────────
+  account_id, product_id (optional)
+  template_type, product_name
+  printer_serial, printed_at
+  zpl_snapshot, sync_status
+
+sync_queue ────────────────────────────────────────────
+  operation_type, entity_type, entity_id
+  payload_json, status, attempts
+  last_error, created_at, processed_at
+
+memories ──── belongs_to rep (rep_id) ─────────────────
+  rep_id, account_id (optional — null = global)
+  category, key, value (JSON)
+  confidence (0.0-1.0), source
+  use_count, last_used_at
+  sf_id, sync_status
+
+feedback_events ────────────────────────────────────────
+  rep_id, account_id (optional)
+  event_type, ai_output, user_correction
+  context_json, created_at, synthesized
+```
+
+---
+
+# Appendix D — Salesforce Data Model
+
+Custom objects (unmanaged for pilot; 2GP package for production) in `ohfy_field__` namespace.
+
+| Object | API Name | Key fields |
+|---|---|---|
+| Field Visit | `ohfy_field__Visit__c` | Account, Rep, Date, Note, RawTranscript, AiInsight, SyncSource |
+| Field Order | `ohfy_field__Order__c` | Account, Rep, OrderDate, TotalAmount, Status, CreatedOffline |
+| Field Order Line | `ohfy_field__OrderLine__c` | Order, ProductSfId, ProductName, Qty, Unit, UnitPrice, LineTotal |
+| Label Print Log | `ohfy_field__LabelPrint__c` | Account, TemplateType, ProductName, PrinterSerial, PrintedAt |
+| Rep Memory | `ohfy_field__RepMemory__c` | RepId, AccountId, Category, Key, Value, Confidence, Source |
+| Sync Log | `ohfy_field__SyncLog__c` | RepId, SyncDate, ItemsPushed, ItemsPulled, Duration, Trigger |
+
+**Note:** `ohfy_field__RepMemory__c` stores rep AI memories in Salesforce so they survive device changes and are available to managers for coaching. Confidence < 0.3 memories are not synced to Salesforce (pruned locally only).
+
+---
+
+# Appendix E — Test Specification
+
+Full test case list. Every item must have a corresponding test before Day 6 ends.
+
+## E.1 Unit tests — AI tools
+
+| Test ID | Description | Fixture | Expected |
+|---|---|---|---|
+| AI-T-001 | Order: "2 kegs pale ale" | demoCatalog | itemsToAdd = [{pale-ale-half-bbl, qty:2, unit:keg}] |
+| AI-T-002 | Order: "couple kegs" | demoCatalog | qty = 2 |
+| AI-T-003 | Order: "a case of red bull" | demoCatalog | unit = case, product matches red-bull* |
+| AI-T-004 | Order: unknown product | demoCatalog | confidence = low |
+| AI-T-005 | Order: does not mutate input | demoCatalog | input array unchanged |
+| AI-T-006 | Note: removes filler words | raw transcript | cleaned text has no "um", "uh" |
+| AI-T-007 | Note: preserves specifics | raw transcript | product names preserved |
+| AI-T-008 | Intel: > 28 days = high urgency | account context | urgency = high |
+| AI-T-009 | Intel: < 14 days = low urgency | account context | urgency = low |
+| AI-T-010 | Intel: returns JSON only | account context | JSON.parse succeeds |
+
+## E.2 Unit tests — ZPL templates
+
+| Test ID | Description | Expected |
+|---|---|---|
+| ZPL-T-001 | Shelf talker: starts with ^XA | ✓ |
+| ZPL-T-002 | Shelf talker: ends with ^XZ | ✓ |
+| ZPL-T-003 | Shelf talker: no ^FO x > 380 | ✓ |
+| ZPL-T-004 | Shelf talker: long name truncated | name ≤ 22 chars in output |
+| ZPL-T-005 | Shelf talker: price formatted $142.00 | ✓ |
+| ZPL-T-006 | Shelf talker: promo line included when provided | ✓ |
+| ZPL-T-007 | Shelf talker: no promo line when not provided | ✓ |
+| ZPL-T-008 | Shelf talker: snapshot regression | matches stored snapshot |
+| ZPL-T-009 | Product card: 3 key facts max | ✓ |
+| ZPL-T-010 | Delivery receipt: line totals correct | unitPrice × qty = lineTotal |
+
+## E.3 Unit tests — sync engine
+
+| Test ID | Description | Expected |
+|---|---|---|
+| SYNC-T-001 | CREATE_ORDER: creates SF record | mockSfClient.createRecord called |
+| SYNC-T-002 | CREATE_ORDER: updates syncStatus on success | syncStatus = 'synced' |
+| SYNC-T-003 | CREATE_ORDER: increments attempts on failure | attempts += 1 |
+| SYNC-T-004 | CREATE_ORDER: sets status to 'failed' at attempts ≥ 3 | status = 'failed' |
+| SYNC-T-005 | Conflict: server wins for account data | local account overwritten |
+| SYNC-T-006 | Queue: does not process items with status='done' | ✓ |
+| SYNC-T-007 | Queue: does not process items with status='failed' | ✓ |
+| SYNC-T-008 | Queue: processes items in created_at order | ✓ |
+
+## E.4 Maestro E2E flows
+
+| Flow | Steps | Pass criteria |
+|---|---|---|
+| onboarding.yaml | All 5 onboarding steps | Reaches home screen with accounts visible |
+| account-visit.yaml | List → detail → order → confirm → sync | Order synced to SF |
+| voice-order.yaml | Voice command → accept → verify line item | Line item added correctly |
+| offline-sync.yaml | Create order offline → reconnect → sync | SF record created |
+| zpl-print.yaml | Select label → preview → print | Preview rendered; print (simulated) logged |
+| ai-correction-learning.yaml | 3 corrections → learning agent → verify memory | 1+ new memory created |
+
+---
+
+# Appendix F — User Guide
+
+## Ohanafy Field User Guide v1.0
+
+*Available in-app at Settings → User Guide. Also available at docs.ohanafy.com/field.*
+
+---
+
+### Section 1: Getting Started
+
+**Setting up Ohanafy Field takes about 5 minutes.** After downloading the app:
+
+1. **Sign in with Salesforce.** Tap "Sign in with Salesforce" and log in with your Ohanafy credentials. Ohanafy Field connects to your Salesforce org to load your territory.
+
+2. **Let the app sync.** On first launch, Ohanafy Field downloads your accounts, products, and order history. This takes 30–60 seconds on a good connection. After that, everything is available offline.
+
+3. **Pair your Zebra printer.** If you have a Zebra ZQ520 or ZQ630 printer, go to Settings → Printers to pair it. You can also do this during onboarding. The app works without a printer — you just won't be able to print labels.
+
+4. **Enable Face ID / Touch ID.** When prompted, allow biometric unlock. This lets you open the app with one glance instead of typing your PIN each time.
+
+**After setup,** your account list will be on the home screen, sorted alphabetically. Accounts needing attention (not visited in 21+ days) are highlighted and can be filtered with the "Needs Attention" button.
+
+---
+
+### Section 2: Account Visits
+
+**Before you walk in:**
+Open the account from your list. Ohanafy Field shows you an **AI insight** at the top of the account screen — the most important thing to know before you knock. This might be a stale reorder, a flagged issue from your last visit, or a selling opportunity.
+
+Tap 👍 if the insight was helpful. Tap 👎 if it wasn't. This feedback helps the AI learn what matters to you and your accounts.
+
+**During the visit:**
+- Use the **Voice button** (microphone icon, bottom right) to log notes and orders hands-free
+- The **Visit History** section shows your last 3 visits with notes
+- The **Last Order** summary shows the last placed order and its status
+
+**After the visit:**
+Tap "Log Visit" to save the visit to Ohanafy Field. You can add or edit your notes before saving. If you're offline, the visit is saved locally and syncs when you get signal.
+
+---
+
+### Section 3: Taking Orders
+
+Tap "New Order" from the account detail screen to open the order entry screen.
+
+**Adding items:**
+- Browse products by category (Beer Kegs / Beer Cases / Energy / Other)
+- Tap a product to add it; use the +/- stepper to change quantity
+- Swipe left on a line item to remove it
+- The order total updates automatically
+
+**Using voice to order:**
+Say the mic button and speak naturally. For example:
+- *"Add 2 kegs Pale Ale"*
+- *"Put a case of Modelo on the order"*
+- *"Three Red Bull Sugarfrees"*
+
+The AI will show you what it understood. Tap **Accept** to add it, **Edit** to change it, or **Reject** to start over.
+
+**Confirming the order:**
+Tap "Confirm Order" to review the full order. Add a delivery date and any notes, then tap "Place Order." If you're offline, the order is saved locally (shown as "Pending Sync") and submitted to Salesforce when you reconnect.
+
+---
+
+### Section 4: Voice Commands
+
+Ohanafy Field understands natural speech. You don't need to use specific phrases — speak the way you normally would.
+
+**Order commands:**
+- "Add [quantity] [product]" — adds to current order
+- "Put [quantity] [product] on the order" — same
+- "Remove the [product]" — removes from order
+- "Change the [product] to [quantity]" — updates quantity
+
+**Note commands:**
+- "Note [text]" — logs a visit note
+- "Log that [text]" — same
+- "Remember [text]" — same
+
+**Tips for better accuracy:**
+- Speak clearly and at a normal pace — the app handles natural speech
+- If the AI gets a product name wrong, tap **Edit** and correct it; the AI learns from your corrections over time
+- Background noise (bar music, warehouse sounds) reduces accuracy — move to a quieter spot for complex orders
+- You don't need to say the full product name: "Pale Ale," "Bud Light," "Red Bull Sugar Free" all work
+
+---
+
+### Section 5: Label Printing
+
+Ohanafy Field can print shelf talkers, product cards, and delivery receipts directly to your Zebra ZQ520 or ZQ630.
+
+**Before printing:**
+- Your Zebra printer must be paired via Bluetooth (Settings → Printers)
+- Load the correct label stock (see your label type's size in §5.2 below)
+- The printer must be powered on and within Bluetooth range (~30 feet)
+
+**Printing a shelf talker:**
+1. From an account detail or order screen, tap "Print Label"
+2. Select "Shelf Talker"
+3. Choose the product
+4. Tap the preview to verify the label looks correct
+5. Tap "Print"
+
+The shelf talker prints in seconds. Hand it to the buyer while you're still in the store.
+
+**Label sizes:**
+| Label type | Size | Stock code |
+|---|---|---|
+| Shelf talker | 2.5" × 1.5" | Zebra ZP #10010044 or equivalent |
+| Product card | 4" × 3" | Zebra #800274-605 or equivalent |
+| Delivery receipt | 4" × 6" | Zebra #800274-607 or equivalent |
+
+**If the printer won't connect:**
+1. Make sure Bluetooth is enabled on your phone
+2. Make sure the printer is powered on (green status light)
+3. Try "Forget Printer" and re-pair in Settings → Printers
+4. Check that the label stock is loaded correctly (media sensing light should be off)
+
+---
+
+### Section 6: AI Features
+
+Ohanafy Field's AI gets smarter the more you use it. Here's how it works.
+
+**AI visit prep:** Before each visit, the AI analyzes your account's order history and visit notes to surface one key insight. This is not a generic tip — it's specific to this account's data.
+
+**AI voice commands:** When you speak, the AI interprets your words into app actions. It understands products by partial name, common abbreviations, and context.
+
+**How the AI learns:**
+Every time you accept, edit, or reject an AI suggestion, the app learns. After several corrections:
+- The AI gets better at recognizing your product shorthand
+- Account-specific patterns are remembered (e.g., The Rail always orders in pairs)
+- Your note style is learned over time
+
+**Reviewing your AI memories:**
+Go to Settings → AI Memory to see what the AI has learned. You can edit or delete any memory. Memories are saved to Salesforce, so they're available on any device you use.
+
+**A badge that says "customer-calibrated"** on an AI insight means the AI used past corrections and feedback from your visits to this specific account — the insight is more personalized than the default.
+
+---
+
+### Section 7: Troubleshooting
+
+**The app won't sync:**
+- Check that you have signal (the offline banner will say "Offline" if not)
+- Tap "Sync Now" in Settings to manually trigger a sync
+- Check Settings → Sync Status for any failed items
+- If items show "Failed after 3 attempts," contact support with the error details
+
+**Voice commands are inaccurate:**
+- Speak clearly and at a normal pace
+- Try moving to a quieter location
+- If a specific product name is consistently misheard, use Edit to correct it — the AI will learn the correct mapping after 2-3 corrections
+- As a last resort, add items manually using the product search
+
+**Printer won't print:**
+- Check Bluetooth is on and the printer is powered and within range
+- Check the printer has label stock loaded
+- Try a calibration print from the printer menu (hold the feed button)
+- Re-pair the printer in Settings → Printers
+
+**An order shows "Sync Failed":**
+- This usually means a Salesforce session issue. Go to Settings → Account and tap "Refresh Connection"
+- If the error persists, export the order as a PDF (tap the order → Share) and enter it manually as a backup
+
+**Contacting support:**
+Email support@ohanafy.com. Tap "Contact Support" in Settings for a pre-filled email with your device info and app version.
+
+---
+
+# Appendix G — In-App Onboarding Script
+
+## Step 1: Welcome
+
+```
+Screen:
+  [Ohanafy Field logo + illustration of a rep at an account]
+
+Heading: Welcome to Ohanafy Field
+
+Body: Your territory. Your accounts. Your AI assistant.
+Works offline, listens to your voice, prints labels on the spot.
+
+CTA: [Get Started]  |  [Sign in]  (already signed in — skip to Step 2)
+```
+
+## Step 2: Your Territory
+
+```
+Screen:
+  [Rep name + territory summary]
+  "Welcome, Jake. You're set up for Birmingham South territory."
+  "36 accounts loaded to your device."
+
+  [Territory account type breakdown]
+  On-premise: 14
+  Off-premise chain: 12
+  Off-premise indie: 7
+  Convenience: 3
+
+Sub-heading: Your data is ready to use offline.
+
+CTA: [Continue]
+```
+
+## Step 3: Pair Your Printer
+
+```
+Screen:
+  [Zebra printer illustration]
+
+Heading: Pair your label printer
+
+Body: Connect your Zebra ZQ520 or ZQ630 to print shelf talkers
+and delivery receipts without going back to the office.
+
+CTA: [Find My Printer]
+     [Skip for now →]
+
+On [Find My Printer]:
+  → Bluetooth scan screen → shows discovered printers
+  → Tap to pair
+  → "ZQ520 paired. You're ready to print."
+
+On [Skip]:
+  → Store skip in PostHog + SecureStore
+  → Continue to Step 4
+```
+
+## Step 4: Try Your First Visit (Guided)
+
+```
+Screen:
+  [Account List — first account highlighted with coach mark]
+
+Coach mark on account card:
+  "Your accounts are here. Tap one to see AI insights and start an order."
+
+[On tap → Account Detail — InsightBanner highlighted]
+
+Coach mark on InsightBanner:
+  "This is your pre-call briefing. The AI scanned the account's history and surfaced
+  the most important thing to know. Tap 👍 or 👎 to teach it your preferences."
+
+[User dismisses mark → VoiceButton highlighted]
+
+Coach mark on VoiceButton:
+  "Tap the mic and speak. 'Add 2 kegs Pale Ale.' The AI will confirm before adding anything."
+
+[User dismisses mark → SyncStatusBar highlighted if visible]
+
+Coach mark on SyncStatusBar:
+  "This shows items waiting to sync to Salesforce. When you get signal, they sync automatically."
+
+CTA: [I'm ready]
+```
+
+## Step 5: Done
+
+```
+Screen:
+  [Checkmark illustration]
+
+Heading: You're all set.
+
+Body: Ohanafy Field is ready. Your accounts are cached for offline use.
+The AI will get smarter as you use it.
+
+If you ever need help: tap the ? button on any screen, or go to Settings → User Guide.
+
+CTA: [Go to My Accounts]
+```
+
+---
+
+**End of Ohanafy Field — Product Engineering Bible v1.0**
+
+*One engineer. One week. One shippable product.*
+
+*Day 1: Foundation. Day 2: Core. Day 3: Voice + AI. Day 4: ZPL + Learning. Day 5: Tests + Onboarding. Day 6: Tablet + A11y + Polish. Day 7: Submit.*
+
+*The rep's got a printer on their belt and an AI in their ear. Go build something they'll actually use.* 🍺📱🖨️

--- a/OHANAFY-FIELD-ROLES-AND-ADMIN.md
+++ b/OHANAFY-FIELD-ROLES-AND-ADMIN.md
@@ -1,0 +1,1318 @@
+# Ohanafy Field — Roles, Permissions & Admin Console
+## Specification v1.0
+
+> **The core principle:** Ohanafy Field contains zero permission logic of its own. Every access decision derives from the user's Salesforce Permission Sets, read at login and cached in SecureStore. Org admins manage access through Salesforce Setup — the tool they already know. The app renders a completely different experience based on who is logged in.
+>
+> **What this doc covers:** The six user roles, how they map to Salesforce Permission Sets, the complete permission matrix, the role-driven navigation system, and the full Admin Console specification for the Salesforce org admin who configures the app for their team.
+
+---
+
+## Table of Contents
+
+- [§1 — The Six Roles](#1--the-six-roles)
+- [§2 — Salesforce Permission Set Architecture](#2--salesforce-permission-set-architecture)
+- [§3 — Permission Matrix](#3--permission-matrix)
+- [§4 — Role-Driven Navigation](#4--role-driven-navigation)
+- [§5 — Role Experiences (UX Specs)](#5--role-experiences-ux-specs)
+- [§6 — Permission Runtime Implementation](#6--permission-runtime-implementation)
+- [§7 — Admin Console Specification](#7--admin-console-specification)
+- [§8 — Admin Console Screens](#8--admin-console-screens)
+- [§9 — Provisioning Flow (New Customer)](#9--provisioning-flow-new-customer)
+- [§10 — Permission Change Propagation](#10--permission-change-propagation)
+- [§11 — Data Scope per Role](#11--data-scope-per-role)
+- [§12 — Implementation Guide for Claude Code](#12--implementation-guide-for-claude-code)
+- [Appendix A — Permission Set Definitions](#appendix-a--permission-set-definitions)
+- [Appendix B — Role Detection Logic](#appendix-b--role-detection-logic)
+- [Appendix C — Navigation Config per Role](#appendix-c--navigation-config-per-role)
+
+---
+
+## §1 — The Six Roles
+
+Six distinct personas use Ohanafy Field. Each has a fundamentally different job, different data needs, different physical context, and different actions they are authorized to take. They are not variations of the same screen — they are different products that happen to share infrastructure.
+
+### Role 1: Field Sales Rep
+**Job:** Drive a territory, visit retail accounts (bars, stores, restaurants), place orders, log visits, print shelf talkers, hit volume targets.
+
+**Physical context:** In a car, walking a store floor, standing in a bar back-of-house. Frequently no signal. One hand free at most. Time pressure at every stop.
+
+**Core actions:** View account list and detail, place orders (voice or tap), log visit notes (voice or tap), print ZPL labels, see AI pre-call briefing.
+
+**What they never do:** Approve other reps' orders, see other reps' accounts, view warehouse inventory levels, manage routes, see P&L.
+
+**Existing spec:** Fully covered in the Product Bible. This role is Jake Thornton.
+
+---
+
+### Role 2: Sales Manager
+**Job:** Lead a team of 5–15 field sales reps. Responsible for territory performance, coaching, large-order approvals, and coverage of key accounts.
+
+**Physical context:** Mix of office (Salesforce desktop) and field (riding with reps, visiting top accounts independently). Has reliable connectivity most of the time.
+
+**Core actions:** View real-time team activity feed, see coverage gaps (accounts not visited in N days), approve or reject orders above threshold, leave coaching notes on rep visits, compare rep performance, view team's AI insights.
+
+**What they never do:** Place orders themselves (unless they also carry a territory), operate warehouse systems, dispatch drivers.
+
+---
+
+### Role 3: Driver
+**Job:** Execute deliveries from the warehouse to retail accounts. Not a salesperson — focused on accurate delivery, receipt confirmation, and physical execution.
+
+**Physical context:** In a delivery truck, often in warehouse loading docks and retail receiving areas. Has a tablet or ruggedized phone mounted in the cab. Route is pre-built — they execute it, they don't plan it.
+
+**Core actions:** View today's delivery route (pre-loaded), confirm delivery at each stop (items, quantities, photos), capture signature or PIN confirmation, print delivery receipts (ZPL), log delivery exceptions (refused, short-shipped, damaged), navigate to next stop.
+
+**What they never do:** Place new orders, see account financial history, modify their own route, see other drivers' routes, access AI selling intelligence.
+
+**Critical difference from Sales Rep:** Drivers never need selling intelligence. They need logistics execution. The AI layer for a driver is "what do I have on my truck for this stop" — not "what should I pitch."
+
+---
+
+### Role 4: Driver Manager (Dispatch)
+**Job:** Build delivery routes, assign drivers, monitor delivery progress throughout the day, handle exceptions (late deliveries, missed stops, damaged goods), manage the fleet.
+
+**Physical context:** Primarily desktop (Salesforce + dispatch tools), but needs mobile visibility during the day.
+
+**Core actions:** View all drivers' real-time progress on a map, see exception alerts (missed delivery window, damaged item report), reassign stops between drivers, communicate with drivers via in-app message, approve delivery exception resolutions, view end-of-day delivery performance summary.
+
+**What they never do:** Place orders, access sales intelligence, manage sales rep activity.
+
+---
+
+### Role 5: Warehouse Worker
+**Job:** Pick and pack orders, stage items for delivery, manage physical inventory movement, receive incoming supplier loads.
+
+**Physical context:** Warehouse floor. Often using a mounted tablet on a forklift or a ruggedized handheld scanner. Loud environment. Gloves on. Voice is important.
+
+**Core actions:** View pick list for today's orders (sorted by warehouse location for efficient picking), confirm item picked (scan barcode or tap), flag out-of-stock or damaged items, view inbound load manifest, confirm receipt of supplier delivery, print warehouse labels (different ZPL format — bin labels, load labels, damage tags).
+
+**What they never do:** See account financial details, access selling intelligence, view driver routes, approve orders.
+
+---
+
+### Role 6: Warehouse Manager
+**Job:** Oversee all warehouse operations — inventory accuracy, pick/pack throughput, inbound receiving, supplier compliance, labor management.
+
+**Physical context:** Warehouse office + floor walkarounds. Mix of desktop and mobile.
+
+**Core actions:** View real-time inventory levels and DOH (days-on-hand) by SKU, see pick productivity by worker, view exception queue (OOS items blocking orders, damaged goods, supplier short-ships), approve inventory adjustments, view inbound load schedule, generate end-of-day inventory reconciliation, manage warehouse worker assignments.
+
+**What they never do:** Access sales account details, approve sales orders, manage driver routes.
+
+---
+
+## §2 — Salesforce Permission Set Architecture
+
+### The model
+
+Ohanafy Field ships six Salesforce Permission Sets as part of its managed package. Org admins assign these to users exactly as they would any other Salesforce permission. The app reads the user's assigned permission sets at login and derives their role.
+
+```
+Salesforce User
+    └── Assigned Permission Sets (many-to-many)
+            ├── ohfy_field__Sales_Rep
+            ├── ohfy_field__Sales_Manager
+            ├── ohfy_field__Driver
+            ├── ohfy_field__Driver_Manager
+            ├── ohfy_field__Warehouse_Worker
+            └── ohfy_field__Warehouse_Manager
+```
+
+### Why Permission Sets, not Profiles
+
+Salesforce best practice for ISV packages is Permission Sets, not Profiles. Reasons:
+- Orgs already have their own Profiles; a managed package can't own them
+- Permission Sets are additive — users can have multiple
+- Permission Sets can be assigned without changing the user's org-wide Profile
+- The app can detect multiple sets (a sales manager who also carries a territory gets both `Sales_Rep` and `Sales_Manager`)
+
+### Multi-role users
+
+Some users legitimately hold two roles. The app handles this as follows:
+
+| Combination | App behavior |
+|---|---|
+| `Sales_Rep` + `Sales_Manager` | Shows manager dashboard as default tab; rep features available via role switcher |
+| `Driver` + `Driver_Manager` | Shows manager view; driver execution available via role switcher |
+| `Sales_Manager` + `Warehouse_Manager` | Operations overview screen combining both feeds |
+| Any + `Warehouse_Manager` | Warehouse Manager always gets a tab regardless of other roles |
+| Three or more roles | Treated as Operations Admin — sees a combined dashboard with access to all permitted features |
+
+A **role switcher** in the app header (a small persona icon) lets multi-role users switch contexts without logging out. The switch is instant — it changes the navigation config and re-scopes all WatermelonDB queries. It does not require a new API call.
+
+### Permission Set Groups (for easy admin assignment)
+
+Ship three Permission Set Groups for common configurations:
+
+| Group | Includes | For |
+|---|---|---|
+| `ohfy_field__Field_Team` | `Sales_Rep` | Standard rep user |
+| `ohfy_field__Sales_Leadership` | `Sales_Rep` + `Sales_Manager` | Territory-carrying sales manager |
+| `ohfy_field__Warehouse_Team` | `Warehouse_Worker` | Standard warehouse employee |
+
+---
+
+## §3 — Permission Matrix
+
+The full permission matrix across all six roles. `✓` = permitted, `–` = not permitted, `R` = read-only.
+
+### Account & Customer Data
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| View own territory accounts | ✓ | ✓ | – | – | – | – |
+| View all territory accounts (their team's) | – | ✓ | – | – | – | – |
+| View account financial history | ✓ | ✓ | – | – | – | – |
+| View account contact details | ✓ | ✓ | R | – | – | – |
+| Edit account notes | ✓ | ✓ | – | – | – | – |
+| Log account visit | ✓ | ✓ | – | – | – | – |
+| View AI pre-call briefing | ✓ | ✓ | – | – | – | – |
+
+### Orders
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| Create order | ✓ | ✓ | – | – | – | – |
+| Edit own draft order | ✓ | ✓ | – | – | – | – |
+| Submit order | ✓ | – | – | – | – | – |
+| Approve order (under threshold) | – | ✓ | – | – | – | – |
+| Approve order (over threshold) | – | ✓* | – | – | – | – |
+| View own orders | ✓ | ✓ | – | – | – | – |
+| View team orders | – | ✓ | – | – | – | – |
+| View orders assigned to driver | – | – | R | R | – | – |
+| Confirm delivery of order | – | – | ✓ | – | – | – |
+| Log delivery exception | – | – | ✓ | ✓ | – | – |
+| Approve delivery exception | – | – | – | ✓ | – | – |
+
+*`Sales_Manager` approval of over-threshold orders requires a separate `ohfy_field__Approve_Large_Orders` permission (custom permission, not a full permission set — assigned as a checkbox within the Sales Manager set). Threshold is configurable in the Admin Console.
+
+### Visits & Activity
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| Log visit (own) | ✓ | ✓ | – | – | – | – |
+| View visit history (own accounts) | ✓ | ✓ | – | – | – | – |
+| View visit history (all team) | – | ✓ | – | – | – | – |
+| Add coaching note to rep visit | – | ✓ | – | – | – | – |
+| View coaching notes on own visits | ✓ | ✓ | – | – | – | – |
+
+### Routes & Delivery
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| View own delivery route | – | – | ✓ | ✓ | – | – |
+| View all driver routes | – | – | – | ✓ | – | – |
+| Navigate to delivery stop | – | – | ✓ | – | – | – |
+| Mark stop complete | – | – | ✓ | – | – | – |
+| Reassign delivery stop | – | – | – | ✓ | – | – |
+| View driver real-time location | – | – | – | ✓ | – | – |
+
+### Inventory & Warehouse
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| View product availability (simple Y/N) | ✓ | ✓ | R | – | ✓ | ✓ |
+| View full inventory levels + DOH | – | – | – | – | R | ✓ |
+| View pick list | – | – | – | – | ✓ | ✓ |
+| Confirm item picked | – | – | – | – | ✓ | – |
+| Flag OOS / damaged | – | – | ✓ | – | ✓ | ✓ |
+| Approve inventory adjustment | – | – | – | – | – | ✓ |
+| View inbound load manifest | – | – | – | – | ✓ | ✓ |
+| Confirm inbound receipt | – | – | – | – | ✓ | ✓ |
+| View warehouse worker productivity | – | – | – | – | – | ✓ |
+
+### ZPL Labels
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| Print shelf talker | ✓ | ✓ | – | – | – | – |
+| Print product feature card | ✓ | ✓ | – | – | – | – |
+| Print delivery receipt | ✓ | – | ✓ | – | – | – |
+| Print driver route sheet | – | – | ✓ | ✓ | – | – |
+| Print bin label (warehouse) | – | – | – | – | ✓ | ✓ |
+| Print damage tag | – | – | ✓ | – | ✓ | ✓ |
+| Print inbound load label | – | – | – | – | ✓ | ✓ |
+
+### AI Features
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| AI pre-call briefing | ✓ | ✓ | – | – | – | – |
+| AI voice order entry | ✓ | ✓ | – | – | – | – |
+| AI voice note dictation | ✓ | ✓ | – | – | – | – |
+| AI selling suggestions | ✓ | ✓ | – | – | – | – |
+| AI delivery confirmation (voice) | – | – | ✓ | – | – | – |
+| AI pick assist (voice pick confirmation) | – | – | – | – | ✓ | – |
+| AI team performance summary | – | ✓ | – | ✓ | – | ✓ |
+| View own AI memories | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Edit own AI memories | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| View team AI memories | – | ✓ | – | ✓ | – | ✓ |
+
+### App Settings & Admin
+
+| Permission | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| Pair Zebra printer | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Configure notification preferences | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Access Admin Console | – | – | – | – | – | – |
+| Manage product catalog | – | – | – | – | – | – |
+| Manage user roles | – | – | – | – | – | – |
+
+*The Admin Console requires a separate `ohfy_field__App_Admin` custom permission (typically given to Salesforce System Admins). It is not available to any of the six operational roles.
+
+---
+
+## §4 — Role-Driven Navigation
+
+The tab bar and navigation structure change completely based on role. The app is a single codebase — `_layout.tsx` reads the user's role from the permission store and renders the appropriate navigation tree.
+
+### Sales Rep navigation
+```
+Tabs: [Accounts] [Route] [Orders] [Settings]
+Deep: Account Detail → Order Entry → Visit Log → Label Print
+```
+
+### Sales Manager navigation
+```
+Tabs: [Team] [Accounts] [Approvals] [Reports] [Settings]
+  Team: Rep activity feed, coverage map, rep list
+  Accounts: Same as rep (for accounts they own or oversee)
+  Approvals: Orders pending approval
+  Reports: Territory performance, visit cadence, order trends
+```
+
+### Driver navigation
+```
+Tabs: [Route] [Deliveries] [Settings]
+  Route: Today's stops in order, map view, nav
+  Deliveries: Delivery confirmation, exceptions, receipt print
+```
+
+### Driver Manager navigation
+```
+Tabs: [Dispatch] [Routes] [Exceptions] [Reports] [Settings]
+  Dispatch: All drivers on a map, real-time progress
+  Routes: Build/edit routes, assign drivers
+  Exceptions: All delivery exceptions across team
+  Reports: Delivery performance, driver productivity
+```
+
+### Warehouse Worker navigation
+```
+Tabs: [Pick List] [Inbound] [Inventory] [Settings]
+  Pick List: Today's orders to pick, sorted by warehouse location
+  Inbound: Today's supplier loads to receive
+  Inventory: Spot inventory check, flag discrepancies
+```
+
+### Warehouse Manager navigation
+```
+Tabs: [Operations] [Inventory] [Workers] [Reports] [Settings]
+  Operations: Live view of pick progress, exceptions queue
+  Inventory: Full inventory, DOH, adjustments
+  Workers: Worker assignments, productivity by picker
+  Reports: Throughput, accuracy, supplier compliance
+```
+
+### Multi-role (role switcher)
+
+When a user has two or more roles, the tab bar shows a **role switcher** as the leftmost icon — a persona silhouette with the current role's initials. Tapping it opens a sheet with all available roles. Switching is instant.
+
+```typescript
+// src/store/role-store.ts
+interface RoleStore {
+  availableRoles: AppRole[];          // all roles this user has
+  activeRole: AppRole;                // currently selected role
+  permissions: PermissionSet;         // derived from activeRole
+  switchRole: (role: AppRole) => void;
+}
+```
+
+---
+
+## §5 — Role Experiences (UX Specs)
+
+### 5.1 Driver — key differences from Sales Rep
+
+The Driver experience is built around **logistics execution**, not selling. Key differences:
+
+**Route screen (primary screen):** A vertically scrolling list of delivery stops in sequence order. Each stop shows: account name, address, order summary (cases/kegs to deliver), delivery window, and status (pending / in progress / complete / exception). A map tab shows all stops pinned with status colors.
+
+**Stop detail:** Tapping a stop shows the delivery manifest — every item, every quantity. Below the manifest: a "Navigate" button (opens Apple Maps / Google Maps with the address), a "Start Delivery" button, and a "Report Issue" button.
+
+**Delivery confirmation flow:**
+1. Tap "Start Delivery" → Start timestamp logged
+2. For each item: tap to confirm quantity (or edit if short-ship)
+3. Tap "Complete" → Capture signature screen (finger-draw) OR "No signature required" toggle
+4. Optional: take a photo of the delivery
+5. Print delivery receipt (ZPL) — auto-prompted
+6. Tap "Confirm Delivery" → Stop marked complete, sync queued
+
+**Exception flow:** "Report Issue" → select issue type (refused delivery / damaged goods / wrong address / access denied / customer not present) → voice or text note → optional photo → submit. Exception goes to Driver Manager's queue immediately on sync.
+
+**AI for drivers:** Limited. Voice confirm: "Confirmed 2 kegs Bud Light and 3 cases Modelo" → AI parses quantities and matches to manifest, shows confirmation. No selling intelligence — Jake's AI briefings never appear in the Driver experience.
+
+**ZPL for drivers:** Delivery receipt and damage tag only. Shelf talkers are hidden.
+
+### 5.2 Warehouse Worker — key differences
+
+The Warehouse Worker experience is built around **physical task execution** in a noisy, hands-busy environment.
+
+**Pick list screen (primary screen):** Orders for today, grouped by warehouse zone/aisle for efficient picking. Each order line shows: product name, quantity, bin location (e.g., "Zone A, Row 3, Bin 7"), and a large checkmark button to confirm. The list is sorted to minimize travel distance — not by account or order number.
+
+**Voice pick:** Worker says "Picked" or taps the mic and says "confirm pale ale, 2 cases, zone A" → AI confirms match to pick list. Reduces mis-picks.
+
+**OOS flag:** If an item isn't there, tap "Flag OOS" → triggers an alert to Warehouse Manager and blocks that order line until resolved.
+
+**Inbound receiving:** Supplier load arrives → Worker scans or selects the load → steps through each item on the manifest → confirms quantities → flags any discrepancies → submits. System updates inventory automatically.
+
+**ZPL for warehouse:** Bin labels, damage tags, inbound load labels. No delivery receipts or shelf talkers.
+
+### 5.3 Sales Manager — team visibility
+
+The Team screen is the Sales Manager's primary screen. It shows:
+
+**Coverage map:** A map of the territory with every account pinned. Color coding:
+- Green: visited in the last 7 days
+- Yellow: visited 8–21 days ago
+- Red: not visited in 21+ days (needs attention)
+- Grey: no rep assigned
+
+**Rep activity feed:** Chronological list of recent activities across all reps — visits logged, orders placed, labels printed, AI insights surfaced. Shows rep name and time. Tapping opens the full record.
+
+**Approvals queue:** Orders over the threshold dollar amount appear here pending manager approval. Shows: rep name, account, order summary, total, time submitted. Approve / Reject / Request Changes with one tap. Rejection requires a reason (shown to rep as a push notification).
+
+**Coaching:** On any visit record, manager can tap "Add Coaching Note" → writes a private note attached to that visit. The rep sees the note the next time they view that visit. Coaching notes are never visible to other reps.
+
+---
+
+## §6 — Permission Runtime Implementation
+
+### 6.1 Auth flow with permission detection
+
+```typescript
+// src/auth/sf-oauth.ts — after token exchange
+
+export async function loadUserPermissions(
+  accessToken: string,
+  instanceUrl: string
+): Promise<UserPermissions> {
+  // 1. Get the user's ID from /services/oauth2/userinfo
+  const userInfo = await sfFetch(accessToken, instanceUrl,
+    '/services/oauth2/userinfo');
+
+  // 2. Query assigned Permission Sets via SOQL
+  // PermissionSetAssignment is queryable without special perms
+  const query = encodeURIComponent(`
+    SELECT PermissionSet.Name, PermissionSet.Label
+    FROM PermissionSetAssignment
+    WHERE AssigneeId = '${userInfo.user_id}'
+    AND PermissionSet.NamespacePrefix = 'ohfy_field'
+  `);
+
+  const psResult = await sfFetch(accessToken, instanceUrl,
+    `/services/data/v59.0/query?q=${query}`);
+
+  // 3. Also check Custom Permissions for fine-grained flags
+  const cpQuery = encodeURIComponent(`
+    SELECT SetupEntityId, SetupEntityType
+    FROM SetupEntityAccess
+    WHERE Parent.Id IN (
+      SELECT PermissionSetId FROM PermissionSetAssignment
+      WHERE AssigneeId = '${userInfo.user_id}'
+    )
+    AND SetupEntityType = 'CustomPermission'
+  `);
+
+  const cpResult = await sfFetch(accessToken, instanceUrl,
+    `/services/data/v59.0/query?q=${cpQuery}`);
+
+  // 4. Derive roles and permissions
+  const assignedSets = psResult.records.map(r => r.PermissionSet.Name);
+  const customPerms = cpResult.records.map(r => r.SetupEntityId);
+
+  return derivePermissions(assignedSets, customPerms, userInfo);
+}
+
+function derivePermissions(
+  permSetNames: string[],
+  customPerms: string[],
+  userInfo: SFUserInfo
+): UserPermissions {
+  const roles: AppRole[] = [];
+
+  if (permSetNames.includes('ohfy_field__Sales_Rep'))        roles.push('sales_rep');
+  if (permSetNames.includes('ohfy_field__Sales_Manager'))    roles.push('sales_manager');
+  if (permSetNames.includes('ohfy_field__Driver'))           roles.push('driver');
+  if (permSetNames.includes('ohfy_field__Driver_Manager'))   roles.push('driver_manager');
+  if (permSetNames.includes('ohfy_field__Warehouse_Worker')) roles.push('warehouse_worker');
+  if (permSetNames.includes('ohfy_field__Warehouse_Manager'))roles.push('warehouse_manager');
+  if (permSetNames.includes('ohfy_field__App_Admin'))        roles.push('app_admin');
+
+  if (roles.length === 0) {
+    throw new PermissionError(
+      'no_role_assigned',
+      'Your Salesforce user has no Ohanafy Field role assigned. ' +
+      'Contact your system administrator.'
+    );
+  }
+
+  return {
+    userId: userInfo.user_id,
+    userName: userInfo.name,
+    userEmail: userInfo.email,
+    roles,
+    primaryRole: determinePrimaryRole(roles),
+    customPermissions: {
+      canApproveLargeOrders: customPerms.includes('ohfy_field__Approve_Large_Orders'),
+      canViewAllTerritories: customPerms.includes('ohfy_field__View_All_Territories'),
+      canManageRoutes: customPerms.includes('ohfy_field__Manage_Routes'),
+    },
+    permSetNames,
+  };
+}
+
+// Primary role determines the default tab set shown on login
+function determinePrimaryRole(roles: AppRole[]): AppRole {
+  const priority: AppRole[] = [
+    'app_admin',
+    'warehouse_manager',
+    'driver_manager',
+    'sales_manager',
+    'warehouse_worker',
+    'driver',
+    'sales_rep',
+  ];
+  return priority.find(r => roles.includes(r)) ?? roles[0];
+}
+```
+
+### 6.2 Permission store (Zustand)
+
+```typescript
+// src/store/permission-store.ts
+import { create } from 'zustand';
+import * as SecureStore from 'expo-secure-store';
+
+interface PermissionStore {
+  permissions: UserPermissions | null;
+  activeRole: AppRole | null;
+  isLoading: boolean;
+
+  loadPermissions: (accessToken: string, instanceUrl: string) => Promise<void>;
+  switchRole: (role: AppRole) => void;
+  hasPermission: (permission: Permission) => boolean;
+  hasRole: (role: AppRole) => boolean;
+  clear: () => void;
+}
+
+export const usePermissionStore = create<PermissionStore>((set, get) => ({
+  permissions: null,
+  activeRole: null,
+  isLoading: false,
+
+  loadPermissions: async (accessToken, instanceUrl) => {
+    set({ isLoading: true });
+    try {
+      const perms = await loadUserPermissions(accessToken, instanceUrl);
+      await SecureStore.setItemAsync('user_permissions', JSON.stringify(perms));
+      await SecureStore.setItemAsync('user_active_role', perms.primaryRole);
+      set({ permissions: perms, activeRole: perms.primaryRole, isLoading: false });
+    } catch (error) {
+      set({ isLoading: false });
+      throw error;
+    }
+  },
+
+  switchRole: (role) => {
+    const { permissions } = get();
+    if (!permissions?.roles.includes(role)) return;
+    SecureStore.setItemAsync('user_active_role', role);
+    set({ activeRole: role });
+  },
+
+  hasPermission: (permission) => {
+    const { activeRole, permissions } = get();
+    if (!activeRole || !permissions) return false;
+    return PERMISSION_MATRIX[activeRole][permission] === true;
+  },
+
+  hasRole: (role) => {
+    return get().permissions?.roles.includes(role) ?? false;
+  },
+
+  clear: () => {
+    SecureStore.deleteItemAsync('user_permissions');
+    SecureStore.deleteItemAsync('user_active_role');
+    set({ permissions: null, activeRole: null });
+  },
+}));
+```
+
+### 6.3 Permission-aware components
+
+```typescript
+// src/components/shared/PermissionGate.tsx
+interface PermissionGateProps {
+  permission: Permission;
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+export function PermissionGate({ permission, children, fallback }: PermissionGateProps) {
+  const hasPermission = usePermissionStore(s => s.hasPermission);
+  if (!hasPermission(permission)) {
+    return <>{fallback ?? null}</>;
+  }
+  return <>{children}</>;
+}
+
+// Usage:
+<PermissionGate permission="can_approve_orders">
+  <ApproveButton onApprove={handleApprove} />
+</PermissionGate>
+
+<PermissionGate
+  permission="can_view_team_activity"
+  fallback={<Text>You don't have access to team activity.</Text>}
+>
+  <TeamActivityFeed />
+</PermissionGate>
+```
+
+### 6.4 Stale permission refresh
+
+Permissions are re-fetched from Salesforce every 4 hours (configurable) and on every app foreground. If Salesforce revokes a permission set while the user has the app open, the change takes effect on the next foreground or sync cycle — not instantly. This is the correct trade-off: constant re-checking would drain battery and add latency to every operation.
+
+```typescript
+// src/auth/permission-refresh.ts
+const PERMISSION_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+export async function refreshPermissionsIfStale(): Promise<void> {
+  const lastRefresh = await SecureStore.getItemAsync('permissions_last_refresh');
+  const lastRefreshMs = lastRefresh ? parseInt(lastRefresh) : 0;
+
+  if (Date.now() - lastRefreshMs < PERMISSION_REFRESH_INTERVAL_MS) {
+    return; // still fresh
+  }
+
+  const { loadPermissions } = usePermissionStore.getState();
+  const accessToken = await SecureStore.getItemAsync('sf_access_token');
+  const instanceUrl = await SecureStore.getItemAsync('sf_instance_url');
+
+  if (accessToken && instanceUrl) {
+    await loadPermissions(accessToken, instanceUrl);
+    await SecureStore.setItemAsync('permissions_last_refresh', String(Date.now()));
+  }
+}
+```
+
+### 6.5 No-permission screen
+
+When a user logs in with no ohfy_field__ Permission Sets assigned:
+
+```
+Screen: "Account not set up"
+
+[Icon: lock]
+
+Heading: You don't have access to Ohanafy Field yet.
+
+Body: Your Salesforce administrator needs to assign you a role
+in Ohanafy Field before you can use the app.
+
+Tell your admin to go to:
+Salesforce Setup → Permission Sets → search "Ohanafy Field" →
+assign the right role to your user.
+
+[Contact your admin →]   (opens mailto: to the org admin email)
+[Try again]              (re-fetches permissions)
+```
+
+---
+
+## §7 — Admin Console Specification
+
+### 7.1 What the Admin Console is
+
+The Admin Console is a **Salesforce-native Lightning app** installed as part of the Ohanafy Field managed package. It is not a separate web app. It lives in Salesforce Lightning under the "Ohanafy Field Admin" Lightning app, accessible only to users with the `ohfy_field__App_Admin` custom permission.
+
+It is not accessible from the mobile app. This is intentional — configuration is a desktop task that an admin does once per setup, not something a rep or manager needs on their phone.
+
+### 7.2 Why Salesforce-native (Lightning app), not a separate web app
+
+- Org admins already live in Salesforce — meeting them there reduces adoption friction
+- Salesforce handles authentication, permissions, and audit logging for free
+- Lightning components can directly query and mutate Salesforce objects
+- Org admins are comfortable with Salesforce UI conventions (page layouts, lists, related lists)
+- Avoids a separate hosted web service, separate auth, and separate deployment
+
+### 7.3 Admin Console Lightning app tabs
+
+```
+Ohanafy Field Admin app
+├── Dashboard        — Health overview, active users, sync stats
+├── Users & Roles    — Who has what role; bulk assignment
+├── App Settings     — Global configuration (thresholds, sync intervals, features)
+├── Product Catalog  — Which SF products sync to the app; field mappings
+├── ZPL Templates    — Manage label templates; upload custom templates
+├── Territories      — Rep ↔ account mapping configuration
+├── Notifications    — Notification rules and delivery settings
+├── AI Configuration — AI feature settings; memory review; system prompts
+├── Sync Monitor     — Real-time sync queue health; failed item resolution
+└── Audit Log        — Every admin action, immutable
+```
+
+---
+
+## §8 — Admin Console Screens
+
+### 8.1 Dashboard
+
+The first screen admins see. Designed to answer "is everything working?" at a glance.
+
+**Widgets:**
+- Active users today (count, with sparkline of last 7 days)
+- Sync queue health: total pending / processing / failed items across all users
+- Last sync error (most recent failed item with short reason)
+- App version distribution (what % of users are on the current build)
+- Permission coverage: how many users have each role (sanity check for mis-assignments)
+- AI usage today: voice commands, insights surfaced, feedback given
+
+**Alert banners (at top, only shown if condition is true):**
+- "12 sync items have failed 3+ times. Review →" (links to Sync Monitor)
+- "3 users have no role assigned" (links to Users & Roles)
+- "App v1.0.3 available — 8 users still on v1.0.1" (links to App Settings)
+
+### 8.2 Users & Roles
+
+A list of all Salesforce users in the org who have at least one ohfy_field__ permission set. Columns: Name, Email, Roles (badge list), Last Active (in app), Sync Status (green/yellow/red).
+
+**Bulk assign:** Multi-select users → "Assign Role" → pick from the six roles → confirm. Creates Permission Set Assignments in Salesforce via Apex. Includes an undo within 60 seconds.
+
+**Single user view:** Click a user → see their full profile: all roles, last login, last sync, sync queue depth, AI memory count, recent activity (last 5 actions from the app), and a "Send Test Notification" button (useful for verifying push notification setup).
+
+**Unassigned users tab:** Shows Salesforce users who are active and have the Ohanafy Field Connected App in their profile but no ohfy_field__ Permission Sets. These users will see the "Account not set up" screen. Admins can bulk-assign directly from this view.
+
+### 8.3 App Settings
+
+Global settings that affect all users. Changes take effect on next app foreground (via permission refresh cycle).
+
+**Order approvals:**
+- Order approval threshold: `$____` (orders above this require Sales Manager approval)
+- Auto-approve timeout: if a manager hasn't acted within `__ hours`, auto-approve or auto-escalate
+- Approval required on weekends: toggle
+
+**Sync settings:**
+- Background sync interval: `15 / 30 / 60 / 120 minutes`
+- Sync on WiFi only: toggle (useful for cellular data-conscious customers)
+- Full resync schedule: `daily / weekly / manual` (wipes local DB and re-pulls from SF)
+- Max offline queue depth before warning rep: `__ items`
+
+**Feature flags (per-org on/off):**
+| Feature | Toggle | Notes |
+|---|---|---|
+| AI pre-call briefing | ✓/– | Requires Anthropic API key configured |
+| Voice commands | ✓/– | Can disable for noise compliance in some facilities |
+| ZPL printing | ✓/– | Disable if no Zebra hardware deployed |
+| AI memories | ✓/– | Some orgs prefer stateless AI |
+| Push notifications | ✓/– | Requires APNs/FCM config complete |
+| Manager approval flow | ✓/– | Disable for orgs with flat authority structures |
+| Delivery confirmation photos | ✓/– | Some orgs have privacy policies against photos |
+
+**AI configuration:**
+- Anthropic API key: `[encrypted input — shows last 4 chars of key]`
+- AI model: `claude-sonnet-4-20250514` (locked; updated by Ohanafy on package update)
+- Insight refresh frequency: how often visit prep insights are recalculated
+
+**Connected App settings:**
+- Client ID: `[read-only — set during installation]`
+- Redirect URI: `[read-only]`
+- Test connectivity: button that fires a test OAuth flow and reports success/failure
+
+### 8.4 Product Catalog
+
+Controls which Salesforce Product records are synced to the app and how they're presented.
+
+**Catalog source:** `ohfy__Product__c` (default) or any custom object with a SOQL-accessible list of products. Admins can write a custom SOQL filter to limit which products appear (e.g., only active products in the rep's assigned pricebook).
+
+**Field mappings:** Map app concepts to Salesforce field API names:
+
+| App concept | Default SF field | Override |
+|---|---|---|
+| Product name | `Name` | `[text field input]` |
+| SKU code | `ProductCode` | `[text field input]` |
+| Unit price | `UnitPrice` (from PricebookEntry) | `[text field input]` |
+| Product category | `Family` | `[text field input]` |
+| Unit of measure | `ohfy__Unit__c` | `[text field input]` |
+| Active flag | `IsActive` | `[text field input]` |
+
+**Category display names:** Map the raw Salesforce `Family` picklist values to display names shown in the app:
+
+| Salesforce Family value | App display name |
+|---|---|
+| `BEER_DRAFT` | `Beer — Kegs` |
+| `BEER_PACKAGED` | `Beer — Cases` |
+| `ENERGY` | `Energy Drinks` |
+| `NA_BEVERAGE` | `Non-Alcoholic` |
+
+**Sync frequency:** Products sync on full resync only (not on every background sync). The catalog changes rarely. Admins can trigger a manual catalog sync from this screen.
+
+### 8.5 ZPL Templates
+
+Manage the label templates available to reps and drivers.
+
+**Built-in templates (read-only, from managed package):**
+- Shelf Talker (2.5" × 1.5")
+- Product Feature Card (4" × 3")
+- Delivery Receipt (4" × 6")
+- Driver Route Sheet (4" × 6")
+- Warehouse Bin Label (2" × 1")
+- Damage Tag (4" × 2")
+
+**Custom templates:** Admins can upload custom ZPL templates. The upload flow:
+1. Paste ZPL string into text area
+2. Fill in parameter names (placeholders that the app will fill at print time)
+3. Select template type (shelf / receipt / warehouse / other)
+4. Choose which roles can access this template
+5. Enter label dimensions (for Labelary preview)
+6. Preview renders via Labelary API — admin sees the label before saving
+7. Save — template appears in the app on next sync for authorized roles
+
+**Per-role template visibility:** A matrix lets admins control which template types appear for which roles. Default matches the permission matrix in §3, but can be customized per org.
+
+### 8.6 Territories
+
+Controls which accounts appear in which rep's account list.
+
+**Territory source:** Reads from Salesforce Territory Management (`UserTerritory2Association` for Enterprise Territory Management) if enabled in the org. Falls back to a direct rep ↔ account assignment model if Territory Management is not enabled.
+
+**Manual assignment (fallback mode):**
+- Rep list on left
+- Account list on right (filterable by existing territory, account type, city)
+- Drag-and-drop or checkbox-select to assign accounts to a rep
+- Bulk import via CSV: `AccountId, RepUserId`
+
+**Territory sync:** When SF Territory Management is active, the app respects it automatically — no manual assignment needed. Admins can see the territory-to-rep mapping here but can't override Salesforce's native territory rules.
+
+**Orphaned accounts:** Accounts not assigned to any rep appear in an "Unassigned" list. If a rep opens the app and their account list is empty, this is the first place admins should check.
+
+### 8.7 Notifications
+
+Configure when the app sends push notifications to each role.
+
+**Notification rules (per role, all configurable on/off + threshold):**
+
+**Sales Rep:**
+- Account not visited in N days → reminder push with account name
+- Order approved by manager → confirmation
+- Order rejected by manager → push with manager's reason
+- Coaching note added to a visit → push to the rep
+
+**Sales Manager:**
+- Order submitted above approval threshold → push with rep name + order total
+- Team member hasn't logged any visits today by 2pm → nudge
+- Account in territory with no visit in 30+ days → escalation alert
+
+**Driver:**
+- Route assigned for tomorrow → morning push with stop count
+- Delivery window starting in 30 minutes → timing alert
+- Exception on a prior stop resolved by manager → confirmation
+
+**Driver Manager:**
+- Driver has not confirmed a stop 30 minutes after the delivery window opened
+- Delivery exception requires resolution
+- All drivers have completed routes → end-of-day summary
+
+**Warehouse Worker:**
+- Pick list available for today → morning notification
+- OOS flag resolved → confirmation they can continue
+
+**Warehouse Manager:**
+- OOS item flagged → immediate push
+- Inbound load arriving in 1 hour → advance notice
+- Picker productivity below threshold → daily summary
+
+**Technical configuration:**
+- APNs certificate or key (iOS) — upload `.p8` file + Key ID + Team ID
+- FCM server key (Android) — paste key from Firebase Console
+- Test send: select a user, send a test notification, confirm receipt
+- Quiet hours: `_:__ PM to _:__ AM` — no notifications outside this window
+
+### 8.8 AI Configuration
+
+**API key management:**
+The Anthropic API key is stored encrypted in a custom metadata type (`ohfy_field__AI_Config__mdt`). It is never returned to the client in plaintext. When the mobile app authenticates, it receives a short-lived signed token that is exchanged at the API gateway for the actual key — the key never travels to the device.
+
+```
+Mobile app → POST /api/ai/command
+           → Salesforce Connected App OAuth validates session
+           → Apex callout signs request with stored API key
+           → Returns response to mobile app
+```
+
+Wait — this changes the architecture from the Product Bible (direct device-to-Anthropic). The tradeoff:
+
+| | Direct (Product Bible) | Via Apex proxy |
+|---|---|---|
+| Latency | Lower | +100–300ms |
+| Key security | Key on device (SecureStore) | Key never leaves SF |
+| Offline | Works | Requires network |
+| Complexity | Lower | Higher |
+
+**Recommendation for v1.0:** Keep the direct architecture from the Product Bible (key in SecureStore, retrieved at auth time). Log this as a known risk in the security review. Move to Apex proxy architecture in v1.1 before enterprise rollout.
+
+**Memory management (admin view):**
+- Per-rep memory count and storage size
+- "Clear all memories for user" button (for offboarding or privacy requests)
+- Memory audit: filterable list of all memories for a selected user (admin-only read access)
+- Global memory retention policy: delete memories older than N days (default: 365)
+
+**System prompt customization:**
+Admins can prepend a custom context block to the AI system prompts. Example: "This distributor specializes in craft and import beer. They do not carry domestic macro brands." This context is injected into every AI call for this org, allowing Ohanafy to serve different customer types without code changes.
+
+### 8.9 Sync Monitor
+
+Real-time view of sync queue health across all users.
+
+**Live queue table:** Every pending / processing / failed sync item, across all users:
+
+| Columns | Description |
+|---|---|
+| User | Which rep/driver/worker |
+| Type | CREATE_ORDER / CREATE_VISIT / CONFIRM_DELIVERY / etc. |
+| Entity | Brief description (e.g., "Order — The Rail — $320") |
+| Status | pending / processing / failed |
+| Attempts | 0–3 (failed at 3) |
+| Last error | Truncated error message |
+| Created | How long ago |
+| Actions | Retry / Discard / View detail |
+
+**Retry:** Admin can manually retry a failed item. Resets attempts to 0 and re-queues it.
+
+**Discard:** Admin discards a failed item after reviewing it. The rep gets a push notification: "Your [order/visit] from [time] could not be synced and was discarded. Please re-enter it."
+
+**Detail view:** Full payload JSON for a sync item (admin-only). Useful for diagnosing data mapping issues.
+
+**Bulk actions:** "Retry all failed" / "Discard all failed older than N days" with confirmation.
+
+**Alerts:** If any user's failed item count exceeds 5, an alert banner appears at the top of this screen and on the Dashboard.
+
+### 8.10 Audit Log
+
+Every admin action in the console is logged, immutable, and queryable.
+
+Captured for every action:
+- Timestamp
+- Admin user name + Salesforce user ID
+- Action type (ROLE_ASSIGN / ROLE_REVOKE / SETTING_CHANGE / TEMPLATE_UPLOAD / SYNC_RETRY / MEMORY_CLEAR / etc.)
+- Target (which user, which record, which setting)
+- Before value / After value (for setting changes)
+- IP address
+
+The Audit Log is a read-only Salesforce Custom Object (`ohfy_field__Admin_Audit_Log__c`) with no delete permission even for System Admins. It cannot be cleared — this is intentional for compliance.
+
+Exportable as CSV. Filterable by date range, admin user, and action type.
+
+---
+
+## §9 — Provisioning Flow (New Customer)
+
+When a new Ohanafy customer purchases Ohanafy Field, this is the sequence:
+
+### Step 1: Package installation (Ohanafy ops or customer IT)
+- Install Ohanafy Field managed package from AppExchange into the customer's Salesforce org
+- Package installs: 6 Permission Sets, 3 Permission Set Groups, all custom objects, the Lightning app, the custom metadata types
+
+### Step 2: Connected App configuration (customer IT or guided by Ohanafy)
+- In Salesforce Setup → Connected Apps → Ohanafy Field → configure OAuth settings
+- Add the customer org's callback URI: `com.ohanafy.field://oauth/callback`
+- Note the Consumer Key (Client ID) — needed in Step 4
+
+### Step 3: Admin Console first run (Ohanafy implementation specialist + customer admin)
+- Open the Ohanafy Field Admin Lightning app
+- Walk through the first-run setup wizard (15–30 minutes):
+  1. Configure product catalog field mappings
+  2. Assign roles to users (bulk import or manual)
+  3. Configure territories (or confirm Territory Management integration)
+  4. Set the order approval threshold
+  5. Configure notification settings
+  6. Enter Anthropic API key (can be Ohanafy's key with usage tracking, or customer's own)
+  7. Send a test notification to confirm APNs/FCM is working
+
+### Step 4: App distribution to users
+- Send users the App Store / Play Store link
+- Users download and open the app
+- They tap "Sign in with Salesforce" → standard OAuth flow using their existing Salesforce credentials
+- App reads their permission sets → renders correct experience
+- First sync downloads their accounts, products, and history
+
+### Step 5: Verification
+- Admin opens Sync Monitor — confirms all first syncs completed successfully
+- Admin opens Dashboard — confirms active users count matches deployed users
+- Admin spot-checks one rep's account list against what's in Salesforce
+
+---
+
+## §10 — Permission Change Propagation
+
+What happens when a Salesforce admin changes a user's permissions mid-day.
+
+| Change | When it takes effect | How |
+|---|---|---|
+| New role assigned | Next app foreground + permission refresh (≤ 4 hours) | Permission refresh cycle |
+| Role revoked | Next app foreground + permission refresh (≤ 4 hours) | Permission refresh cycle |
+| Custom permission added | Next app foreground | Same |
+| Immediate revocation needed | Admin taps "Force logout" in Admin Console → User screen | Invalidates SF session; user sees login screen on next API call |
+
+**Force logout:** The Admin Console's user detail screen has a "Force Logout" button that calls a Salesforce API to revoke the user's Connected App access tokens. This is for security incidents (lost device, terminated employee). The user sees the standard "Session expired" screen on their next sync attempt.
+
+**Device loss protocol:**
+1. Admin → Users & Roles → find user → Force Logout (invalidates tokens)
+2. User's unsynced data is lost — this is unavoidable with a truly offline-first app
+3. Admin → Sync Monitor → check for pending items from that user → note any that need manual re-entry
+4. If the lost data is critical (large unsynced orders), admin can reconstruct from the rep's last-known state
+
+---
+
+## §11 — Data Scope per Role
+
+WatermelonDB only syncs the data each role actually needs. This reduces sync time, storage, and the surface area of data that could be exposed if a device is lost.
+
+| Data type | Sales Rep | Sales Manager | Driver | Driver Mgr | WH Worker | WH Manager |
+|---|---|---|---|---|---|---|
+| Accounts | Own territory | Full team territory | Delivery stops only | All | – | – |
+| Account financial history | Own accounts | Full team | – | – | – | – |
+| Products | Full catalog | Full catalog | Route manifest only | – | Active SKUs | Full catalog + inventory |
+| Orders | Own orders | All team orders | Today's delivery orders | All delivery orders | Today's pick orders | All orders |
+| Visits | Own visits | All team visits | – | – | – | – |
+| Inventory levels | Product available Y/N | Product available Y/N | – | – | Full detail | Full detail |
+| Routes | – | – | Own route | All routes | – | – |
+| Pick lists | – | – | – | – | Own list | All lists |
+| AI memories | Own | Own + can read team | Own | Own + can read team | Own | Own + can read team |
+
+**Implementation note:** The sync engine reads the user's active role from the permission store and applies a `syncScope` filter before every pull from Salesforce. A driver does not have `ohfy__Account__c` financial history in their WatermelonDB — it was never synced. This is not a UI-level permission gate; it is a data-level control.
+
+---
+
+## §12 — Implementation Guide for Claude Code
+
+### Day 1 additions (from the Product Bible)
+
+Add to the Day 1 targets in the Product Bible:
+
+- [ ] `loadUserPermissions()` implemented and tested with fixture permission sets
+- [ ] `usePermissionStore` Zustand store created
+- [ ] `PermissionGate` component renders and hides correctly based on role
+- [ ] No-permission screen implemented
+- [ ] Role switcher renders for a user with two roles
+
+### New WatermelonDB tables needed
+
+Add to the schema in §5 of the Product Bible:
+
+```typescript
+tableSchema({
+  name: 'permissions',
+  columns: [
+    { name: 'user_id', type: 'string' },
+    { name: 'roles_json', type: 'string' },        // JSON array of AppRole
+    { name: 'primary_role', type: 'string' },
+    { name: 'custom_perms_json', type: 'string' }, // JSON object
+    { name: 'fetched_at', type: 'number' },        // for stale check
+  ],
+}),
+```
+
+### New Salesforce objects needed
+
+Add to the SFDX package in §E of the Product Bible:
+
+- `ohfy_field__Admin_Config__mdt` — custom metadata for org-wide settings
+- `ohfy_field__Admin_Audit_Log__c` — immutable audit trail
+- `ohfy_field__ZPL_Template__c` — custom ZPL templates per org
+- `ohfy_field__Territory_Assignment__c` — manual rep ↔ account mapping (fallback)
+- `ohfy_field__Notification_Rule__c` — configurable notification rules
+- `ohfy_field__AI_Config__mdt` — encrypted AI settings (API key, prompt customizations)
+
+### New Maestro E2E flows needed
+
+Add to the test suite in §12 of the Product Bible:
+
+- `role-detection.yaml` — login with each of the 6 roles; verify correct tab set renders
+- `permission-gate.yaml` — login as Sales Rep; verify manager-only features are absent
+- `role-switch.yaml` — login as Sales Rep + Sales Manager; switch roles; verify nav changes
+- `no-permission.yaml` — login with no ohfy_field__ Permission Sets; verify no-permission screen
+- `admin-console.yaml` — login as App Admin; verify Admin Console Lightning app loads
+
+### CLAUDE.md additions
+
+Add to `CLAUDE.md` (§10 of the Harness):
+
+```markdown
+## Role system
+Every screen checks `usePermissionStore().hasPermission(permission)` before rendering
+restricted features. Never check role names directly in components — always use
+the permission abstraction. Permission matrix lives in `src/permissions/matrix.ts`.
+
+Roles are read from Salesforce Permission Sets at auth time. Never hardcode
+role logic. If a new permission is needed, add it to:
+1. The Permission Set in the SFDX package
+2. `src/permissions/types.ts` (the Permission enum)
+3. `src/permissions/matrix.ts` (which roles get it)
+4. Any component that needs to gate on it
+
+Available agents for permission work:
+- `salesforce-integration` for Permission Set Apex and SOQL
+- `rn-architect` for PermissionGate component and navigation routing
+```
+
+---
+
+## Appendix A — Permission Set Definitions
+
+These six Permission Sets ship with the managed package. Each grants the minimum object and field permissions needed for that role. They intentionally do NOT grant permissions on any non-`ohfy_field__` objects — existing Salesforce permissions handle those.
+
+### `ohfy_field__Sales_Rep`
+
+**Object permissions:**
+- `ohfy_field__Visit__c`: Create, Read, Edit (own)
+- `ohfy_field__Order__c`: Create, Read, Edit (own draft only)
+- `ohfy_field__OrderLine__c`: Create, Read, Edit, Delete (own orders only)
+- `ohfy_field__LabelPrint__c`: Create, Read (own)
+- `ohfy_field__RepMemory__c`: Read, Edit (own)
+- `ohfy_field__SyncLog__c`: Create (own)
+
+**Custom permissions:** None by default
+
+**Read access on Ohanafy core objects (no edit):**
+- `ohfy__Account__c` — account details for assigned territory
+- `ohfy__Product__c` — product catalog
+- `ohfy__Order__c` — prior order history for assigned accounts
+
+### `ohfy_field__Sales_Manager`
+
+All permissions from `ohfy_field__Sales_Rep`, plus:
+
+**Object permissions:**
+- `ohfy_field__Visit__c`: Read all (team), Edit (coaching note field only on others' records)
+- `ohfy_field__Order__c`: Read all (team), Edit (`Status__c` field for approval actions)
+
+**Custom permissions:**
+- `ohfy_field__Approve_Large_Orders` — granted within this set by default (configurable off in Admin Console)
+
+**Additional read access:**
+- All accounts in the assigned territory (not just own accounts)
+
+### `ohfy_field__Driver`
+
+**Object permissions:**
+- `ohfy_field__DeliveryConfirmation__c`: Create, Read (own routes)
+- `ohfy_field__DeliveryException__c`: Create, Read (own routes)
+- `ohfy_field__LabelPrint__c`: Create, Read (own — delivery receipt and damage tag only)
+- `ohfy_field__SyncLog__c`: Create (own)
+
+**Read access:**
+- `ohfy__Order__c`: Read (today's delivery orders only, filtered by assigned route)
+- `ohfy_field__Route__c`: Read (own assigned routes)
+
+### `ohfy_field__Driver_Manager`
+
+All permissions from `ohfy_field__Driver`, plus:
+
+**Object permissions:**
+- `ohfy_field__Route__c`: Create, Read, Edit, Delete
+- `ohfy_field__DeliveryException__c`: Read all, Edit (`Resolution__c`, `Status__c`)
+
+**Read access:**
+- All drivers' routes and delivery confirmations
+
+### `ohfy_field__Warehouse_Worker`
+
+**Object permissions:**
+- `ohfy_field__PickConfirmation__c`: Create, Read (own)
+- `ohfy_field__InventoryFlag__c`: Create, Read (own)
+- `ohfy_field__LabelPrint__c`: Create, Read (warehouse label types only)
+- `ohfy_field__SyncLog__c`: Create (own)
+
+**Read access:**
+- `ohfy__Order__c`: Read (today's orders assigned to pick)
+- `ohfy__Product__c`: Read (product name, SKU, bin location)
+- `ohfy__InventoryItem__c`: Read (basic availability)
+
+### `ohfy_field__Warehouse_Manager`
+
+All permissions from `ohfy_field__Warehouse_Worker`, plus:
+
+**Object permissions:**
+- `ohfy__InventoryItem__c`: Read, Edit (`Quantity__c`, `LastAdjustedDate__c`)
+- `ohfy_field__InventoryFlag__c`: Read all, Edit (resolution fields)
+- `ohfy_field__InventoryAdjustment__c`: Create, Read, Edit (own adjustments)
+
+**Read access:**
+- Full inventory levels across all SKUs
+- All warehouse workers' pick confirmations and productivity data
+
+---
+
+## Appendix B — Role Detection Logic
+
+```typescript
+// src/permissions/types.ts
+
+export type AppRole =
+  | 'sales_rep'
+  | 'sales_manager'
+  | 'driver'
+  | 'driver_manager'
+  | 'warehouse_worker'
+  | 'warehouse_manager'
+  | 'app_admin';
+
+export type Permission =
+  // Account
+  | 'view_own_accounts'
+  | 'view_team_accounts'
+  | 'view_account_financials'
+  | 'log_visit'
+  | 'view_team_visits'
+  | 'add_coaching_note'
+  // Orders
+  | 'create_order'
+  | 'submit_order'
+  | 'approve_order'
+  | 'view_team_orders'
+  // Delivery
+  | 'view_own_route'
+  | 'view_all_routes'
+  | 'confirm_delivery'
+  | 'log_delivery_exception'
+  | 'approve_delivery_exception'
+  | 'manage_routes'
+  // Warehouse
+  | 'view_pick_list'
+  | 'confirm_pick'
+  | 'view_full_inventory'
+  | 'adjust_inventory'
+  | 'view_worker_productivity'
+  // AI
+  | 'ai_visit_prep'
+  | 'ai_voice_order'
+  | 'ai_voice_note'
+  | 'ai_selling_suggestions'
+  | 'ai_voice_delivery'
+  | 'ai_voice_pick'
+  | 'ai_team_summary'
+  | 'view_own_memories'
+  | 'view_team_memories'
+  // ZPL
+  | 'print_shelf_talker'
+  | 'print_product_card'
+  | 'print_delivery_receipt'
+  | 'print_route_sheet'
+  | 'print_bin_label'
+  | 'print_damage_tag';
+
+// src/permissions/matrix.ts
+export const PERMISSION_MATRIX: Record<AppRole, Record<Permission, boolean>> = {
+  sales_rep: {
+    view_own_accounts: true,
+    view_team_accounts: false,
+    view_account_financials: true,
+    log_visit: true,
+    view_team_visits: false,
+    add_coaching_note: false,
+    create_order: true,
+    submit_order: true,
+    approve_order: false,
+    view_team_orders: false,
+    view_own_route: false,
+    view_all_routes: false,
+    confirm_delivery: false,
+    log_delivery_exception: false,
+    approve_delivery_exception: false,
+    manage_routes: false,
+    view_pick_list: false,
+    confirm_pick: false,
+    view_full_inventory: false,
+    adjust_inventory: false,
+    view_worker_productivity: false,
+    ai_visit_prep: true,
+    ai_voice_order: true,
+    ai_voice_note: true,
+    ai_selling_suggestions: true,
+    ai_voice_delivery: false,
+    ai_voice_pick: false,
+    ai_team_summary: false,
+    view_own_memories: true,
+    view_team_memories: false,
+    print_shelf_talker: true,
+    print_product_card: true,
+    print_delivery_receipt: true,
+    print_route_sheet: false,
+    print_bin_label: false,
+    print_damage_tag: false,
+  },
+  // ... (all six roles follow the matrix in §3)
+};
+```
+
+---
+
+## Appendix C — Navigation Config per Role
+
+```typescript
+// src/navigation/role-nav-config.ts
+
+export interface TabConfig {
+  name: string;
+  title: string;
+  icon: string;          // lucide-react-native icon name
+  href: string;          // Expo Router path
+  badge?: 'sync_count' | 'approval_count' | 'exception_count';
+}
+
+export const ROLE_NAV_CONFIG: Record<AppRole, TabConfig[]> = {
+  sales_rep: [
+    { name: 'accounts', title: 'Accounts', icon: 'Building2', href: '/(tabs)/' },
+    { name: 'route',    title: 'Route',    icon: 'MapPin',    href: '/(tabs)/route' },
+    { name: 'orders',   title: 'Orders',   icon: 'ShoppingCart', href: '/(tabs)/orders' },
+    { name: 'settings', title: 'Settings', icon: 'Settings2', href: '/(tabs)/settings' },
+  ],
+  sales_manager: [
+    { name: 'team',      title: 'Team',      icon: 'Users',       href: '/(tabs)/team', badge: 'approval_count' },
+    { name: 'accounts',  title: 'Accounts',  icon: 'Building2',   href: '/(tabs)/' },
+    { name: 'approvals', title: 'Approvals', icon: 'CheckSquare', href: '/(tabs)/approvals', badge: 'approval_count' },
+    { name: 'reports',   title: 'Reports',   icon: 'BarChart2',   href: '/(tabs)/reports' },
+    { name: 'settings',  title: 'Settings',  icon: 'Settings2',   href: '/(tabs)/settings' },
+  ],
+  driver: [
+    { name: 'route',      title: 'Route',      icon: 'Truck',   href: '/(tabs)/route' },
+    { name: 'deliveries', title: 'Deliveries', icon: 'Package', href: '/(tabs)/deliveries', badge: 'exception_count' },
+    { name: 'settings',   title: 'Settings',   icon: 'Settings2', href: '/(tabs)/settings' },
+  ],
+  driver_manager: [
+    { name: 'dispatch',   title: 'Dispatch',   icon: 'Map',         href: '/(tabs)/dispatch' },
+    { name: 'routes',     title: 'Routes',     icon: 'Route',       href: '/(tabs)/routes' },
+    { name: 'exceptions', title: 'Exceptions', icon: 'AlertTriangle', href: '/(tabs)/exceptions', badge: 'exception_count' },
+    { name: 'reports',    title: 'Reports',    icon: 'BarChart2',   href: '/(tabs)/reports' },
+    { name: 'settings',   title: 'Settings',   icon: 'Settings2',   href: '/(tabs)/settings' },
+  ],
+  warehouse_worker: [
+    { name: 'picklist', title: 'Pick List', icon: 'ClipboardList', href: '/(tabs)/picklist' },
+    { name: 'inbound',  title: 'Inbound',   icon: 'ArrowDownToLine', href: '/(tabs)/inbound' },
+    { name: 'settings', title: 'Settings',  icon: 'Settings2',    href: '/(tabs)/settings' },
+  ],
+  warehouse_manager: [
+    { name: 'operations', title: 'Operations', icon: 'Activity',      href: '/(tabs)/operations', badge: 'exception_count' },
+    { name: 'inventory',  title: 'Inventory',  icon: 'Boxes',         href: '/(tabs)/inventory' },
+    { name: 'workers',    title: 'Workers',    icon: 'Users',         href: '/(tabs)/workers' },
+    { name: 'reports',    title: 'Reports',    icon: 'BarChart2',     href: '/(tabs)/reports' },
+    { name: 'settings',   title: 'Settings',   icon: 'Settings2',     href: '/(tabs)/settings' },
+  ],
+  app_admin: [
+    // App admin uses Salesforce Lightning — no mobile tab set
+    // If app_admin + another role, show that other role's tabs
+  ],
+};
+```

--- a/scripts/link-env.sh
+++ b/scripts/link-env.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# scripts/link-env.sh
+# Symlink the worktree's .env.local to a shared file under ~/.config/ohanafy-field/
+# so credentials persist across Conductor worktrees / branches.
+#
+# Usage:
+#   bash scripts/link-env.sh        # idempotent — safe to run on any worktree
+
+set -euo pipefail
+
+SHARED_DIR="$HOME/.config/ohanafy-field"
+SHARED_ENV="$SHARED_DIR/.env.local"
+LOCAL_ENV="$(pwd)/.env.local"
+
+mkdir -p "$SHARED_DIR"
+chmod 700 "$SHARED_DIR"
+
+# First-time bootstrap
+if [ ! -f "$SHARED_ENV" ]; then
+  if [ -f "$LOCAL_ENV" ] && [ ! -L "$LOCAL_ENV" ]; then
+    # Promote this worktree's existing .env.local to the shared location
+    mv "$LOCAL_ENV" "$SHARED_ENV"
+    chmod 600 "$SHARED_ENV"
+    echo "✓ Promoted $LOCAL_ENV → $SHARED_ENV"
+  elif [ -f .env.example ]; then
+    cp .env.example "$SHARED_ENV"
+    chmod 600 "$SHARED_ENV"
+    echo "✓ Created $SHARED_ENV from .env.example. Fill in values before running the app."
+  else
+    touch "$SHARED_ENV"
+    chmod 600 "$SHARED_ENV"
+    echo "✓ Created empty $SHARED_ENV. Add keys per .env.example."
+  fi
+fi
+
+# Link this worktree's .env.local
+if [ -L "$LOCAL_ENV" ]; then
+  current_target=$(readlink "$LOCAL_ENV")
+  if [ "$current_target" = "$SHARED_ENV" ]; then
+    echo "✓ $LOCAL_ENV already linked → $SHARED_ENV"
+    exit 0
+  else
+    echo "⚠  $LOCAL_ENV is a symlink pointing at $current_target — replacing with link to $SHARED_ENV"
+    rm "$LOCAL_ENV"
+  fi
+elif [ -f "$LOCAL_ENV" ]; then
+  echo "⚠  $LOCAL_ENV is a real file (not a symlink). Move or remove it manually first, then re-run." >&2
+  exit 1
+fi
+
+ln -s "$SHARED_ENV" "$LOCAL_ENV"
+echo "✓ Linked $LOCAL_ENV → $SHARED_ENV"
+echo ""
+echo "  Edit this file from any worktree:"
+echo "  $SHARED_ENV"

--- a/scripts/pmd-ruleset.xml
+++ b/scripts/pmd-ruleset.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Ohanafy Field Security Review Ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+           http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>
+    Apex PMD ruleset aligned to Salesforce AppExchange Security Review requirements.
+    Zero violations required before security review submission.
+    This ruleset is also enforced in CI on every push.
+  </description>
+
+  <!-- ═══════════════════════════════════════════
+       SECURITY — Critical. Rejection guaranteed.
+       ═══════════════════════════════════════════ -->
+
+  <!-- Sharing model not declared -->
+  <rule ref="category/apex/security.xml/ApexSharingViolations">
+    <priority>1</priority>
+  </rule>
+
+  <!-- SOQL injection via string concatenation -->
+  <rule ref="category/apex/security.xml/ApexSOQLInjection">
+    <priority>1</priority>
+  </rule>
+
+  <!-- XSS from URL parameters -->
+  <rule ref="category/apex/security.xml/ApexXSSFromURLParam">
+    <priority>1</priority>
+  </rule>
+
+  <!-- XSS from escape-unsafe methods -->
+  <rule ref="category/apex/security.xml/ApexXSSFromEscapeFalse">
+    <priority>1</priority>
+  </rule>
+
+  <!-- CRUD/FLS violations -->
+  <rule ref="category/apex/security.xml/ApexCRUDViolation">
+    <priority>1</priority>
+  </rule>
+
+  <!-- Open redirect vulnerability -->
+  <rule ref="category/apex/security.xml/ApexOpenRedirect">
+    <priority>1</priority>
+  </rule>
+
+  <!-- HTTP callout (not HTTPS) -->
+  <rule ref="category/apex/security.xml/ApexInsecureEndpoint">
+    <priority>1</priority>
+  </rule>
+
+  <!-- Dangerous permissions in Apex -->
+  <rule ref="category/apex/security.xml/ApexDangerousMethods">
+    <priority>1</priority>
+  </rule>
+
+  <!-- ═══════════════════════════════════════════
+       PERFORMANCE — Flagged in security review.
+       ═══════════════════════════════════════════ -->
+
+  <!-- SOQL inside for loop (governor limit risk) -->
+  <rule ref="category/apex/performance.xml/AvoidSoqlInLoops">
+    <priority>1</priority>
+  </rule>
+
+  <!-- DML inside for loop -->
+  <rule ref="category/apex/performance.xml/AvoidDmlStatementsInLoops">
+    <priority>1</priority>
+  </rule>
+
+  <!-- SOSL inside for loop -->
+  <rule ref="category/apex/performance.xml/AvoidSoslInLoops">
+    <priority>1</priority>
+  </rule>
+
+  <!-- ═══════════════════════════════════════════
+       ERROR HANDLING — Required for good review.
+       ═══════════════════════════════════════════ -->
+
+  <!-- Empty catch blocks -->
+  <rule ref="category/apex/errorprone.xml/EmptyCatchBlock">
+    <priority>2</priority>
+  </rule>
+
+  <!-- Hardcoded Salesforce IDs -->
+  <rule ref="category/apex/errorprone.xml/AvoidHardcodingId">
+    <priority>2</priority>
+  </rule>
+
+  <!-- NullPointerException risks -->
+  <rule ref="category/apex/errorprone.xml/ApexCSRF">
+    <priority>2</priority>
+  </rule>
+
+  <!-- ═══════════════════════════════════════════
+       BEST PRACTICES — Advisory but improve score.
+       ═══════════════════════════════════════════ -->
+
+  <!-- Avoid global modifier unless required -->
+  <rule ref="category/apex/bestpractices.xml/AvoidGlobalModifier">
+    <priority>3</priority>
+  </rule>
+
+  <!-- System.debug should use LoggingLevel -->
+  <rule ref="category/apex/bestpractices.xml/DebugsShouldUseLoggingLevel">
+    <priority>3</priority>
+  </rule>
+
+  <!-- Unused local variables -->
+  <rule ref="category/apex/bestpractices.xml/UnusedLocalVariable">
+    <priority>3</priority>
+  </rule>
+
+</ruleset>

--- a/scripts/setup-harness.sh
+++ b/scripts/setup-harness.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Ohanafy Field — Harness Setup
+# Run from the project root BEFORE Day 1 of the Product Bible.
+set -euo pipefail
+
+echo ""
+echo "══════════════════════════════════════════════"
+echo "  Ohanafy Field — Harness Setup"
+echo "══════════════════════════════════════════════"
+echo ""
+
+# ─────────────────────────────────────────────────
+# 1. CLAUDE CODE PLUGINS — Anthropic Official
+# ─────────────────────────────────────────────────
+echo "→ [1/7] Installing Anthropic official plugin marketplaces..."
+
+claude plugin marketplace add anthropics/skills           2>/dev/null || true
+claude plugin marketplace add anthropics/claude-plugins-official 2>/dev/null || true
+
+echo "   Installing core skills..."
+claude plugin install anthropics/skills:document-skills   2>/dev/null || echo "   (skip: document-skills)"
+claude plugin install anthropics/skills:skill-creator     2>/dev/null || echo "   (skip: skill-creator)"
+claude plugin install anthropics/skills:webapp-testing    2>/dev/null || echo "   (skip: webapp-testing)"
+claude plugin install anthropics/skills:brand-guidelines  2>/dev/null || echo "   (skip: brand-guidelines)"
+
+echo "✅ Anthropic official plugins step complete."
+
+# ─────────────────────────────────────────────────
+# 2. SDLC & CODE QUALITY PLUGINS — obra/superpowers
+# ─────────────────────────────────────────────────
+echo "→ [2/7] Installing SDLC skill bundles..."
+
+claude plugin marketplace add obra/superpowers            2>/dev/null || true
+
+# Core engineering discipline skills
+claude plugin install obra/superpowers:test-driven-development       2>/dev/null || echo "   (skip: test-driven-development)"
+claude plugin install obra/superpowers:systematic-debugging          2>/dev/null || echo "   (skip: systematic-debugging)"
+claude plugin install obra/superpowers:root-cause-tracing            2>/dev/null || echo "   (skip: root-cause-tracing)"
+claude plugin install obra/superpowers:subagent-driven-development   2>/dev/null || echo "   (skip: subagent-driven-development)"
+claude plugin install obra/superpowers:error-handling-patterns       2>/dev/null || echo "   (skip: error-handling-patterns)"
+
+echo "✅ SDLC skills step complete."
+
+# ─────────────────────────────────────────────────
+# 3. REFERENCE REPOS — Read-only, for patterns
+# ─────────────────────────────────────────────────
+echo "→ [3/7] Cloning reference repositories..."
+mkdir -p references
+grep -qxF 'references/' .gitignore 2>/dev/null || echo "references/" >> .gitignore
+
+pushd references > /dev/null
+
+  # ── Ohanafy private repos (require authenticated gh) ──────────────────────
+  echo "   Ohanafy private references..."
+  mkdir -p ohanafy
+  pushd ohanafy > /dev/null
+    for repo in \
+      ohanafy/ohanafy-managed-package \
+      ohanafy/ohanafy-connect \
+    ; do
+      gh repo clone "$repo" 2>/dev/null \
+        || echo "   (skip: $repo — unavailable or already cloned)"
+    done
+  popd > /dev/null
+
+  # ── Claude Code best practices ────────────────────────────────────────────
+  echo "   Claude Code best practices..."
+  gh repo clone hesreallyhim/awesome-claude-code         2>/dev/null || true
+  gh repo clone wshobson/agents                          2>/dev/null || true
+  gh repo clone shanraisshan/claude-code-best-practice   2>/dev/null || true
+  gh repo clone ThibautMelen/agentic-workflow-patterns   2>/dev/null || true
+  gh repo clone rohitg00/awesome-claude-code-toolkit     2>/dev/null || true
+
+  # ── Anthropic AI reference ────────────────────────────────────────────────
+  echo "   Anthropic AI patterns..."
+  gh repo clone anthropics/anthropic-cookbook            2>/dev/null || true
+
+  # ── React Native / Expo core ──────────────────────────────────────────────
+  echo "   React Native / Expo reference..."
+  gh repo clone expo/expo                                2>/dev/null || true
+  gh repo clone expo/router                              2>/dev/null || true
+  gh repo clone software-mansion/react-native-reanimated 2>/dev/null || true
+  gh repo clone Shopify/flash-list                       2>/dev/null || true
+  gh repo clone Nozbe/WatermelonDB                       2>/dev/null || true
+
+  # ── Mobile UI & design systems ────────────────────────────────────────────
+  echo "   Mobile UI design systems..."
+  gh repo clone shadcn-ui/ui                             2>/dev/null || true
+  gh repo clone tailwindlabs/tailwindcss                 2>/dev/null || true
+  gh repo clone nativewindui/nativewindui                2>/dev/null || true
+
+  # ── Testing ───────────────────────────────────────────────────────────────
+  echo "   Testing frameworks..."
+  gh repo clone mobile-dev-inc/maestro                   2>/dev/null || true
+  gh repo clone callstack/react-native-testing-library   2>/dev/null \
+    || gh repo clone testing-library/react-native-testing-library 2>/dev/null \
+    || true
+
+  # ── Accessibility ─────────────────────────────────────────────────────────
+  echo "   Accessibility references..."
+  gh repo clone FormidableLabs/react-native-a11y          2>/dev/null || true
+  gh repo clone dequelabs/axe-core                        2>/dev/null || true
+
+  # ── Salesforce ────────────────────────────────────────────────────────────
+  echo "   Salesforce references..."
+  gh repo clone trailheadapps/lwc-recipes                2>/dev/null || true
+  gh repo clone sfdx-isv/sfdx-falcon-template            2>/dev/null || true
+  gh repo clone forcedotcom/SalesforceMobileSDK-iOS      2>/dev/null || true
+
+  # ── Error tracking + observability ───────────────────────────────────────
+  echo "   Observability..."
+  gh repo clone getsentry/sentry-react-native            2>/dev/null || true
+  gh repo clone PostHog/posthog-react-native             2>/dev/null || true
+
+  # ── Documentation ─────────────────────────────────────────────────────────
+  echo "   Documentation tools..."
+  gh repo clone TypeStrong/typedoc                       2>/dev/null || true
+  gh repo clone jsdoc/jsdoc                              2>/dev/null || true
+
+popd > /dev/null
+
+echo "✅ Reference repos cloned to ./references/"
+
+# ─────────────────────────────────────────────────
+# 4. .claude/ DIRECTORY SKELETON
+# ─────────────────────────────────────────────────
+echo "→ [4/7] Verifying .claude/ directory skeleton..."
+
+mkdir -p .claude/{agents,skills,commands,rules,hooks}
+echo "✅ .claude/ skeleton verified. Files written by §5–§9 of the harness."
+
+# ─────────────────────────────────────────────────
+# 5. .claude/ FILES (already written by Session 0)
+# ─────────────────────────────────────────────────
+echo "→ [5/7] Confirming .claude/ files exist..."
+test -f .claude/settings.json && echo "   ✓ settings.json"
+echo "   agents:   $(ls .claude/agents/ 2>/dev/null | wc -l | tr -d ' ')"
+echo "   skills:   $(ls .claude/skills/ 2>/dev/null | wc -l | tr -d ' ')"
+echo "   commands: $(ls .claude/commands/ 2>/dev/null | wc -l | tr -d ' ')"
+echo "   rules:    $(ls .claude/rules/ 2>/dev/null | wc -l | tr -d ' ')"
+echo "   hooks:    $(ls .claude/hooks/ 2>/dev/null | wc -l | tr -d ' ')"
+
+# ─────────────────────────────────────────────────
+# 6. EAS + EXPO VERIFICATION
+# ─────────────────────────────────────────────────
+echo "→ [6/7] Verifying Expo + EAS toolchain..."
+npx expo --version 2>/dev/null || echo "   (warn: expo CLI not callable)"
+eas whoami 2>/dev/null || echo "   (warn: eas-cli not installed or not logged in — run: npm install -g eas-cli && eas login)"
+
+# ─────────────────────────────────────────────────
+# 7. FINAL VERIFICATION
+# ─────────────────────────────────────────────────
+echo "→ [7/7] Running harness verification..."
+echo ""
+echo "════════ HARNESS SETUP COMPLETE ════════"
+echo ""
+echo "Next steps:"
+echo "  1. Run the §2 verification checklist (see HARNESS-VERIFICATION.md)"
+echo "  2. Fill .env.local with credentials"
+echo "  3. Read §11 reference reading list (30 min — worth it)"
+echo "  4. Start Day 1 of OHANAFY-FIELD-PRODUCT-BIBLE.md"
+echo ""

--- a/scripts/sf-bootstrap/README.md
+++ b/scripts/sf-bootstrap/README.md
@@ -1,0 +1,68 @@
+# sf-bootstrap
+
+One-time SFDX project for the Ohanafy Field Mobile OAuth client.
+
+## Status
+
+- ✅ `sf` CLI installed (advances issue #10 — P1)
+- ✅ Authed to the dev sandbox as alias `ohanafy-sandbox`
+- ⚠ **Connected App deploy blocked** — see "Known issue" below
+- 🔁 Pivoted to UI-based **External Client App** for the dev sandbox
+
+## Known issue: Connected App creation disabled in scratch / dev orgs
+
+```
+You can't create a connected app. To enable connected app creation,
+contact Salesforce Customer Support.
+```
+
+As of recent Salesforce releases, classic Connected App creation is disabled in many scratch / Developer Edition orgs. Salesforce wants new clients on **External Client Apps**.
+
+**Implications:**
+- The `Ohanafy_Field_Mobile.connectedApp-meta.xml` here is kept for the **AppExchange managed package** (where Connected Apps are still required for ISV-distributed apps) — this file moves to `packages/sfdx-package/force-app/main/default/connectedApps/` on Day 4.
+- The dev sandbox uses an **External Client App** created via the UI (see manual steps below) for OAuth testing during Days 1–3.
+- The mobile OAuth flow is identical regardless of which kind of app — same endpoints, same PKCE, same scopes.
+
+## Manual one-time setup (dev sandbox)
+
+In your main browser (logged in to the sandbox):
+
+1. Setup → Apps → **External Client Apps** → Settings → ensure External Client Apps are enabled
+2. Setup → Apps → **External Client Apps** → **New External Client App**
+3. Fill:
+   - **External Client App Name:** `Ohanafy Field Mobile`
+   - **API Name:** `Ohanafy_Field_Mobile`
+   - **Contact Email:** `daniel.zeder@ohanafy.com`
+   - **Distribution State:** Local
+4. Configure **OAuth Settings**:
+   - **Enable OAuth:** ✓
+   - **Callback URL:** `com.ohanafy.field://oauth/callback`
+   - **OAuth Scopes:** `Manage user data via APIs (api)`, `Perform requests at any time (refresh_token, offline_access)`
+   - **Require Proof Key for Code Exchange (PKCE):** ✓
+   - **Require Secret for Web Server Flow:** ✗ (mobile public client)
+   - **Require Secret for Refresh Token Flow:** ✗
+5. Save and wait ~2 minutes for activation
+6. Copy the **Consumer Key** (shown on the External Client App detail page)
+
+Paste back to Claude (or just into `~/.config/ohanafy-field/.env.local`):
+
+```
+EXPO_PUBLIC_SF_INSTANCE_URL=https://enterprise-fun-8206-dev-ed.scratch.my.salesforce.com
+EXPO_PUBLIC_SF_CLIENT_ID=<the Consumer Key>
+```
+
+## Auth (already done)
+
+```bash
+cd scripts/sf-bootstrap
+sf org login web \
+  --instance-url https://enterprise-fun-8206-dev-ed.scratch.my.salesforce.com \
+  --alias ohanafy-sandbox
+```
+
+## Deploy attempts (for the record)
+
+```bash
+# This fails on the dev sandbox — kept as documentation:
+sf project deploy start --target-org ohanafy-sandbox --source-dir force-app
+```

--- a/scripts/sf-bootstrap/force-app/main/default/connectedApps/.forceignore
+++ b/scripts/sf-bootstrap/force-app/main/default/connectedApps/.forceignore
@@ -1,0 +1,1 @@
+# keep this dir tracked in git but excluded from sf project commands when run from root

--- a/scripts/sf-bootstrap/force-app/main/default/connectedApps/Ohanafy_Field_Mobile.connectedApp-meta.xml
+++ b/scripts/sf-bootstrap/force-app/main/default/connectedApps/Ohanafy_Field_Mobile.connectedApp-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConnectedApp xmlns="http://soap.sforce.com/2006/04/metadata">
+    <contactEmail>daniel.zeder@ohanafy.com</contactEmail>
+    <description>Ohanafy Field — mobile OAuth client (PKCE). Used for development and the AppExchange-distributed mobile app.</description>
+    <label>Ohanafy Field Mobile</label>
+    <oauthConfig>
+        <callbackUrl>com.ohanafy.field://oauth/callback</callbackUrl>
+        <isAdminApproved>false</isAdminApproved>
+        <isConsumerSecretOptional>true</isConsumerSecretOptional>
+        <isIntrospectAllTokens>false</isIntrospectAllTokens>
+        <isPkceRequired>true</isPkceRequired>
+        <isSecretRequiredForRefreshToken>false</isSecretRequiredForRefreshToken>
+        <scopes>Api</scopes>
+        <scopes>RefreshToken</scopes>
+    </oauthConfig>
+</ConnectedApp>

--- a/scripts/sf-bootstrap/sfdx-project.json
+++ b/scripts/sf-bootstrap/sfdx-project.json
@@ -1,0 +1,12 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "name": "ohanafy-field-bootstrap",
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "61.0"
+}


### PR DESCRIPTION
## Summary

- Stands up the Claude Code harness for the Ohanafy Field 7-day sprint: 9 agents, 7 skills, 7 slash commands, 7 rules, 3 executable hooks, plus `CLAUDE.md` with the document hierarchy and 10 permanent behavioral rules
- Drops the four canonical project docs at the repo root (Harness, Product Bible, Roles & Admin, AppExchange Security Review) plus `HARNESS-VERIFICATION.md` documenting the §2 checklist results
- Adds `scripts/setup-harness.sh` (idempotent bootstrap), `scripts/pmd-ruleset.xml` (zero-violations gate for AppExchange), `scripts/link-env.sh` (symlinks each Conductor worktree's `.env.local` to `~/.config/ohanafy-field/.env.local` so secrets persist across worktrees), and `scripts/sf-bootstrap/` with the Connected App XML for the AppExchange managed package and a README explaining the dev-sandbox External Client App workaround
- Closes Session 0 issues #1–#7 and #10; ready to take a feature branch for Day 1 scaffolding (Expo + WatermelonDB schema with permissions table from Roles §12 + permission system + SF OAuth + biometric lock + role-driven nav)

## Test plan

- [ ] `jq -e . .claude/settings.json` exits 0
- [ ] `bash scripts/link-env.sh` is idempotent on a fresh worktree
- [ ] `pmd check --rulesets scripts/pmd-ruleset.xml --dir scripts/sf-bootstrap/force-app/` parses ruleset
- [ ] `cat HARNESS-VERIFICATION.md` shows P0 cluster green
- [ ] No `.env.local`, `references/`, or `.sf/` files in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)