### PR TITLE
feat(day-2): core features — accounts, orders, visits, offline sync

### DIFF
--- a/__tests__/unit/sync/queue-processor.test.ts
+++ b/__tests__/unit/sync/queue-processor.test.ts
@@ -1,0 +1,209 @@
+import { processQueueItem } from '@/sync/queue-processor';
+import type { SFClient } from '@/sync/sf-client';
+
+type FakeOrder = {
+  sfId?: string;
+  status: string;
+  sfSyncStatus: string;
+  updatedAt: Date;
+  [key: string]: unknown;
+};
+type FakeVisit = {
+  sfId?: string;
+  sfSyncStatus: string;
+  [key: string]: unknown;
+};
+type FakeQueueItem = {
+  id: string;
+  status: string;
+  attempts: number;
+  lastError?: string;
+  processedAt?: Date;
+  operationType: 'CREATE_ORDER' | 'CREATE_VISIT';
+  payloadJson: string;
+  [key: string]: unknown;
+};
+
+function makeFakeDb() {
+  const orders: Record<string, FakeOrder> = {
+    local_order_001: { status: 'pending_sync', sfSyncStatus: 'pending', updatedAt: new Date() },
+  };
+  const visits: Record<string, FakeVisit> = {
+    local_visit_001: { sfSyncStatus: 'pending' },
+  };
+  const queueItems: Record<string, FakeQueueItem> = {};
+
+  function makeRecordProxy<T extends Record<string, unknown>>(target: T) {
+    return {
+      ...target,
+      update: async (mutator: (rec: T) => void) => {
+        mutator(target);
+      },
+    };
+  }
+
+  const db = {
+    write: async (fn: () => Promise<void>) => fn(),
+    get: (table: string) => ({
+      find: async (id: string) => {
+        if (table === 'orders' && orders[id]) return makeRecordProxy(orders[id]);
+        if (table === 'visits' && visits[id]) return makeRecordProxy(visits[id]);
+        if (table === 'sync_queue' && queueItems[id]) return makeRecordProxy(queueItems[id]);
+        throw new Error(`record not found: ${table}/${id}`);
+      },
+    }),
+  };
+
+  return { db, orders, visits, queueItems };
+}
+
+describe('processQueueItem — CREATE_ORDER', () => {
+  it('creates order in Salesforce, creates lines, updates local sync status', async () => {
+    const { db, orders, queueItems } = makeFakeDb();
+    queueItems.qi_1 = {
+      id: 'qi_1',
+      status: 'pending',
+      attempts: 0,
+      operationType: 'CREATE_ORDER',
+      payloadJson: JSON.stringify({
+        localId: 'local_order_001',
+        accountSfId: 'a01',
+        repId: 'rep_1',
+        totalAmount: 356,
+        lines: [
+          {
+            productSfId: 'p01',
+            productName: 'Pale Ale',
+            quantity: 2,
+            unit: 'keg',
+            unitPrice: 178,
+            lineTotal: 356,
+          },
+        ],
+      }),
+    };
+
+    const calls: Array<{ object: string; payload: Record<string, unknown> }> = [];
+    const client: SFClient = {
+      createRecord: jest.fn(async (object, payload) => {
+        calls.push({ object, payload });
+        return { id: object === 'ohfy_field__Order__c' ? 'SF_ORDER_001' : 'SF_LINE_001' };
+      }),
+      updateRecord: jest.fn(),
+      query: jest.fn(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await processQueueItem(queueItems.qi_1 as any, db as any, client);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].object).toBe('ohfy_field__Order__c');
+    expect(calls[1].object).toBe('ohfy_field__OrderLine__c');
+    expect(orders.local_order_001.sfId).toBe('SF_ORDER_001');
+    expect(orders.local_order_001.status).toBe('synced');
+    expect(orders.local_order_001.sfSyncStatus).toBe('synced');
+    expect(queueItems.qi_1.status).toBe('done');
+  });
+
+  it('marks item failed (still pending, attempts++) on Salesforce error', async () => {
+    const { db, queueItems } = makeFakeDb();
+    queueItems.qi_2 = {
+      id: 'qi_2',
+      status: 'pending',
+      attempts: 0,
+      operationType: 'CREATE_ORDER',
+      payloadJson: JSON.stringify({
+        localId: 'local_order_001',
+        accountSfId: 'a01',
+        repId: 'rep_1',
+        totalAmount: 0,
+        lines: [],
+      }),
+    };
+
+    const client: SFClient = {
+      createRecord: jest.fn(async () => {
+        throw new Error('SF timeout');
+      }),
+      updateRecord: jest.fn(),
+      query: jest.fn(),
+    };
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      processQueueItem(queueItems.qi_2 as any, db as any, client)
+    ).rejects.toThrow('SF timeout');
+    expect(queueItems.qi_2.attempts).toBe(1);
+    expect(queueItems.qi_2.status).toBe('pending');
+    expect(queueItems.qi_2.lastError).toContain('SF timeout');
+  });
+
+  it('marks item permanently failed at attempts >= 3', async () => {
+    const { db, queueItems } = makeFakeDb();
+    queueItems.qi_3 = {
+      id: 'qi_3',
+      status: 'pending',
+      attempts: 2,
+      operationType: 'CREATE_ORDER',
+      payloadJson: JSON.stringify({
+        localId: 'local_order_001',
+        accountSfId: 'a01',
+        repId: 'rep_1',
+        totalAmount: 0,
+        lines: [],
+      }),
+    };
+
+    const client: SFClient = {
+      createRecord: jest.fn(async () => {
+        throw new Error('SF timeout');
+      }),
+      updateRecord: jest.fn(),
+      query: jest.fn(),
+    };
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      processQueueItem(queueItems.qi_3 as any, db as any, client)
+    ).rejects.toThrow('SF timeout');
+    expect(queueItems.qi_3.attempts).toBe(3);
+    expect(queueItems.qi_3.status).toBe('failed');
+  });
+});
+
+describe('processQueueItem — CREATE_VISIT', () => {
+  it('creates visit in Salesforce and updates local sync status', async () => {
+    const { db, visits, queueItems } = makeFakeDb();
+    queueItems.qi_v1 = {
+      id: 'qi_v1',
+      status: 'pending',
+      attempts: 0,
+      operationType: 'CREATE_VISIT',
+      payloadJson: JSON.stringify({
+        localId: 'local_visit_001',
+        accountSfId: 'a01',
+        repId: 'rep_1',
+        note: 'Tap issue resolved.',
+      }),
+    };
+
+    const client: SFClient = {
+      createRecord: jest.fn(async () => ({ id: 'SF_VISIT_001' })),
+      updateRecord: jest.fn(),
+      query: jest.fn(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await processQueueItem(queueItems.qi_v1 as any, db as any, client);
+
+    expect(client.createRecord).toHaveBeenCalledWith(
+      'ohfy_field__Visit__c',
+      expect.objectContaining({
+        ohfy_field__Account__c: 'a01',
+        ohfy_field__Note__c: 'Tap issue resolved.',
+      })
+    );
+    expect(visits.local_visit_001.sfId).toBe('SF_VISIT_001');
+    expect(visits.local_visit_001.sfSyncStatus).toBe('synced');
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,20 +1,95 @@
-import { Text, View } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
+import { router } from 'expo-router';
+import { useCallback, useState } from 'react';
+import { Pressable, Text, TextInput, View } from 'react-native';
 
+import { AccountCard } from '@/components/account/AccountCard';
+import { EmptyState } from '@/components/shared/EmptyState';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { LoadingSkeleton } from '@/components/shared/LoadingSkeleton';
+import { OfflineBanner } from '@/components/sync/OfflineBanner';
+import { SyncStatusBar } from '@/components/sync/SyncStatusBar';
+import type { Account } from '@/db/models/Account';
+import { useAccountList } from '@/hooks/useAccountList';
+
+const ACCOUNT_CARD_HEIGHT = 100;
 
 export default function Accounts(): React.ReactNode {
+  const [search, setSearch] = useState('');
+  const [needsAttentionOnly, setNeedsAttentionOnly] = useState(false);
+  const { accounts, loading } = useAccountList({ search, needsAttentionOnly });
+
+  const handleOpen = useCallback((id: string) => {
+    router.push(`/account/${id}`);
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: Account }) => <AccountCard account={item} onPress={handleOpen} />,
+    [handleOpen]
+  );
+
   return (
     <ErrorBoundary screenName="Accounts">
-      <View
-        accessibilityLabel="Accounts list"
-        className="flex-1 bg-ohanafy-paper px-6 pt-16 dark:bg-ohanafy-dark-surface"
-      >
-        <Text className="text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
-          Accounts
-        </Text>
-        <Text className="mt-2 text-base text-ohanafy-muted dark:text-ohanafy-dark-muted">
-          Day 2 fills this in: FlashList of accounts from WatermelonDB, search, and Needs Attention filter.
-        </Text>
+      <View className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface">
+        <OfflineBanner />
+        <SyncStatusBar />
+        <View className="px-4 pb-3 pt-12">
+          <Text className="mb-3 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+            Accounts
+          </Text>
+          <TextInput
+            accessibilityLabel="Search accounts"
+            accessibilityHint="Filters the account list as you type"
+            placeholder="Search…"
+            placeholderTextColor="#9a9a9a"
+            value={search}
+            onChangeText={setSearch}
+            className="rounded-xl bg-ohanafy-cork px-4 py-3 text-base text-ohanafy-ink dark:bg-ohanafy-dark-elevated dark:text-ohanafy-dark-text"
+          />
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Needs Attention filter"
+            accessibilityState={{ selected: needsAttentionOnly }}
+            accessibilityHint="Toggles the filter to show only accounts that need attention"
+            onPress={() => setNeedsAttentionOnly((v) => !v)}
+            className={
+              needsAttentionOnly
+                ? 'mt-3 self-start rounded-full bg-ohanafy-denim px-3 py-1.5'
+                : 'mt-3 self-start rounded-full border border-ohanafy-denim px-3 py-1.5'
+            }
+          >
+            <Text
+              className={
+                needsAttentionOnly
+                  ? 'text-xs font-bold text-ohanafy-paper'
+                  : 'text-xs font-bold text-ohanafy-denim dark:text-ohanafy-denim-light'
+              }
+            >
+              Needs Attention
+            </Text>
+          </Pressable>
+        </View>
+        {loading ? (
+          <LoadingSkeleton count={5} itemHeight={ACCOUNT_CARD_HEIGHT} />
+        ) : accounts.length === 0 ? (
+          <EmptyState
+            title="No accounts found"
+            description={
+              search
+                ? `Nothing matches "${search}". Try a different search.`
+                : 'When your sync completes, accounts in your territory will appear here.'
+            }
+          />
+        ) : (
+          <FlashList
+            data={accounts}
+            renderItem={renderItem}
+            estimatedItemSize={ACCOUNT_CARD_HEIGHT}
+            keyExtractor={(item) => item.id}
+            getItemType={() => 'account'}
+            accessibilityLabel={`Accounts, ${accounts.length} items`}
+          />
+        )}
       </View>
     </ErrorBoundary>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,7 +7,10 @@ import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { database } from '@/db';
+import { seedDatabase } from '@/db/seeder';
 import { initPostHog, initSentry } from '@/observability';
+import { startSyncEngine } from '@/sync/engine';
 
 initSentry();
 
@@ -20,11 +23,25 @@ const queryClient = new QueryClient({
   },
 });
 
+const useSeed = process.env.EXPO_PUBLIC_USE_SEED_DATA === 'true';
+
 export default function RootLayout(): React.ReactNode {
   useEffect(() => {
     // Defer non-critical init off the launch path
     const id = setTimeout(() => initPostHog(), 0);
-    return () => clearTimeout(id);
+
+    // Seed demo data on first run if enabled (no-op when DB already has rows)
+    if (useSeed) {
+      seedDatabase(database, { repId: 'demo-rep' }).catch(() => undefined);
+    }
+
+    // Auto-flush sync queue on reconnect
+    const stopSync = startSyncEngine();
+
+    return () => {
+      clearTimeout(id);
+      stopSync();
+    };
   }, []);
 
   return (

--- a/app/account/[id].tsx
+++ b/app/account/[id].tsx
@@ -1,0 +1,155 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
+
+import { useAuthStore } from '@/auth/store';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { database } from '@/db';
+import type { Account } from '@/db/models/Account';
+import type { Order } from '@/db/models/Order';
+import type { Visit } from '@/db/models/Visit';
+import { getAccountById } from '@/db/repositories/accounts';
+import { createDraftOrder, listOrdersForAccount } from '@/db/repositories/orders';
+import { listVisitsForAccount } from '@/db/repositories/visits';
+
+export default function AccountDetail(): React.ReactNode {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const repId = useAuthStore((s) => s.userId) ?? 'demo-rep';
+  const [account, setAccount] = useState<Account | null>(null);
+  const [visits, setVisits] = useState<Visit[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    (async (): Promise<void> => {
+      const [a, vs, os] = await Promise.all([
+        getAccountById(database, id),
+        listVisitsForAccount(database, id, 5),
+        listOrdersForAccount(database, id),
+      ]);
+      if (cancelled) return;
+      setAccount(a);
+      setVisits(vs);
+      setOrders(os);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const handleNewOrder = async (): Promise<void> => {
+    if (!account) return;
+    const order = await createDraftOrder(database, {
+      accountId: account.id,
+      accountSfId: account.sfId,
+      repId,
+    });
+    router.push(`/order/${order.id}`);
+  };
+
+  const handleLogVisit = (): void => {
+    if (!account) return;
+    router.push(`/visit/new?accountId=${account.id}&accountSfId=${account.sfId}`);
+  };
+
+  if (loading || !account) {
+    return (
+      <ErrorBoundary screenName="AccountDetail">
+        <View className="flex-1 items-center justify-center bg-ohanafy-paper dark:bg-ohanafy-dark-surface">
+          <ActivityIndicator color="#4A5F80" />
+        </View>
+      </ErrorBoundary>
+    );
+  }
+
+  const lastOrder = orders[0];
+
+  return (
+    <ErrorBoundary screenName="AccountDetail">
+      <ScrollView
+        accessibilityLabel={`Account: ${account.name}`}
+        className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface"
+        contentContainerClassName="px-4 pt-12 pb-32"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back to accounts"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+        </Pressable>
+
+        <Text className="text-3xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          {account.name}
+        </Text>
+        <Text className="mt-1 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+          {account.contactName} · {account.contactTitle}
+        </Text>
+        <Text className="mt-1 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+          {account.addressStreet}, {account.addressCity}, {account.addressState}
+        </Text>
+
+        <View className="mt-6 flex-row gap-3">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="New order"
+            accessibilityHint="Starts a new order for this account"
+            onPress={handleNewOrder}
+            className="flex-1 rounded-xl bg-ohanafy-denim px-4 py-3 active:opacity-80"
+          >
+            <Text className="text-center text-base font-bold text-ohanafy-paper">New Order</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Log visit"
+            accessibilityHint="Logs a visit note for this account"
+            onPress={handleLogVisit}
+            className="flex-1 rounded-xl border border-ohanafy-denim px-4 py-3 active:opacity-80"
+          >
+            <Text className="text-center text-base font-bold text-ohanafy-denim dark:text-ohanafy-denim-light">
+              Log Visit
+            </Text>
+          </Pressable>
+        </View>
+
+        {lastOrder ? (
+          <View className="mt-6 rounded-2xl bg-ohanafy-cork p-4 dark:bg-ohanafy-dark-elevated">
+            <Text className="mb-1 text-xs font-bold uppercase tracking-wider text-ohanafy-muted dark:text-ohanafy-dark-muted">
+              Last Order
+            </Text>
+            <Text className="text-base text-ohanafy-ink dark:text-ohanafy-dark-text">
+              ${lastOrder.totalAmount.toFixed(2)} · {lastOrder.status}
+            </Text>
+          </View>
+        ) : null}
+
+        <Text className="mb-2 mt-8 text-xs font-bold uppercase tracking-wider text-ohanafy-muted dark:text-ohanafy-dark-muted">
+          Recent Visits
+        </Text>
+        {visits.length === 0 ? (
+          <Text className="text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+            No visits logged yet.
+          </Text>
+        ) : (
+          visits.map((v) => (
+            <View
+              key={v.id}
+              className="mb-2 rounded-xl bg-ohanafy-cork p-3 dark:bg-ohanafy-dark-elevated"
+            >
+              <Text className="text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+                {v.visitDate.toLocaleDateString()}
+              </Text>
+              <Text className="mt-1 text-sm text-ohanafy-ink dark:text-ohanafy-dark-text">
+                {v.note ?? '(no note)'}
+              </Text>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/app/order/[id].tsx
+++ b/app/order/[id].tsx
@@ -1,0 +1,165 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
+import { ActivityIndicator, Pressable, Text, View } from 'react-native';
+
+import { LineItem } from '@/components/order/LineItem';
+import { ProductPicker } from '@/components/order/ProductPicker';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { database } from '@/db';
+import {
+  addLineToOrder,
+  removeLine,
+  updateLineQuantity,
+} from '@/db/repositories/orders';
+import type { Product } from '@/db/models/Product';
+import { useOrder } from '@/hooks/useOrder';
+
+export default function OrderEntry(): React.ReactNode {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { order, lines, products, loading } = useOrder(id);
+  const [showPicker, setShowPicker] = useState(false);
+
+  const handleAdd = async (product: Product): Promise<void> => {
+    if (!id) return;
+    const existing = lines.find((l) => l.productId === product.id);
+    if (existing) {
+      await updateLineQuantity(database, existing.id, existing.quantity + 1);
+    } else {
+      await addLineToOrder(database, id, { product, quantity: 1 });
+    }
+  };
+
+  const handleIncrement = async (lineId: string): Promise<void> => {
+    const line = lines.find((l) => l.id === lineId);
+    if (line) await updateLineQuantity(database, lineId, line.quantity + 1);
+  };
+
+  const handleDecrement = async (lineId: string): Promise<void> => {
+    const line = lines.find((l) => l.id === lineId);
+    if (line) await updateLineQuantity(database, lineId, line.quantity - 1);
+  };
+
+  const handleRemove = async (lineId: string): Promise<void> => {
+    await removeLine(database, lineId);
+  };
+
+  const handleConfirm = (): void => {
+    if (id) router.push(`/order/${id}/confirm`);
+  };
+
+  if (loading || !order) {
+    return (
+      <ErrorBoundary screenName="OrderEntry">
+        <View className="flex-1 items-center justify-center bg-ohanafy-paper dark:bg-ohanafy-dark-surface">
+          <ActivityIndicator color="#4A5F80" />
+        </View>
+      </ErrorBoundary>
+    );
+  }
+
+  return (
+    <ErrorBoundary screenName="OrderEntry">
+      <View
+        accessibilityLabel="Order entry"
+        className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface"
+      >
+        <View className="border-b border-ohanafy-cork px-4 pb-4 pt-12 dark:border-ohanafy-dark-elevated">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            onPress={() => router.back()}
+            className="mb-3 self-start"
+          >
+            <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+          </Pressable>
+          <Text className="text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+            Order
+          </Text>
+          <Text className="mt-1 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+            {lines.length} {lines.length === 1 ? 'line' : 'lines'} · ${order.totalAmount.toFixed(2)}
+          </Text>
+        </View>
+
+        {showPicker ? (
+          <View className="flex-1">
+            <View className="flex-row items-center justify-between px-4 pt-3">
+              <Text className="text-xs font-bold uppercase tracking-wider text-ohanafy-muted dark:text-ohanafy-dark-muted">
+                Add a product
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Close product picker"
+                onPress={() => setShowPicker(false)}
+              >
+                <Text className="text-sm font-bold text-ohanafy-denim dark:text-ohanafy-denim-light">
+                  Done
+                </Text>
+              </Pressable>
+            </View>
+            <ProductPicker
+              products={products}
+              onSelect={(p) => {
+                handleAdd(p);
+              }}
+            />
+          </View>
+        ) : (
+          <View className="flex-1 px-4 pt-3">
+            {lines.length === 0 ? (
+              <Text className="text-center text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+                No items yet. Tap Add Item below.
+              </Text>
+            ) : (
+              lines.map((line) => (
+                <LineItem
+                  key={line.id}
+                  line={line}
+                  onIncrement={handleIncrement}
+                  onDecrement={handleDecrement}
+                  onRemove={handleRemove}
+                />
+              ))
+            )}
+          </View>
+        )}
+
+        <View className="border-t border-ohanafy-cork bg-ohanafy-paper px-4 pb-8 pt-3 dark:border-ohanafy-dark-elevated dark:bg-ohanafy-dark-surface">
+          <View className="flex-row gap-3">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={showPicker ? 'Hide product picker' : 'Add item'}
+              onPress={() => setShowPicker((v) => !v)}
+              className="flex-1 rounded-xl border border-ohanafy-denim px-4 py-3"
+            >
+              <Text className="text-center text-base font-bold text-ohanafy-denim dark:text-ohanafy-denim-light">
+                {showPicker ? 'Hide Picker' : '+ Add Item'}
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Review and confirm order"
+              accessibilityState={{ disabled: lines.length === 0 }}
+              disabled={lines.length === 0}
+              onPress={handleConfirm}
+              className={
+                lines.length === 0
+                  ? 'flex-1 rounded-xl bg-ohanafy-cork px-4 py-3 dark:bg-ohanafy-dark-elevated'
+                  : 'flex-1 rounded-xl bg-ohanafy-denim px-4 py-3 active:opacity-80'
+              }
+            >
+              <Text
+                className={
+                  lines.length === 0
+                    ? 'text-center text-base font-bold text-ohanafy-muted'
+                    : 'text-center text-base font-bold text-ohanafy-paper'
+                }
+              >
+                Review
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </ErrorBoundary>
+  );
+}

--- a/app/order/[id]/confirm.tsx
+++ b/app/order/[id]/confirm.tsx
@@ -1,0 +1,124 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
+
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { database } from '@/db';
+import { submitOrder } from '@/db/repositories/orders';
+import { enqueue } from '@/db/repositories/sync-queue';
+import { useOrder } from '@/hooks/useOrder';
+
+export default function OrderConfirm(): React.ReactNode {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { order, lines, loading } = useOrder(id);
+  const [busy, setBusy] = useState(false);
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!id || !order) return;
+    setBusy(true);
+    try {
+      await submitOrder(database, id);
+      await enqueue(database, {
+        operationType: 'CREATE_ORDER',
+        entityType: 'order',
+        entityId: id,
+        payload: {
+          localId: id,
+          accountSfId: order.accountSfId,
+          repId: order.repId,
+          totalAmount: order.totalAmount,
+          lines: lines.map((l) => ({
+            productSfId: l.productSfId,
+            productName: l.productName,
+            quantity: l.quantity,
+            unit: l.unit,
+            unitPrice: l.unitPrice,
+            lineTotal: l.lineTotal,
+          })),
+        },
+      });
+      router.dismissAll();
+      router.replace('/(tabs)');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading || !order) {
+    return (
+      <ErrorBoundary screenName="OrderConfirm">
+        <View className="flex-1 items-center justify-center bg-ohanafy-paper dark:bg-ohanafy-dark-surface">
+          <ActivityIndicator color="#4A5F80" />
+        </View>
+      </ErrorBoundary>
+    );
+  }
+
+  return (
+    <ErrorBoundary screenName="OrderConfirm">
+      <ScrollView
+        accessibilityLabel="Confirm order"
+        className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface"
+        contentContainerClassName="px-4 pt-12 pb-32"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back to order entry"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+        </Pressable>
+        <Text className="mb-4 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          Confirm Order
+        </Text>
+        {lines.map((line) => (
+          <View
+            key={line.id}
+            className="mb-2 rounded-xl bg-ohanafy-cork p-3 dark:bg-ohanafy-dark-elevated"
+          >
+            <View className="flex-row items-center justify-between">
+              <Text className="flex-1 text-base text-ohanafy-ink dark:text-ohanafy-dark-text">
+                {line.quantity} × {line.productName}
+              </Text>
+              <Text className="text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+                ${line.lineTotal.toFixed(2)}
+              </Text>
+            </View>
+          </View>
+        ))}
+        <View className="mt-4 rounded-2xl bg-ohanafy-denim p-4">
+          <Text className="text-xs font-bold uppercase tracking-wider text-ohanafy-paper opacity-80">
+            Total
+          </Text>
+          <Text className="mt-1 text-3xl font-bold text-ohanafy-paper">
+            ${order.totalAmount.toFixed(2)}
+          </Text>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Place order"
+          accessibilityHint="Saves the order locally and queues it for sync to Salesforce"
+          accessibilityState={{ disabled: busy }}
+          disabled={busy}
+          onPress={handleSubmit}
+          className={
+            busy
+              ? 'mt-6 rounded-xl bg-ohanafy-cork px-4 py-4 dark:bg-ohanafy-dark-elevated'
+              : 'mt-6 rounded-xl bg-ohanafy-denim px-4 py-4 active:opacity-80'
+          }
+        >
+          <Text
+            className={
+              busy
+                ? 'text-center text-base font-bold text-ohanafy-muted'
+                : 'text-center text-base font-bold text-ohanafy-paper'
+            }
+          >
+            {busy ? 'Placing…' : 'Place Order'}
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/app/visit/new.tsx
+++ b/app/visit/new.tsx
@@ -1,0 +1,95 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
+import { Pressable, Text, TextInput, View } from 'react-native';
+
+import { useAuthStore } from '@/auth/store';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { database } from '@/db';
+import { logVisit } from '@/db/repositories/visits';
+import { enqueue } from '@/db/repositories/sync-queue';
+
+export default function NewVisit(): React.ReactNode {
+  const { accountId, accountSfId } = useLocalSearchParams<{
+    accountId: string;
+    accountSfId: string;
+  }>();
+  const repId = useAuthStore((s) => s.userId) ?? 'demo-rep';
+  const [note, setNote] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const handleSave = async (): Promise<void> => {
+    if (!accountId || !accountSfId || !note.trim()) return;
+    setBusy(true);
+    try {
+      const visit = await logVisit(database, {
+        accountId,
+        accountSfId,
+        repId,
+        note: note.trim(),
+      });
+      await enqueue(database, {
+        operationType: 'CREATE_VISIT',
+        entityType: 'visit',
+        entityId: visit.id,
+        payload: { localId: visit.id, accountSfId, note: note.trim(), repId },
+      });
+      router.back();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <ErrorBoundary screenName="NewVisit">
+      <View
+        accessibilityLabel="New visit note"
+        className="flex-1 bg-ohanafy-paper px-4 pt-12 dark:bg-ohanafy-dark-surface"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">Cancel</Text>
+        </Pressable>
+        <Text className="mb-4 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          Log Visit
+        </Text>
+        <TextInput
+          accessibilityLabel="Visit note"
+          accessibilityHint="Type the visit note here. Day 3 adds voice dictation."
+          placeholder="What did you talk about? Any tap issues, new menu items, sell-through concerns…"
+          placeholderTextColor="#9a9a9a"
+          value={note}
+          onChangeText={setNote}
+          multiline
+          textAlignVertical="top"
+          className="min-h-[160px] rounded-2xl bg-ohanafy-cork p-4 text-base text-ohanafy-ink dark:bg-ohanafy-dark-elevated dark:text-ohanafy-dark-text"
+        />
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Save visit"
+          accessibilityState={{ disabled: busy || note.trim().length === 0 }}
+          disabled={busy || note.trim().length === 0}
+          onPress={handleSave}
+          className={
+            busy || note.trim().length === 0
+              ? 'mt-6 rounded-xl bg-ohanafy-cork px-4 py-3 dark:bg-ohanafy-dark-elevated'
+              : 'mt-6 rounded-xl bg-ohanafy-denim px-4 py-3 active:opacity-80'
+          }
+        >
+          <Text
+            className={
+              busy || note.trim().length === 0
+                ? 'text-center text-base font-bold text-ohanafy-muted'
+                : 'text-center text-base font-bold text-ohanafy-paper'
+            }
+          >
+            {busy ? 'Saving…' : 'Save Visit'}
+          </Text>
+        </Pressable>
+      </View>
+    </ErrorBoundary>
+  );
+}

--- a/src/components/account/AccountCard.tsx
+++ b/src/components/account/AccountCard.tsx
@@ -1,0 +1,56 @@
+import { memo } from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+import type { Account } from '@/db/models/Account';
+
+interface AccountCardProps {
+  account: Account;
+  onPress: (id: string) => void;
+}
+
+function AccountCardBase({ account, onPress }: AccountCardProps): React.ReactNode {
+  const lastOrderDays = account.daysSinceLastOrder;
+  const subtitle = `${account.addressCity}, ${account.addressState} · ${account.channel}`;
+  const lastOrderLabel =
+    lastOrderDays === 0 ? 'Today' : `${lastOrderDays}d since last order`;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${account.name}, ${subtitle}, ${lastOrderLabel}`}
+      accessibilityHint="Opens account detail"
+      onPress={() => onPress(account.id)}
+      testID={`account-card-${account.sfId}`}
+      className="mx-4 mb-3 rounded-2xl bg-ohanafy-paper p-4 active:opacity-80 dark:bg-ohanafy-dark-elevated"
+    >
+      <View className="flex-row items-center justify-between">
+        <Text className="flex-1 text-lg font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          {account.name}
+        </Text>
+        {account.needsAttention ? (
+          <View
+            accessibilityLabel="Needs attention"
+            className="ml-2 rounded-full bg-ohanafy-mellow px-2 py-0.5"
+          >
+            <Text className="text-xs font-bold text-ohanafy-ink">!</Text>
+          </View>
+        ) : null}
+      </View>
+      <Text className="mt-1 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+        {subtitle}
+      </Text>
+      <Text className="mt-1 text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+        {lastOrderLabel}
+      </Text>
+    </Pressable>
+  );
+}
+
+export const AccountCard = memo(
+  AccountCardBase,
+  (prev, next) =>
+    prev.account.id === next.account.id &&
+    prev.account.needsAttention === next.account.needsAttention &&
+    prev.account.daysSinceLastOrder === next.account.daysSinceLastOrder &&
+    prev.onPress === next.onPress
+);

--- a/src/components/order/LineItem.tsx
+++ b/src/components/order/LineItem.tsx
@@ -1,0 +1,81 @@
+import { memo } from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+import type { OrderLine } from '@/db/models/OrderLine';
+
+interface LineItemProps {
+  line: OrderLine;
+  onIncrement: (lineId: string) => void;
+  onDecrement: (lineId: string) => void;
+  onRemove: (lineId: string) => void;
+}
+
+function LineItemBase({
+  line,
+  onIncrement,
+  onDecrement,
+  onRemove,
+}: LineItemProps): React.ReactNode {
+  return (
+    <View
+      accessibilityLabel={`${line.quantity} ${line.unit} of ${line.productName}, line total ${line.lineTotal} dollars`}
+      className="mb-3 rounded-2xl bg-ohanafy-paper p-4 dark:bg-ohanafy-dark-elevated"
+    >
+      <View className="flex-row items-center justify-between">
+        <Text className="flex-1 text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          {line.productName}
+        </Text>
+        <Text className="text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          ${line.lineTotal.toFixed(2)}
+        </Text>
+      </View>
+      <Text className="mt-1 text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+        {line.unit} · ${line.unitPrice.toFixed(2)}/each
+      </Text>
+      <View className="mt-3 flex-row items-center justify-between">
+        <View className="flex-row items-center gap-2">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Decrease quantity of ${line.productName}`}
+            onPress={() => onDecrement(line.id)}
+            className="h-9 w-9 items-center justify-center rounded-full bg-ohanafy-cork dark:bg-ohanafy-dark-surface"
+          >
+            <Text className="text-lg font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">−</Text>
+          </Pressable>
+          <Text
+            accessibilityLiveRegion="polite"
+            className="min-w-[32px] text-center text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text"
+          >
+            {line.quantity}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Increase quantity of ${line.productName}`}
+            onPress={() => onIncrement(line.id)}
+            className="h-9 w-9 items-center justify-center rounded-full bg-ohanafy-cork dark:bg-ohanafy-dark-surface"
+          >
+            <Text className="text-lg font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">+</Text>
+          </Pressable>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Remove ${line.productName} from order`}
+          onPress={() => onRemove(line.id)}
+          className="px-3 py-2"
+        >
+          <Text className="text-sm font-bold text-ohanafy-denim dark:text-ohanafy-denim-light">
+            Remove
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+export const LineItem = memo(
+  LineItemBase,
+  (prev, next) =>
+    prev.line.id === next.line.id &&
+    prev.line.quantity === next.line.quantity &&
+    prev.line.lineTotal === next.line.lineTotal
+);

--- a/src/components/order/ProductPicker.tsx
+++ b/src/components/order/ProductPicker.tsx
@@ -1,0 +1,49 @@
+import { FlashList } from '@shopify/flash-list';
+import { Pressable, Text, View } from 'react-native';
+
+import type { Product } from '@/db/models/Product';
+
+interface ProductPickerProps {
+  products: Product[];
+  onSelect: (product: Product) => void;
+}
+
+const PRODUCT_ROW_HEIGHT = 56;
+
+export function ProductPicker({ products, onSelect }: ProductPickerProps): React.ReactNode {
+  return (
+    <View
+      accessibilityLabel={`Product catalog, ${products.length} items`}
+      className="flex-1"
+    >
+      <FlashList
+        data={products}
+        estimatedItemSize={PRODUCT_ROW_HEIGHT}
+        keyExtractor={(p) => p.id}
+        getItemType={() => 'product'}
+        renderItem={({ item }) => (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Add ${item.name} to order`}
+            accessibilityHint={`${item.unitLabel}, $${item.pricePerUnit.toFixed(2)} per ${item.unit}`}
+            onPress={() => onSelect(item)}
+            testID={`product-${item.sfId}`}
+            className="mx-4 mb-2 rounded-xl bg-ohanafy-cork p-3 active:opacity-80 dark:bg-ohanafy-dark-elevated"
+          >
+            <View className="flex-row items-center justify-between">
+              <Text className="flex-1 text-base text-ohanafy-ink dark:text-ohanafy-dark-text">
+                {item.name}
+              </Text>
+              <Text className="text-sm font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+                ${item.pricePerUnit.toFixed(2)}
+              </Text>
+            </View>
+            <Text className="mt-0.5 text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+              {item.unitLabel} · {item.skuCode}
+            </Text>
+          </Pressable>
+        )}
+      />
+    </View>
+  );
+}

--- a/src/components/shared/EmptyState.tsx
+++ b/src/components/shared/EmptyState.tsx
@@ -1,0 +1,25 @@
+import { Text, View } from 'react-native';
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+}
+
+export function EmptyState({ title, description }: EmptyStateProps): React.ReactNode {
+  return (
+    <View
+      accessibilityRole="text"
+      accessibilityLabel={description ? `${title}. ${description}` : title}
+      className="flex-1 items-center justify-center px-8 py-16"
+    >
+      <Text className="mb-2 text-center text-lg font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+        {title}
+      </Text>
+      {description ? (
+        <Text className="text-center text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+          {description}
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/src/components/shared/LoadingSkeleton.tsx
+++ b/src/components/shared/LoadingSkeleton.tsx
@@ -1,0 +1,28 @@
+import { View } from 'react-native';
+
+interface LoadingSkeletonProps {
+  count?: number;
+  itemHeight?: number;
+}
+
+export function LoadingSkeleton({
+  count = 5,
+  itemHeight = 88,
+}: LoadingSkeletonProps): React.ReactNode {
+  return (
+    <View
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading"
+      accessibilityLiveRegion="polite"
+      className="px-4 py-2"
+    >
+      {Array.from({ length: count }, (_, i) => (
+        <View
+          key={i}
+          style={{ height: itemHeight }}
+          className="mb-3 rounded-2xl bg-ohanafy-cork dark:bg-ohanafy-dark-elevated"
+        />
+      ))}
+    </View>
+  );
+}

--- a/src/components/sync/OfflineBanner.tsx
+++ b/src/components/sync/OfflineBanner.tsx
@@ -1,0 +1,20 @@
+import { Text, View } from 'react-native';
+
+import { useOfflineStatus } from '@/hooks/useOfflineStatus';
+
+export function OfflineBanner(): React.ReactNode {
+  const { isOffline } = useOfflineStatus();
+  if (!isOffline) return null;
+  return (
+    <View
+      accessibilityRole="alert"
+      accessibilityLabel="You are offline. Changes will sync when you reconnect."
+      accessibilityLiveRegion="polite"
+      className="bg-ohanafy-denim px-4 py-2"
+    >
+      <Text className="text-center text-xs font-bold text-ohanafy-paper">
+        Offline — changes will sync when you reconnect
+      </Text>
+    </View>
+  );
+}

--- a/src/components/sync/SyncStatusBar.tsx
+++ b/src/components/sync/SyncStatusBar.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { Text, View } from 'react-native';
+
+import { database } from '@/db';
+import { countPending } from '@/db/repositories/sync-queue';
+
+export function SyncStatusBar(): React.ReactNode {
+  const [pending, setPending] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    const tick = async (): Promise<void> => {
+      const n = await countPending(database);
+      if (active) setPending(n);
+    };
+    tick();
+    const id = setInterval(tick, 5000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (pending === 0) return null;
+
+  return (
+    <View
+      accessibilityLabel={`${pending} ${pending === 1 ? 'item' : 'items'} pending sync`}
+      accessibilityLiveRegion="polite"
+      className="bg-ohanafy-cork px-4 py-1.5 dark:bg-ohanafy-dark-elevated"
+    >
+      <Text className="text-center text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+        {pending} {pending === 1 ? 'change' : 'changes'} pending sync
+      </Text>
+    </View>
+  );
+}

--- a/src/data/seed-data.ts
+++ b/src/data/seed-data.ts
@@ -1,0 +1,333 @@
+// Day-2 demo fixture for the Yellowhammer Beverage pilot. Replaces real SF data
+// when EXPO_PUBLIC_USE_SEED_DATA=true. Day 4 deletes this in favor of live SF sync.
+//
+// 5 accounts (Birmingham AL retailers — fictional), 10 products (kegs, cases, energy),
+// one recent visit and one recent order per account so the UI has things to render.
+
+export interface SeedAccount {
+  sfId: string;
+  name: string;
+  accountType: 'on_premise' | 'off_premise_chain' | 'off_premise_indie' | 'convenience';
+  channel: string;
+  territoryId: string;
+  contactName: string;
+  contactTitle: string;
+  contactPhone: string;
+  addressStreet: string;
+  addressCity: string;
+  addressState: string;
+  latitude: number;
+  longitude: number;
+  daysSinceLastOrder: number;
+  ytdRevenue: number;
+  needsAttention: boolean;
+}
+
+export interface SeedProduct {
+  sfId: string;
+  name: string;
+  category: 'beer_keg' | 'beer_case' | 'energy' | 'other';
+  unit: 'keg' | 'case';
+  unitLabel: string;
+  pricePerUnit: number;
+  supplierId: string;
+  skuCode: string;
+}
+
+export interface SeedVisit {
+  accountSfId: string;
+  daysAgo: number;
+  durationMinutes: number;
+  note: string;
+}
+
+export interface SeedOrderLine {
+  productSfId: string;
+  quantity: number;
+}
+
+export interface SeedOrder {
+  accountSfId: string;
+  daysAgo: number;
+  status: 'synced';
+  notes?: string;
+  lines: SeedOrderLine[];
+}
+
+export const SEED_ACCOUNTS: SeedAccount[] = [
+  {
+    sfId: 'a01_the_rail',
+    name: 'The Rail',
+    accountType: 'on_premise',
+    channel: 'Bar',
+    territoryId: 't_birmingham',
+    contactName: 'Marcus Lee',
+    contactTitle: 'Owner',
+    contactPhone: '+12055551001',
+    addressStreet: '1140 22nd St S',
+    addressCity: 'Birmingham',
+    addressState: 'AL',
+    latitude: 33.5031,
+    longitude: -86.7964,
+    daysSinceLastOrder: 32,
+    ytdRevenue: 41250,
+    needsAttention: true,
+  },
+  {
+    sfId: 'a02_oak_alley',
+    name: 'Oak Alley Tavern',
+    accountType: 'on_premise',
+    channel: 'Bar & Grill',
+    territoryId: 't_birmingham',
+    contactName: 'Priya Shah',
+    contactTitle: 'GM',
+    contactPhone: '+12055551002',
+    addressStreet: '2300 7th Ave S',
+    addressCity: 'Birmingham',
+    addressState: 'AL',
+    latitude: 33.5089,
+    longitude: -86.788,
+    daysSinceLastOrder: 8,
+    ytdRevenue: 78400,
+    needsAttention: false,
+  },
+  {
+    sfId: 'a03_southside_market',
+    name: 'Southside Market',
+    accountType: 'off_premise_indie',
+    channel: 'Bottle Shop',
+    territoryId: 't_birmingham',
+    contactName: 'Devin Carter',
+    contactTitle: 'Buyer',
+    contactPhone: '+12055551003',
+    addressStreet: '1936 Magnolia Ave S',
+    addressCity: 'Birmingham',
+    addressState: 'AL',
+    latitude: 33.4892,
+    longitude: -86.7937,
+    daysSinceLastOrder: 14,
+    ytdRevenue: 29800,
+    needsAttention: false,
+  },
+  {
+    sfId: 'a04_homewood_bottle',
+    name: 'Homewood Bottle Co.',
+    accountType: 'off_premise_indie',
+    channel: 'Bottle Shop',
+    territoryId: 't_homewood',
+    contactName: 'Shauna Robins',
+    contactTitle: 'Owner',
+    contactPhone: '+12055551004',
+    addressStreet: '2912 18th St S',
+    addressCity: 'Homewood',
+    addressState: 'AL',
+    latitude: 33.4731,
+    longitude: -86.8023,
+    daysSinceLastOrder: 27,
+    ytdRevenue: 33500,
+    needsAttention: true,
+  },
+  {
+    sfId: 'a05_quickstop_vestavia',
+    name: 'QuickStop Vestavia',
+    accountType: 'convenience',
+    channel: 'Convenience',
+    territoryId: 't_vestavia',
+    contactName: 'Rohan Patel',
+    contactTitle: 'Manager',
+    contactPhone: '+12055551005',
+    addressStreet: '700 Montgomery Hwy',
+    addressCity: 'Vestavia Hills',
+    addressState: 'AL',
+    latitude: 33.4451,
+    longitude: -86.7856,
+    daysSinceLastOrder: 6,
+    ytdRevenue: 18200,
+    needsAttention: false,
+  },
+];
+
+export const SEED_PRODUCTS: SeedProduct[] = [
+  {
+    sfId: 'p01_yh_pale_ale_hb',
+    name: 'Yellowhammer Pale Ale',
+    category: 'beer_keg',
+    unit: 'keg',
+    unitLabel: '1/2 bbl',
+    pricePerUnit: 178,
+    supplierId: 'sup_yellowhammer',
+    skuCode: 'YH-PA-HB',
+  },
+  {
+    sfId: 'p02_yh_pale_ale_case',
+    name: 'Yellowhammer Pale Ale 12pk',
+    category: 'beer_case',
+    unit: 'case',
+    unitLabel: '24-unit',
+    pricePerUnit: 32,
+    supplierId: 'sup_yellowhammer',
+    skuCode: 'YH-PA-CS',
+  },
+  {
+    sfId: 'p03_yh_belgian_white',
+    name: 'Yellowhammer Belgian White',
+    category: 'beer_keg',
+    unit: 'keg',
+    unitLabel: '1/2 bbl',
+    pricePerUnit: 184,
+    supplierId: 'sup_yellowhammer',
+    skuCode: 'YH-BW-HB',
+  },
+  {
+    sfId: 'p04_modelo_keg',
+    name: 'Modelo Especial',
+    category: 'beer_keg',
+    unit: 'keg',
+    unitLabel: '1/2 bbl',
+    pricePerUnit: 192,
+    supplierId: 'sup_modelo',
+    skuCode: 'MD-ESP-HB',
+  },
+  {
+    sfId: 'p05_modelo_case',
+    name: 'Modelo Especial 12pk',
+    category: 'beer_case',
+    unit: 'case',
+    unitLabel: '24-unit',
+    pricePerUnit: 36,
+    supplierId: 'sup_modelo',
+    skuCode: 'MD-ESP-CS',
+  },
+  {
+    sfId: 'p06_corona_case',
+    name: 'Corona Extra 12pk',
+    category: 'beer_case',
+    unit: 'case',
+    unitLabel: '24-unit',
+    pricePerUnit: 35,
+    supplierId: 'sup_corona',
+    skuCode: 'CR-EX-CS',
+  },
+  {
+    sfId: 'p07_redbull_original',
+    name: 'Red Bull 8.4oz',
+    category: 'energy',
+    unit: 'case',
+    unitLabel: '24-can',
+    pricePerUnit: 48,
+    supplierId: 'sup_redbull',
+    skuCode: 'RB-OG-CS',
+  },
+  {
+    sfId: 'p08_redbull_sugarfree',
+    name: 'Red Bull Sugarfree 8.4oz',
+    category: 'energy',
+    unit: 'case',
+    unitLabel: '24-can',
+    pricePerUnit: 48,
+    supplierId: 'sup_redbull',
+    skuCode: 'RB-SF-CS',
+  },
+  {
+    sfId: 'p09_redbull_total_zero',
+    name: 'Red Bull Total Zero 12oz',
+    category: 'energy',
+    unit: 'case',
+    unitLabel: '24-can',
+    pricePerUnit: 52,
+    supplierId: 'sup_redbull',
+    skuCode: 'RB-TZ-CS',
+  },
+  {
+    sfId: 'p10_white_claw_variety',
+    name: 'White Claw Variety 12pk',
+    category: 'beer_case',
+    unit: 'case',
+    unitLabel: '24-unit',
+    pricePerUnit: 38,
+    supplierId: 'sup_whiteclaw',
+    skuCode: 'WC-VAR-CS',
+  },
+];
+
+export const SEED_VISITS: SeedVisit[] = [
+  {
+    accountSfId: 'a01_the_rail',
+    daysAgo: 28,
+    durationMinutes: 22,
+    note: 'Tap issue on the lager line — Marcus said theyd flush the lines this week.',
+  },
+  {
+    accountSfId: 'a02_oak_alley',
+    daysAgo: 6,
+    durationMinutes: 18,
+    note: 'New summer menu launches Friday. Priya is interested in the Belgian White.',
+  },
+  {
+    accountSfId: 'a03_southside_market',
+    daysAgo: 12,
+    durationMinutes: 14,
+    note: 'Devin wants to try a Red Bull Total Zero endcap for July.',
+  },
+  {
+    accountSfId: 'a04_homewood_bottle',
+    daysAgo: 24,
+    durationMinutes: 16,
+    note: 'Shauna mentioned slow sell-through on the Pale Ale 12pk.',
+  },
+  {
+    accountSfId: 'a05_quickstop_vestavia',
+    daysAgo: 5,
+    durationMinutes: 10,
+    note: 'Cooler reset Wednesday; Rohan keeping Modelo case position.',
+  },
+];
+
+export const SEED_ORDERS: SeedOrder[] = [
+  {
+    accountSfId: 'a01_the_rail',
+    daysAgo: 32,
+    status: 'synced',
+    lines: [
+      { productSfId: 'p01_yh_pale_ale_hb', quantity: 2 },
+      { productSfId: 'p03_yh_belgian_white', quantity: 1 },
+    ],
+  },
+  {
+    accountSfId: 'a02_oak_alley',
+    daysAgo: 8,
+    status: 'synced',
+    lines: [
+      { productSfId: 'p04_modelo_keg', quantity: 3 },
+      { productSfId: 'p07_redbull_original', quantity: 4 },
+    ],
+  },
+  {
+    accountSfId: 'a03_southside_market',
+    daysAgo: 14,
+    status: 'synced',
+    lines: [
+      { productSfId: 'p06_corona_case', quantity: 6 },
+      { productSfId: 'p08_redbull_sugarfree', quantity: 5 },
+    ],
+  },
+  {
+    accountSfId: 'a04_homewood_bottle',
+    daysAgo: 27,
+    status: 'synced',
+    lines: [
+      { productSfId: 'p02_yh_pale_ale_case', quantity: 4 },
+      { productSfId: 'p10_white_claw_variety', quantity: 8 },
+    ],
+  },
+  {
+    accountSfId: 'a05_quickstop_vestavia',
+    daysAgo: 6,
+    status: 'synced',
+    lines: [
+      { productSfId: 'p05_modelo_case', quantity: 12 },
+      { productSfId: 'p07_redbull_original', quantity: 6 },
+      { productSfId: 'p09_redbull_total_zero', quantity: 4 },
+    ],
+  },
+];

--- a/src/db/repositories/accounts.ts
+++ b/src/db/repositories/accounts.ts
@@ -1,0 +1,42 @@
+import type { Database } from '@nozbe/watermelondb';
+import { Q } from '@nozbe/watermelondb';
+
+import type { Account } from '../models/Account';
+
+export interface ListAccountsOptions {
+  search?: string;
+  needsAttentionOnly?: boolean;
+}
+
+function buildQuery(opts: ListAccountsOptions): unknown[] {
+  const clauses: unknown[] = [Q.where('is_archived', false)];
+  if (opts.needsAttentionOnly) {
+    clauses.push(Q.where('needs_attention', true));
+  }
+  if (opts.search && opts.search.trim().length > 0) {
+    clauses.push(Q.where('name', Q.like(`%${Q.sanitizeLikeString(opts.search.trim())}%`)));
+  }
+  clauses.push(Q.sortBy('name', Q.asc));
+  return clauses;
+}
+
+export async function listAccounts(
+  db: Database,
+  opts: ListAccountsOptions = {}
+): Promise<Account[]> {
+  const collection = db.get<Account>('accounts');
+  return collection.query(...(buildQuery(opts) as Parameters<typeof collection.query>)).fetch();
+}
+
+export function observeAccounts(db: Database, opts: ListAccountsOptions = {}) {
+  const collection = db.get<Account>('accounts');
+  return collection.query(...(buildQuery(opts) as Parameters<typeof collection.query>)).observe();
+}
+
+export async function getAccountById(db: Database, id: string): Promise<Account | null> {
+  try {
+    return await db.get<Account>('accounts').find(id);
+  } catch {
+    return null;
+  }
+}

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -1,0 +1,33 @@
+export {
+  listAccounts,
+  observeAccounts,
+  getAccountById,
+} from './accounts';
+export type { ListAccountsOptions } from './accounts';
+
+export {
+  listOrdersForAccount,
+  listLinesForOrder,
+  createDraftOrder,
+  addLineToOrder,
+  removeLine,
+  updateLineQuantity,
+  submitOrder,
+} from './orders';
+export type { NewOrderInput, OrderLineInput } from './orders';
+
+export {
+  listVisitsForAccount,
+  logVisit,
+} from './visits';
+export type { NewVisitInput } from './visits';
+
+export {
+  enqueue,
+  listPending,
+  countPending,
+  markProcessing,
+  markDone,
+  markFailed,
+} from './sync-queue';
+export type { SyncOperationType, EnqueueInput } from './sync-queue';

--- a/src/db/repositories/orders.ts
+++ b/src/db/repositories/orders.ts
@@ -1,0 +1,135 @@
+import type { Database } from '@nozbe/watermelondb';
+import { Q } from '@nozbe/watermelondb';
+
+import type { Order } from '../models/Order';
+import type { OrderLine } from '../models/OrderLine';
+import type { Product } from '../models/Product';
+
+export interface NewOrderInput {
+  accountId: string;
+  accountSfId: string;
+  repId: string;
+}
+
+export interface OrderLineInput {
+  product: Pick<Product, 'id' | 'sfId' | 'name' | 'unit' | 'pricePerUnit'>;
+  quantity: number;
+}
+
+export async function listOrdersForAccount(
+  db: Database,
+  accountId: string
+): Promise<Order[]> {
+  return db
+    .get<Order>('orders')
+    .query(Q.where('account_id', accountId), Q.sortBy('order_date', Q.desc))
+    .fetch();
+}
+
+export async function listLinesForOrder(
+  db: Database,
+  orderId: string
+): Promise<OrderLine[]> {
+  return db.get<OrderLine>('order_lines').query(Q.where('order_id', orderId)).fetch();
+}
+
+export async function createDraftOrder(
+  db: Database,
+  input: NewOrderInput
+): Promise<Order> {
+  const now = Date.now();
+  let created!: Order;
+  await db.write(async () => {
+    created = await db.get<Order>('orders').create((rec) => {
+      rec.accountId = input.accountId;
+      rec.accountSfId = input.accountSfId;
+      rec.repId = input.repId;
+      rec.status = 'draft';
+      rec.orderDate = new Date(now);
+      rec.totalAmount = 0;
+      rec.sfSyncStatus = 'pending';
+      rec.syncAttempts = 0;
+      rec.createdOffline = true;
+      rec.createdAt = new Date(now);
+      rec.updatedAt = new Date(now);
+    });
+  });
+  return created;
+}
+
+export async function addLineToOrder(
+  db: Database,
+  orderId: string,
+  input: OrderLineInput
+): Promise<OrderLine> {
+  let created!: OrderLine;
+  await db.write(async () => {
+    created = await db.get<OrderLine>('order_lines').create((rec) => {
+      rec.orderId = orderId;
+      rec.productId = input.product.id;
+      rec.productSfId = input.product.sfId;
+      rec.productName = input.product.name;
+      rec.quantity = input.quantity;
+      rec.unit = input.product.unit;
+      rec.unitPrice = input.product.pricePerUnit;
+      rec.lineTotal = input.product.pricePerUnit * input.quantity;
+    });
+    await recalcOrderTotal(db, orderId);
+  });
+  return created;
+}
+
+export async function removeLine(db: Database, lineId: string): Promise<void> {
+  await db.write(async () => {
+    const line = await db.get<OrderLine>('order_lines').find(lineId);
+    const orderId = line.orderId;
+    await line.markAsDeleted();
+    await recalcOrderTotal(db, orderId);
+  });
+}
+
+export async function updateLineQuantity(
+  db: Database,
+  lineId: string,
+  quantity: number
+): Promise<void> {
+  if (quantity < 1) {
+    await removeLine(db, lineId);
+    return;
+  }
+  await db.write(async () => {
+    const line = await db.get<OrderLine>('order_lines').find(lineId);
+    await line.update((rec) => {
+      rec.quantity = quantity;
+      rec.lineTotal = rec.unitPrice * quantity;
+    });
+    await recalcOrderTotal(db, line.orderId);
+  });
+}
+
+async function recalcOrderTotal(db: Database, orderId: string): Promise<void> {
+  const lines = await db
+    .get<OrderLine>('order_lines')
+    .query(Q.where('order_id', orderId))
+    .fetch();
+  const total = lines.reduce((sum, l) => sum + l.lineTotal, 0);
+  const order = await db.get<Order>('orders').find(orderId);
+  await order.update((rec) => {
+    rec.totalAmount = total;
+    rec.updatedAt = new Date();
+  });
+}
+
+export async function submitOrder(
+  db: Database,
+  orderId: string
+): Promise<void> {
+  await db.write(async () => {
+    const order = await db.get<Order>('orders').find(orderId);
+    await order.update((rec) => {
+      rec.status = 'pending_sync';
+      rec.sfSyncStatus = 'pending';
+      rec.updatedAt = new Date();
+    });
+  });
+}

--- a/src/db/repositories/sync-queue.ts
+++ b/src/db/repositories/sync-queue.ts
@@ -1,0 +1,94 @@
+import type { Database } from '@nozbe/watermelondb';
+import { Q } from '@nozbe/watermelondb';
+
+import type { SyncQueueItem } from '../models/SyncQueueItem';
+
+export type SyncOperationType =
+  | 'CREATE_ORDER'
+  | 'UPDATE_ORDER'
+  | 'CREATE_VISIT'
+  | 'UPDATE_VISIT'
+  | 'CREATE_LABEL_LOG';
+
+export interface EnqueueInput {
+  operationType: SyncOperationType;
+  entityType: string;
+  entityId: string;
+  payload: Record<string, unknown>;
+}
+
+export async function enqueue(db: Database, input: EnqueueInput): Promise<SyncQueueItem> {
+  let created!: SyncQueueItem;
+  await db.write(async () => {
+    created = await db.get<SyncQueueItem>('sync_queue').create((rec) => {
+      rec.operationType = input.operationType;
+      rec.entityType = input.entityType;
+      rec.entityId = input.entityId;
+      rec.payloadJson = JSON.stringify(input.payload);
+      rec.status = 'pending';
+      rec.attempts = 0;
+      rec.createdAt = new Date();
+    });
+  });
+  return created;
+}
+
+export async function listPending(
+  db: Database,
+  limit = 10
+): Promise<SyncQueueItem[]> {
+  return db
+    .get<SyncQueueItem>('sync_queue')
+    .query(
+      Q.where('status', 'pending'),
+      Q.sortBy('created_at', Q.asc),
+      Q.take(limit)
+    )
+    .fetch();
+}
+
+export async function countPending(db: Database): Promise<number> {
+  return db
+    .get<SyncQueueItem>('sync_queue')
+    .query(Q.where('status', Q.oneOf(['pending', 'processing'])))
+    .fetchCount();
+}
+
+export async function markProcessing(
+  db: Database,
+  itemId: string
+): Promise<void> {
+  await db.write(async () => {
+    const item = await db.get<SyncQueueItem>('sync_queue').find(itemId);
+    await item.update((rec) => {
+      rec.status = 'processing';
+    });
+  });
+}
+
+export async function markDone(db: Database, itemId: string): Promise<void> {
+  await db.write(async () => {
+    const item = await db.get<SyncQueueItem>('sync_queue').find(itemId);
+    await item.update((rec) => {
+      rec.status = 'done';
+      rec.processedAt = new Date();
+    });
+  });
+}
+
+export async function markFailed(
+  db: Database,
+  itemId: string,
+  error: string
+): Promise<void> {
+  await db.write(async () => {
+    const item = await db.get<SyncQueueItem>('sync_queue').find(itemId);
+    const nextAttempts = item.attempts + 1;
+    await item.update((rec) => {
+      rec.attempts = nextAttempts;
+      rec.lastError = error;
+      // Three strikes and fail permanently — surfaces in UI for manual retry/discard
+      rec.status = nextAttempts >= 3 ? 'failed' : 'pending';
+    });
+  });
+}

--- a/src/db/repositories/visits.ts
+++ b/src/db/repositories/visits.ts
@@ -1,0 +1,47 @@
+import type { Database } from '@nozbe/watermelondb';
+import { Q } from '@nozbe/watermelondb';
+
+import type { Visit } from '../models/Visit';
+
+export interface NewVisitInput {
+  accountId: string;
+  accountSfId: string;
+  repId: string;
+  note: string;
+  rawTranscript?: string;
+  durationMinutes?: number;
+}
+
+export async function listVisitsForAccount(
+  db: Database,
+  accountId: string,
+  limit = 10
+): Promise<Visit[]> {
+  return db
+    .get<Visit>('visits')
+    .query(
+      Q.where('account_id', accountId),
+      Q.sortBy('visit_date', Q.desc),
+      Q.take(limit)
+    )
+    .fetch();
+}
+
+export async function logVisit(db: Database, input: NewVisitInput): Promise<Visit> {
+  let created!: Visit;
+  await db.write(async () => {
+    created = await db.get<Visit>('visits').create((rec) => {
+      rec.accountId = input.accountId;
+      rec.accountSfId = input.accountSfId;
+      rec.repId = input.repId;
+      rec.visitDate = new Date();
+      rec.durationMinutes = input.durationMinutes;
+      rec.note = input.note;
+      rec.rawTranscript = input.rawTranscript;
+      rec.sfSyncStatus = 'pending';
+      rec.syncAttempts = 0;
+      rec.createdOffline = true;
+    });
+  });
+  return created;
+}

--- a/src/db/seeder.ts
+++ b/src/db/seeder.ts
@@ -1,0 +1,174 @@
+import type { Database } from '@nozbe/watermelondb';
+
+import {
+  SEED_ACCOUNTS,
+  SEED_ORDERS,
+  SEED_PRODUCTS,
+  SEED_VISITS,
+} from '@/data/seed-data';
+
+import type { Account } from './models/Account';
+import type { Order } from './models/Order';
+import type { OrderLine } from './models/OrderLine';
+import type { Product } from './models/Product';
+import type { Visit } from './models/Visit';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface SeedOptions {
+  repId: string;
+}
+
+export async function isDatabaseEmpty(db: Database): Promise<boolean> {
+  const accountCount = await db.get<Account>('accounts').query().fetchCount();
+  return accountCount === 0;
+}
+
+export async function seedDatabase(db: Database, opts: SeedOptions): Promise<void> {
+  const empty = await isDatabaseEmpty(db);
+  if (!empty) return;
+
+  const now = Date.now();
+  const repId = opts.repId;
+
+  await db.write(async () => {
+    const productsCollection = db.get<Product>('products');
+    const accountsCollection = db.get<Account>('accounts');
+    const visitsCollection = db.get<Visit>('visits');
+    const ordersCollection = db.get<Order>('orders');
+    const orderLinesCollection = db.get<OrderLine>('order_lines');
+
+    // Products
+    const productBySfId = new Map<string, Product>();
+    for (const p of SEED_PRODUCTS) {
+      const created = await productsCollection.create((rec) => {
+        rec.sfId = p.sfId;
+        rec.name = p.name;
+        rec.category = p.category;
+        rec.unit = p.unit;
+        rec.unitLabel = p.unitLabel;
+        rec.pricePerUnit = p.pricePerUnit;
+        rec.supplierId = p.supplierId;
+        rec.skuCode = p.skuCode;
+        rec.isActive = true;
+      });
+      productBySfId.set(p.sfId, created);
+    }
+
+    // Accounts
+    const accountBySfId = new Map<string, Account>();
+    for (const a of SEED_ACCOUNTS) {
+      const lastOrderTs = now - a.daysSinceLastOrder * DAY_MS;
+      const created = await accountsCollection.create((rec) => {
+        rec.sfId = a.sfId;
+        rec.name = a.name;
+        rec.accountType = a.accountType;
+        rec.channel = a.channel;
+        rec.territoryId = a.territoryId;
+        rec.contactName = a.contactName;
+        rec.contactTitle = a.contactTitle;
+        rec.contactPhone = a.contactPhone;
+        rec.addressStreet = a.addressStreet;
+        rec.addressCity = a.addressCity;
+        rec.addressState = a.addressState;
+        rec.latitude = a.latitude;
+        rec.longitude = a.longitude;
+        rec.lastOrderDate = new Date(lastOrderTs);
+        rec.daysSinceLastOrder = a.daysSinceLastOrder;
+        rec.ytdRevenue = a.ytdRevenue;
+        rec.needsAttention = a.needsAttention;
+        rec.syncedAt = new Date(now);
+        rec.isArchived = false;
+      });
+      accountBySfId.set(a.sfId, created);
+    }
+
+    // Visits — set last_visit_date on the account too
+    for (const v of SEED_VISITS) {
+      const account = accountBySfId.get(v.accountSfId);
+      if (!account) continue;
+      const visitTs = now - v.daysAgo * DAY_MS;
+      await visitsCollection.create((rec) => {
+        rec.accountId = account.id;
+        rec.accountSfId = v.accountSfId;
+        rec.repId = repId;
+        rec.visitDate = new Date(visitTs);
+        rec.durationMinutes = v.durationMinutes;
+        rec.note = v.note;
+        rec.sfSyncStatus = 'synced';
+        rec.syncAttempts = 0;
+        rec.createdOffline = false;
+      });
+      await account.update((rec) => {
+        rec.lastVisitDate = new Date(visitTs);
+      });
+    }
+
+    // Orders + lines
+    for (const o of SEED_ORDERS) {
+      const account = accountBySfId.get(o.accountSfId);
+      if (!account) continue;
+      const orderTs = now - o.daysAgo * DAY_MS;
+      let total = 0;
+      const linePayloads: { product: Product; qty: number }[] = [];
+      for (const line of o.lines) {
+        const product = productBySfId.get(line.productSfId);
+        if (!product) continue;
+        total += product.pricePerUnit * line.quantity;
+        linePayloads.push({ product, qty: line.quantity });
+      }
+      const order = await ordersCollection.create((rec) => {
+        rec.sfId = `${o.accountSfId}_order_${o.daysAgo}`;
+        rec.accountId = account.id;
+        rec.accountSfId = o.accountSfId;
+        rec.repId = repId;
+        rec.status = o.status;
+        rec.orderDate = new Date(orderTs);
+        rec.totalAmount = total;
+        rec.notes = o.notes;
+        rec.sfSyncStatus = 'synced';
+        rec.syncAttempts = 0;
+        rec.createdOffline = false;
+        rec.createdAt = new Date(orderTs);
+        rec.updatedAt = new Date(orderTs);
+      });
+      for (const { product, qty } of linePayloads) {
+        await orderLinesCollection.create((rec) => {
+          rec.orderId = order.id;
+          rec.productId = product.id;
+          rec.productSfId = product.sfId;
+          rec.productName = product.name;
+          rec.quantity = qty;
+          rec.unit = product.unit;
+          rec.unitPrice = product.pricePerUnit;
+          rec.lineTotal = product.pricePerUnit * qty;
+        });
+      }
+    }
+  });
+}
+
+export async function clearDatabase(db: Database): Promise<void> {
+  await db.write(async () => {
+    const tables = [
+      'order_lines',
+      'orders',
+      'visits',
+      'label_prints',
+      'sync_queue',
+      'memories',
+      'feedback_events',
+      'accounts',
+      'products',
+      'permissions',
+    ];
+    for (const table of tables) {
+      const all = await db.get(table).query().fetch();
+      for (const rec of all) {
+        await rec.markAsDeleted();
+      }
+    }
+    // Purge soft-deleted rows so subsequent isDatabaseEmpty checks return true
+    await db.adapter.unsafeExecute({ sqls: tables.map((t) => [`DELETE FROM ${t}`, []]) });
+  });
+}

--- a/src/hooks/useAccountList.ts
+++ b/src/hooks/useAccountList.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import { database } from '@/db';
+import type { Account } from '@/db/models/Account';
+import { observeAccounts, type ListAccountsOptions } from '@/db/repositories/accounts';
+
+export interface AccountListState {
+  accounts: Account[];
+  loading: boolean;
+}
+
+export function useAccountList(opts: ListAccountsOptions): AccountListState {
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    const subscription = observeAccounts(database, opts).subscribe((next) => {
+      setAccounts(next);
+      setLoading(false);
+    });
+    return () => subscription.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opts.search, opts.needsAttentionOnly]);
+
+  return { accounts, loading };
+}

--- a/src/hooks/useOfflineStatus.ts
+++ b/src/hooks/useOfflineStatus.ts
@@ -1,0 +1,38 @@
+import NetInfo from '@react-native-community/netinfo';
+import { useEffect, useState } from 'react';
+
+export interface OfflineStatus {
+  isOffline: boolean;
+  type: string;
+  isInternetReachable: boolean | null;
+}
+
+export function useOfflineStatus(): OfflineStatus {
+  const [status, setStatus] = useState<OfflineStatus>({
+    isOffline: false,
+    type: 'unknown',
+    isInternetReachable: null,
+  });
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setStatus({
+        isOffline: !state.isConnected || state.isInternetReachable === false,
+        type: state.type,
+        isInternetReachable: state.isInternetReachable,
+      });
+    });
+
+    NetInfo.fetch().then((state) => {
+      setStatus({
+        isOffline: !state.isConnected || state.isInternetReachable === false,
+        type: state.type,
+        isInternetReachable: state.isInternetReachable,
+      });
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  return status;
+}

--- a/src/hooks/useOrder.ts
+++ b/src/hooks/useOrder.ts
@@ -1,0 +1,63 @@
+import { Q } from '@nozbe/watermelondb';
+import { useEffect, useState } from 'react';
+
+import { database } from '@/db';
+import type { Order } from '@/db/models/Order';
+import type { OrderLine } from '@/db/models/OrderLine';
+import type { Product } from '@/db/models/Product';
+
+export interface OrderState {
+  order: Order | null;
+  lines: OrderLine[];
+  products: Product[];
+  loading: boolean;
+}
+
+export function useOrder(orderId: string | undefined): OrderState {
+  const [state, setState] = useState<OrderState>({
+    order: null,
+    lines: [],
+    products: [],
+    loading: true,
+  });
+
+  useEffect(() => {
+    if (!orderId) return;
+    let active = true;
+    const orderObs = database.get<Order>('orders').findAndObserve(orderId);
+    const linesObs = database
+      .get<OrderLine>('order_lines')
+      .query(Q.where('order_id', orderId))
+      .observe();
+    const productsObs = database
+      .get<Product>('products')
+      .query(Q.where('is_active', true), Q.sortBy('name', Q.asc))
+      .observe();
+
+    let order: Order | null = null;
+    let lines: OrderLine[] = [];
+    let products: Product[] = [];
+
+    const subOrder = orderObs.subscribe((o) => {
+      order = o;
+      if (active) setState({ order, lines, products, loading: false });
+    });
+    const subLines = linesObs.subscribe((ls) => {
+      lines = ls;
+      if (active) setState({ order, lines, products, loading: false });
+    });
+    const subProducts = productsObs.subscribe((ps) => {
+      products = ps;
+      if (active) setState({ order, lines, products, loading: false });
+    });
+
+    return () => {
+      active = false;
+      subOrder.unsubscribe();
+      subLines.unsubscribe();
+      subProducts.unsubscribe();
+    };
+  }, [orderId]);
+
+  return state;
+}

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -1,0 +1,42 @@
+import NetInfo from '@react-native-community/netinfo';
+
+import { database } from '@/db';
+import { listPending } from '@/db/repositories/sync-queue';
+
+import { processQueueItem } from './queue-processor';
+import { sfClient, type SFClient } from './sf-client';
+
+interface SyncOptions {
+  client?: SFClient;
+  batchSize?: number;
+}
+
+let inFlight = false;
+
+export async function flushQueue(options: SyncOptions = {}): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    const client = options.client ?? sfClient;
+    const items = await listPending(database, options.batchSize ?? 10);
+    for (const item of items) {
+      try {
+        await processQueueItem(item, database, client);
+      } catch {
+        // queue-processor already records the failure; continue with the next item
+      }
+    }
+  } finally {
+    inFlight = false;
+  }
+}
+
+export function startSyncEngine(options: SyncOptions = {}): () => void {
+  const unsubscribe = NetInfo.addEventListener((state) => {
+    if (state.isConnected && state.isInternetReachable !== false) {
+      // Fire and forget — failures are logged on each item, not at engine level
+      flushQueue(options).catch(() => undefined);
+    }
+  });
+  return unsubscribe;
+}

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,0 +1,4 @@
+export { sfClient } from './sf-client';
+export type { SFClient } from './sf-client';
+export { processQueueItem } from './queue-processor';
+export { flushQueue, startSyncEngine } from './engine';

--- a/src/sync/queue-processor.ts
+++ b/src/sync/queue-processor.ts
@@ -1,0 +1,116 @@
+import type { Database } from '@nozbe/watermelondb';
+
+import type { Order } from '@/db/models/Order';
+import type { SyncQueueItem } from '@/db/models/SyncQueueItem';
+import type { Visit } from '@/db/models/Visit';
+import { markDone, markFailed, markProcessing } from '@/db/repositories/sync-queue';
+
+import type { SFClient } from './sf-client';
+
+interface CreateOrderPayload {
+  localId: string;
+  accountSfId: string;
+  repId: string;
+  totalAmount: number;
+  lines: Array<{
+    productSfId: string;
+    productName: string;
+    quantity: number;
+    unit: string;
+    unitPrice: number;
+    lineTotal: number;
+  }>;
+}
+
+interface CreateVisitPayload {
+  localId: string;
+  accountSfId: string;
+  repId: string;
+  note: string;
+}
+
+export async function processQueueItem(
+  item: SyncQueueItem,
+  db: Database,
+  client: SFClient
+): Promise<void> {
+  await markProcessing(db, item.id);
+  try {
+    switch (item.operationType) {
+      case 'CREATE_ORDER':
+        await processCreateOrder(item, db, client);
+        break;
+      case 'CREATE_VISIT':
+        await processCreateVisit(item, db, client);
+        break;
+      default:
+        throw new Error(`Unknown operation type: ${item.operationType}`);
+    }
+    await markDone(db, item.id);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    await markFailed(db, item.id, msg);
+    throw error;
+  }
+}
+
+async function processCreateOrder(
+  item: SyncQueueItem,
+  db: Database,
+  client: SFClient
+): Promise<void> {
+  const payload = JSON.parse(item.payloadJson) as CreateOrderPayload;
+  const { id: sfOrderId } = await client.createRecord('ohfy_field__Order__c', {
+    ohfy_field__Account__c: payload.accountSfId,
+    ohfy_field__Rep__c: payload.repId,
+    ohfy_field__Total_Amount__c: payload.totalAmount,
+    ohfy_field__Status__c: 'Submitted',
+    ohfy_field__Created_Offline__c: true,
+  });
+
+  // Create line items
+  for (const line of payload.lines) {
+    await client.createRecord('ohfy_field__OrderLine__c', {
+      ohfy_field__Order__c: sfOrderId,
+      ohfy_field__Product_Sf_Id__c: line.productSfId,
+      ohfy_field__Product_Name__c: line.productName,
+      ohfy_field__Quantity__c: line.quantity,
+      ohfy_field__Unit__c: line.unit,
+      ohfy_field__Unit_Price__c: line.unitPrice,
+      ohfy_field__Line_Total__c: line.lineTotal,
+    });
+  }
+
+  // Update local order with the SF id and synced status
+  await db.write(async () => {
+    const order = await db.get<Order>('orders').find(payload.localId);
+    await order.update((rec) => {
+      rec.sfId = sfOrderId;
+      rec.status = 'synced';
+      rec.sfSyncStatus = 'synced';
+      rec.updatedAt = new Date();
+    });
+  });
+}
+
+async function processCreateVisit(
+  item: SyncQueueItem,
+  db: Database,
+  client: SFClient
+): Promise<void> {
+  const payload = JSON.parse(item.payloadJson) as CreateVisitPayload;
+  const { id: sfVisitId } = await client.createRecord('ohfy_field__Visit__c', {
+    ohfy_field__Account__c: payload.accountSfId,
+    ohfy_field__Rep__c: payload.repId,
+    ohfy_field__Note__c: payload.note,
+    ohfy_field__Visit_Date__c: new Date().toISOString(),
+  });
+
+  await db.write(async () => {
+    const visit = await db.get<Visit>('visits').find(payload.localId);
+    await visit.update((rec) => {
+      rec.sfId = sfVisitId;
+      rec.sfSyncStatus = 'synced';
+    });
+  });
+}

--- a/src/sync/sf-client.ts
+++ b/src/sync/sf-client.ts
@@ -1,0 +1,79 @@
+import { loadTokens, refreshAccessToken } from '@/auth/token-manager';
+
+export interface SFClient {
+  createRecord: (objectName: string, payload: Record<string, unknown>) => Promise<{ id: string }>;
+  updateRecord: (
+    objectName: string,
+    id: string,
+    payload: Record<string, unknown>
+  ) => Promise<void>;
+  query: <T>(soql: string) => Promise<T[]>;
+}
+
+const API_VERSION = 'v59.0';
+
+async function authedFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  const tokens = await loadTokens();
+  if (!tokens) throw new Error('Not authenticated to Salesforce');
+
+  const doFetch = async (token: string): Promise<Response> => {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...((init?.headers as Record<string, string> | undefined) ?? {}),
+    };
+    return fetch(input, { ...init, headers });
+  };
+
+  let response = await doFetch(tokens.accessToken);
+  if (response.status === 401) {
+    const fresh = await refreshAccessToken();
+    response = await doFetch(fresh);
+  }
+  return response;
+}
+
+export const sfClient: SFClient = {
+  async createRecord(objectName, payload) {
+    const tokens = await loadTokens();
+    if (!tokens) throw new Error('Not authenticated to Salesforce');
+    const response = await authedFetch(
+      `${tokens.instanceUrl}/services/data/${API_VERSION}/sobjects/${objectName}/`,
+      { method: 'POST', body: JSON.stringify(payload) }
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`SF createRecord ${objectName} failed: ${response.status} ${text}`);
+    }
+    const data = (await response.json()) as { id: string };
+    return { id: data.id };
+  },
+
+  async updateRecord(objectName, id, payload) {
+    const tokens = await loadTokens();
+    if (!tokens) throw new Error('Not authenticated to Salesforce');
+    const response = await authedFetch(
+      `${tokens.instanceUrl}/services/data/${API_VERSION}/sobjects/${objectName}/${id}`,
+      { method: 'PATCH', body: JSON.stringify(payload) }
+    );
+    if (!response.ok && response.status !== 204) {
+      const text = await response.text();
+      throw new Error(`SF updateRecord ${objectName} failed: ${response.status} ${text}`);
+    }
+  },
+
+  async query(soql) {
+    const tokens = await loadTokens();
+    if (!tokens) throw new Error('Not authenticated to Salesforce');
+    const response = await authedFetch(
+      `${tokens.instanceUrl}/services/data/${API_VERSION}/query?q=${encodeURIComponent(soql)}`,
+      { method: 'GET' }
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`SF query failed: ${response.status} ${text}`);
+    }
+    const data = (await response.json()) as { records: unknown[] };
+    return data.records as never[];
+  },
+};


### PR DESCRIPTION
## Summary

Day 2 of the 7-day sprint per Bible §9 Tuesday — every rep feature that matters offline, working end-to-end. Foundation for Day 3 voice.

- **Data layer** — demo seed (5 Birmingham AL accounts: The Rail, Oak Alley, Southside Market, Homewood Bottle, QuickStop Vestavia + 10 products + recent visits/orders), repositories for accounts/orders/visits/sync-queue with reactive WDB observables, search uses `Q.like` with sanitization
- **UI** — Account list (FlashList, search, Needs Attention filter pill, skeleton + empty state) · Account detail (info, last order pill, recent visits, action buttons) · Order entry (stepper, swipe-to-remove, ProductPicker flyout, live total) · Order confirm (review + Place Order saves `pending_sync` + enqueues CREATE_ORDER) · Visit log (text input, enqueues CREATE_VISIT)
- **Sync** — `sf-client` (REST + auto refresh-token retry on 401), `queue-processor` (CREATE_ORDER creates `ohfy_field__Order__c` + `OrderLine__c`, CREATE_VISIT creates `ohfy_field__Visit__c`, marks failed at attempts ≥ 3), `engine` flushes on reconnect via NetInfo subscription with single-flight guard, `OfflineBanner` + `SyncStatusBar` surface state in UI
- **Tests** — 4 new fixture-based queue-processor tests (success, transient retry, permanent fail, visit success). Day 1's 27 still pass — total **31/31 jest, tsc clean, eslint clean**

Roles doc Day 2 additions: none explicit. The 5 non-Sales-Rep tab sets stay stubbed via `(no-permission)` and the role switcher; they fold into later days alongside their features.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — 31/31 pass
- [x] `npx eslint src/ app/` — exit 0
- [ ] `npx expo start` boot, log in as `daniel.zeder@ohanafy.com`, switch to FieldSalesRep, see seeded accounts
- [ ] Open The Rail → start an order → add 2 kegs Pale Ale via ProductPicker → confirm → "Place Order"
- [ ] Verify `sync_queue` has 1 pending item; SyncStatusBar shows "1 change pending sync"
- [ ] Toggle airplane mode, create another order, restore network → flushQueue runs and items go to `done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)