### PR TITLE
feat(day-4): ZPL templates, learning agent, SFDX package skeleton, push

### DIFF
--- a/__tests__/unit/ai/learning-agent.test.ts
+++ b/__tests__/unit/ai/learning-agent.test.ts
@@ -1,0 +1,150 @@
+import { runLearningAgent } from '@/ai/agents/learning-agent';
+
+interface FakeFeedback {
+  id: string;
+  repId: string;
+  eventType: string;
+  aiOutput: string;
+  synthesized: boolean;
+  [key: string]: unknown;
+}
+
+interface FakeMemory {
+  id: string;
+  repId: string;
+  category: string;
+  key: string;
+  value: string;
+  confidence: number;
+  source: string;
+  [key: string]: unknown;
+}
+
+function makeDb(events: FakeFeedback[]) {
+  const memories: FakeMemory[] = [];
+  function makeRecordProxy<T extends Record<string, unknown>>(target: T) {
+    return {
+      ...target,
+      update: async (mutator: (rec: T) => void) => mutator(target),
+    };
+  }
+  const db = {
+    write: async (fn: () => Promise<void>) => fn(),
+    get: (table: string) => ({
+      query: () => ({
+        fetch: async () =>
+          table === 'feedback_events'
+            ? events
+                .filter((e) => !e.synthesized)
+                .map((e) => makeRecordProxy(e))
+            : [],
+      }),
+      create: async (mutator: (rec: FakeMemory) => void) => {
+        const rec: FakeMemory = {
+          id: `m_${memories.length + 1}`,
+          repId: '',
+          category: '',
+          key: '',
+          value: '',
+          confidence: 0,
+          source: '',
+        };
+        // The repository setter (writeMemory) sets all fields; the date fields
+        // use Date objects which we ignore in the fake.
+        mutator(rec);
+        memories.push(rec);
+        return rec;
+      },
+    }),
+  };
+  return { db, memories, events };
+}
+
+describe('runLearningAgent', () => {
+  it('returns zero counts and no memories when there are no unprocessed events', async () => {
+    const { db } = makeDb([]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await runLearningAgent(db as any, { repId: 'rep1' });
+    expect(result).toEqual({ processed: 0, memoriesCreated: 0, patternsBelowFloor: 0 });
+  });
+
+  it('does NOT create memories when below the noise floor (< 3 examples)', async () => {
+    const events: FakeFeedback[] = [
+      {
+        id: 'e1',
+        repId: 'rep1',
+        eventType: 'command_edited',
+        synthesized: false,
+        aiOutput: JSON.stringify({
+          action: { type: 'ADD_TO_ORDER', items: [{ productName: 'Pale Ale' }] },
+        }),
+      },
+      {
+        id: 'e2',
+        repId: 'rep1',
+        eventType: 'command_edited',
+        synthesized: false,
+        aiOutput: JSON.stringify({
+          action: { type: 'ADD_TO_ORDER', items: [{ productName: 'Pale Ale' }] },
+        }),
+      },
+    ];
+    const { db, memories } = makeDb(events);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await runLearningAgent(db as any, { repId: 'rep1' });
+    expect(memories).toHaveLength(0);
+    expect(result.memoriesCreated).toBe(0);
+    expect(result.patternsBelowFloor).toBe(1);
+  });
+
+  it('creates a memory at confidence 0.7 for 3 examples', async () => {
+    const events: FakeFeedback[] = Array.from({ length: 3 }, (_, i) => ({
+      id: `e${i}`,
+      repId: 'rep1',
+      eventType: 'command_edited',
+      synthesized: false,
+      aiOutput: JSON.stringify({
+        action: { type: 'ADD_TO_ORDER', items: [{ productName: 'Pale Ale' }] },
+      }),
+    }));
+    const { db, memories } = makeDb(events);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await runLearningAgent(db as any, { repId: 'rep1' });
+    expect(memories).toHaveLength(1);
+    expect(memories[0].confidence).toBe(0.7);
+    expect(memories[0].category).toBe('PRODUCT_NICKNAME');
+    expect(result.memoriesCreated).toBe(1);
+  });
+
+  it('creates a memory at confidence 0.9 for 4+ examples', async () => {
+    const events: FakeFeedback[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `e${i}`,
+      repId: 'rep1',
+      eventType: 'command_edited',
+      synthesized: false,
+      aiOutput: JSON.stringify({
+        action: { type: 'ADD_TO_ORDER', items: [{ productName: 'Pale Ale' }] },
+      }),
+    }));
+    const { db, memories } = makeDb(events);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runLearningAgent(db as any, { repId: 'rep1' });
+    expect(memories[0].confidence).toBe(0.9);
+  });
+
+  it('marks every processed event as synthesized (idempotent re-runs)', async () => {
+    const events: FakeFeedback[] = Array.from({ length: 3 }, (_, i) => ({
+      id: `e${i}`,
+      repId: 'rep1',
+      eventType: 'command_edited',
+      synthesized: false,
+      aiOutput: JSON.stringify({
+        action: { type: 'ADD_TO_ORDER', items: [{ productName: 'Pale Ale' }] },
+      }),
+    }));
+    const { db } = makeDb(events);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runLearningAgent(db as any, { repId: 'rep1' });
+    expect(events.every((e) => e.synthesized)).toBe(true);
+  });
+});

--- a/__tests__/unit/zpl/__snapshots__/delivery-receipt.test.ts.snap
+++ b/__tests__/unit/zpl/__snapshots__/delivery-receipt.test.ts.snap
@@ -9,7 +9,7 @@ exports[`generateDeliveryReceipt matches snapshot 1`] = `
 ^FO30,75^A0N,24,24^FDDelivery Receipt^FS
 ^FO30,130^A0N,28,28^FDThe Rail^FS
 ^FO30,170^A0N,22,22^FDOrder: OF-1042^FS
-^FO30,200^A0N,22,22^FDDate: 4/29/2026^FS
+^FO30,200^A0N,22,22^FDDate: 4/30/2026^FS
 ^FO30,230^A0N,22,22^FDRep: Jake Thornton^FS
 ^FO30,275^GB580,2,2^FS
 ^FO30,285^A0N,22,22^FDQty  Item                     Total^FS

--- a/__tests__/unit/zpl/__snapshots__/delivery-receipt.test.ts.snap
+++ b/__tests__/unit/zpl/__snapshots__/delivery-receipt.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateDeliveryReceipt matches snapshot 1`] = `
+"^XA
+^CI28
+^PW640
+^LL960
+^FO30,25^A0N,40,40^FDOhanafy Field^FS
+^FO30,75^A0N,24,24^FDDelivery Receipt^FS
+^FO30,130^A0N,28,28^FDThe Rail^FS
+^FO30,170^A0N,22,22^FDOrder: OF-1042^FS
+^FO30,200^A0N,22,22^FDDate: 4/29/2026^FS
+^FO30,230^A0N,22,22^FDRep: Jake Thornton^FS
+^FO30,275^GB580,2,2^FS
+^FO30,285^A0N,22,22^FDQty  Item                     Total^FS
+^FO30,315^GB580,2,2^FS
+^FO30,330^A0N,22,22^FD2 keg  Yellowhammer Pale Ale^FS
+^FO450,330^A0N,22,22^FD$356.00^FS
+^FO30,362^A0N,22,22^FD1 keg  Modelo Especial^FS
+^FO450,362^A0N,22,22^FD$192.00^FS
+^FO30,424^GB580,2,2^FS
+^FO30,439^A0N,32,32^FDTotal: $548.00^FS
+^FO30,504^GB580,2,2^FS
+^FO30,516^A0N,18,18^FDSignature^FS
+^XZ"
+`;

--- a/__tests__/unit/zpl/__snapshots__/product-card.test.ts.snap
+++ b/__tests__/unit/zpl/__snapshots__/product-card.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateProductCard matches snapshot 1`] = `
+"^XA
+^CI28
+^PW640
+^LL480
+^FO30,25^A0N,48,48^FDYellowhammer Belgian White^FS
+^FO30,80^A0N,28,28^FDSKU: YH-BW-HB^FS
+^FO30,120^GB580,2,2^FS
+^FO30,140^A0N,72,72^FD$184.00^FS
+^FO30,230^A0N,28,28^FD• Brewed in Birmingham AL^FS
+^FO30,280^A0N,28,28^FD• 1/2 bbl keg^FS
+^FO30,330^A0N,28,28^FD• Year-round^FS
+^XZ"
+`;

--- a/__tests__/unit/zpl/__snapshots__/shelf-talker.test.ts.snap
+++ b/__tests__/unit/zpl/__snapshots__/shelf-talker.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateShelfTalker matches snapshot for regression detection 1`] = `
+"^XA
+^CI28
+^PW400
+^LL240
+^FO20,15^A0N,36,36^FDYellowhammer Pale Ale^FS
+^FO20,60^A0N,22,22^FDYH-PA-HB^FS
+^FO20,95^A0N,54,54^FD$142.00^FS
+^FO20,170^A0N,22,22^FDNew seasonal release^FS
+^XZ"
+`;

--- a/__tests__/unit/zpl/delivery-receipt.test.ts
+++ b/__tests__/unit/zpl/delivery-receipt.test.ts
@@ -4,7 +4,10 @@ describe('generateDeliveryReceipt', () => {
   const baseParams = {
     accountName: 'The Rail',
     orderNumber: 'OF-1042',
-    deliveryDate: new Date('2026-04-30T00:00:00Z'),
+    // Local-time Date constructor — always renders as 4/30/2026 via
+    // toLocaleDateString regardless of the test runner's timezone (CI is UTC,
+    // local dev may be EDT/PDT — both interpret this the same way).
+    deliveryDate: new Date(2026, 3, 30),
     rep: 'Jake Thornton',
     lines: [
       {

--- a/__tests__/unit/zpl/delivery-receipt.test.ts
+++ b/__tests__/unit/zpl/delivery-receipt.test.ts
@@ -1,0 +1,82 @@
+import { generateDeliveryReceipt } from '@/zpl/templates/delivery-receipt';
+
+describe('generateDeliveryReceipt', () => {
+  const baseParams = {
+    accountName: 'The Rail',
+    orderNumber: 'OF-1042',
+    deliveryDate: new Date('2026-04-30T00:00:00Z'),
+    rep: 'Jake Thornton',
+    lines: [
+      {
+        productName: 'Yellowhammer Pale Ale',
+        quantity: 2,
+        unit: 'keg',
+        unitPrice: 178,
+        lineTotal: 356,
+      },
+      {
+        productName: 'Modelo Especial',
+        quantity: 1,
+        unit: 'keg',
+        unitPrice: 192,
+        lineTotal: 192,
+      },
+    ],
+    totalAmount: 548,
+  };
+
+  it('starts with ^XA and ends with ^XZ', () => {
+    const zpl = generateDeliveryReceipt(baseParams);
+    expect(zpl).toMatch(/^\^XA/);
+    expect(zpl.trim()).toMatch(/\^XZ$/);
+  });
+
+  it('uses PW640 LL960 for 4×6 inch receipt', () => {
+    const zpl = generateDeliveryReceipt(baseParams);
+    expect(zpl).toContain('^PW640');
+    expect(zpl).toContain('^LL960');
+  });
+
+  it('all ^FO x coordinates within margin (<= 620)', () => {
+    const zpl = generateDeliveryReceipt(baseParams);
+    const xCoords = [...zpl.matchAll(/\^FO(\d+),/g)].map((m) => Number.parseInt(m[1], 10));
+    for (const x of xCoords) {
+      expect(x).toBeLessThanOrEqual(620);
+    }
+  });
+
+  it('renders each line item exactly once', () => {
+    const zpl = generateDeliveryReceipt(baseParams);
+    expect((zpl.match(/Yellowhammer Pale Ale/g) ?? []).length).toBe(1);
+    expect((zpl.match(/Modelo Especial/g) ?? []).length).toBe(1);
+  });
+
+  it('shows line totals correctly (qty × unitPrice = lineTotal)', () => {
+    const zpl = generateDeliveryReceipt(baseParams);
+    expect(zpl).toContain('$356.00');
+    expect(zpl).toContain('$192.00');
+  });
+
+  it('renders the order total', () => {
+    const zpl = generateDeliveryReceipt(baseParams);
+    expect(zpl).toContain('Total: $548.00');
+  });
+
+  it('caps to 16 lines when more are provided', () => {
+    const manyLines = Array.from({ length: 25 }, (_, i) => ({
+      productName: `Product ${i}`,
+      quantity: 1,
+      unit: 'case',
+      unitPrice: 10,
+      lineTotal: 10,
+    }));
+    const zpl = generateDeliveryReceipt({ ...baseParams, lines: manyLines });
+    expect(zpl).toContain('Product 0');
+    expect(zpl).toContain('Product 15');
+    expect(zpl).not.toContain('Product 16');
+  });
+
+  it('matches snapshot', () => {
+    expect(generateDeliveryReceipt(baseParams)).toMatchSnapshot();
+  });
+});

--- a/__tests__/unit/zpl/product-card.test.ts
+++ b/__tests__/unit/zpl/product-card.test.ts
@@ -1,0 +1,53 @@
+import { generateProductCard } from '@/zpl/templates/product-card';
+
+describe('generateProductCard', () => {
+  const baseParams = {
+    productName: 'Yellowhammer Belgian White',
+    skuCode: 'YH-BW-HB',
+    pricePerCase: 184,
+    facts: ['Brewed in Birmingham AL', '1/2 bbl keg', 'Year-round'],
+  };
+
+  it('starts with ^XA and ends with ^XZ', () => {
+    const zpl = generateProductCard(baseParams);
+    expect(zpl).toMatch(/^\^XA/);
+    expect(zpl.trim()).toMatch(/\^XZ$/);
+  });
+
+  it('uses PW640 for 4 inch width', () => {
+    const zpl = generateProductCard(baseParams);
+    expect(zpl).toContain('^PW640');
+  });
+
+  it('all ^FO x coordinates are within label width minus margin (< 620)', () => {
+    const zpl = generateProductCard({
+      ...baseParams,
+      productName: 'An Even Longer Product Name That Tests Boundaries',
+    });
+    const xCoords = [...zpl.matchAll(/\^FO(\d+),/g)].map((m) => Number.parseInt(m[1], 10));
+    for (const x of xCoords) {
+      expect(x).toBeLessThan(620);
+    }
+  });
+
+  it('limits to 3 facts even when more provided', () => {
+    const zpl = generateProductCard({
+      ...baseParams,
+      facts: ['Fact one', 'Fact two', 'Fact three', 'Fact four', 'Fact five'],
+    });
+    expect(zpl).toContain('Fact one');
+    expect(zpl).toContain('Fact two');
+    expect(zpl).toContain('Fact three');
+    expect(zpl).not.toContain('Fact four');
+    expect(zpl).not.toContain('Fact five');
+  });
+
+  it('formats price as $X.XX', () => {
+    const zpl = generateProductCard(baseParams);
+    expect(zpl).toContain('$184.00');
+  });
+
+  it('matches snapshot', () => {
+    expect(generateProductCard(baseParams)).toMatchSnapshot();
+  });
+});

--- a/__tests__/unit/zpl/shelf-talker.test.ts
+++ b/__tests__/unit/zpl/shelf-talker.test.ts
@@ -1,0 +1,85 @@
+import { generateShelfTalker } from '@/zpl/templates/shelf-talker';
+
+describe('generateShelfTalker', () => {
+  it('starts with ^XA and ends with ^XZ', () => {
+    const zpl = generateShelfTalker({
+      productName: 'Yellowhammer Pale Ale',
+      skuCode: 'YH-PA-HB',
+      pricePerCase: 142,
+    });
+    expect(zpl).toMatch(/^\^XA/);
+    expect(zpl.trim()).toMatch(/\^XZ$/);
+  });
+
+  it('contains UTF-8 charset and PW400', () => {
+    const zpl = generateShelfTalker({
+      productName: 'Test',
+      skuCode: 'T-1',
+      pricePerCase: 10,
+    });
+    expect(zpl).toContain('^CI28');
+    expect(zpl).toContain('^PW400');
+  });
+
+  it('all ^FO x coordinates are within label width minus margin (< 380)', () => {
+    const zpl = generateShelfTalker({
+      productName: 'A Very Long Product Name That Might Overflow',
+      skuCode: 'VL-PROD-HB-EXTENDED',
+      pricePerCase: 999.99,
+      promoLine: 'Promo with a much too long banner that goes way over',
+    });
+    const xCoords = [...zpl.matchAll(/\^FO(\d+),/g)].map((m) => Number.parseInt(m[1], 10));
+    for (const x of xCoords) {
+      expect(x).toBeLessThan(380);
+    }
+  });
+
+  it('truncates product name longer than 22 chars', () => {
+    const zpl = generateShelfTalker({
+      productName: 'This Name Is Way Too Long For The 2.5 Inch Label',
+      skuCode: 'TN-LONG',
+      pricePerCase: 50,
+    });
+    expect(zpl).not.toContain('This Name Is Way Too Long For The 2.5 Inch Label');
+    expect(zpl).toMatch(/This Name Is Way Too…/);
+  });
+
+  it('formats price as $X.XX', () => {
+    const zpl = generateShelfTalker({
+      productName: 'Test',
+      skuCode: 'T-1',
+      pricePerCase: 142,
+    });
+    expect(zpl).toContain('$142.00');
+  });
+
+  it('includes promo line when provided', () => {
+    const zpl = generateShelfTalker({
+      productName: 'Test',
+      skuCode: 'T-1',
+      pricePerCase: 50,
+      promoLine: 'Buy 2 get 1 free',
+    });
+    expect(zpl).toContain('Buy 2 get 1 free');
+  });
+
+  it('omits promo region entirely when no promo line is given', () => {
+    const zpl = generateShelfTalker({
+      productName: 'Test',
+      skuCode: 'T-1',
+      pricePerCase: 50,
+    });
+    // Only 3 ^FO blocks — name, sku, price
+    expect(zpl.match(/\^FO/g)).toHaveLength(3);
+  });
+
+  it('matches snapshot for regression detection', () => {
+    const zpl = generateShelfTalker({
+      productName: 'Yellowhammer Pale Ale',
+      skuCode: 'YH-PA-HB',
+      pricePerCase: 142,
+      promoLine: 'New seasonal release',
+    });
+    expect(zpl).toMatchSnapshot();
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,4 +1,5 @@
-import { ScrollView, Text, View } from 'react-native';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, Text, View } from 'react-native';
 
 import { useAuthStore } from '@/auth/store';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -34,6 +35,21 @@ export default function Settings(): React.ReactNode {
         </View>
 
         <RoleSwitcher />
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="AI memories"
+          accessibilityHint="View and delete the patterns the AI has learned from your corrections"
+          onPress={() => router.push('/settings/memories')}
+          className="mt-4 rounded-2xl bg-ohanafy-cork p-4 active:opacity-80 dark:bg-ohanafy-dark-elevated"
+        >
+          <Text className="text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+            AI Memories
+          </Text>
+          <Text className="mt-1 text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+            View and manage what the AI has learned from your corrections.
+          </Text>
+        </Pressable>
       </ScrollView>
     </ErrorBoundary>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,10 @@ import { useEffect } from 'react';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { database } from '@/db';
 import { seedDatabase } from '@/db/seeder';
+import {
+  configureAndroidChannel,
+  requestNotificationPermission,
+} from '@/notifications';
 import { initPostHog, initSentry } from '@/observability';
 import { startSyncEngine } from '@/sync/engine';
 
@@ -37,6 +41,9 @@ export default function RootLayout(): React.ReactNode {
 
     // Auto-flush sync queue on reconnect
     const stopSync = startSyncEngine();
+
+    // Notifications: request permission once, configure the Android channel
+    requestNotificationPermission().then(() => configureAndroidChannel());
 
     return () => {
       clearTimeout(id);

--- a/app/label/preview.tsx
+++ b/app/label/preview.tsx
@@ -1,0 +1,230 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Image, Pressable, ScrollView, Text, View } from 'react-native';
+
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { useOfflineStatus } from '@/hooks/useOfflineStatus';
+import {
+  generateProductCard,
+  generateShelfTalker,
+  generateDeliveryReceipt,
+  printZpl,
+  recordLabelPrint,
+  renderZplPreview,
+  type LabelTemplateType,
+} from '@/zpl';
+
+interface DemoParams {
+  productName: string;
+  skuCode: string;
+  pricePerCase: number;
+}
+
+const DEMO: DemoParams = {
+  productName: 'Yellowhammer Pale Ale',
+  skuCode: 'YH-PA-HB',
+  pricePerCase: 142,
+};
+
+function buildZpl(template: LabelTemplateType): { zpl: string; w: number; h: number } {
+  switch (template) {
+    case 'shelf_talker':
+      return {
+        zpl: generateShelfTalker({
+          productName: DEMO.productName,
+          skuCode: DEMO.skuCode,
+          pricePerCase: DEMO.pricePerCase,
+          promoLine: 'Cooler reset this week',
+        }),
+        w: 2.5,
+        h: 1.5,
+      };
+    case 'product_card':
+      return {
+        zpl: generateProductCard({
+          productName: DEMO.productName,
+          skuCode: DEMO.skuCode,
+          pricePerCase: DEMO.pricePerCase,
+          facts: ['Brewed in Birmingham AL', '1/2 bbl keg', 'Year-round'],
+        }),
+        w: 4,
+        h: 3,
+      };
+    case 'delivery_receipt':
+      return {
+        zpl: generateDeliveryReceipt({
+          accountName: 'The Rail',
+          orderNumber: 'OF-1042',
+          deliveryDate: new Date(),
+          rep: 'Jake Thornton',
+          totalAmount: 548,
+          lines: [
+            {
+              productName: 'Yellowhammer Pale Ale',
+              quantity: 2,
+              unit: 'keg',
+              unitPrice: 178,
+              lineTotal: 356,
+            },
+            {
+              productName: 'Modelo Especial',
+              quantity: 1,
+              unit: 'keg',
+              unitPrice: 192,
+              lineTotal: 192,
+            },
+          ],
+        }),
+        w: 4,
+        h: 6,
+      };
+  }
+}
+
+export default function LabelPreview(): React.ReactNode {
+  const { template, accountId } = useLocalSearchParams<{
+    template: LabelTemplateType;
+    accountId?: string;
+  }>();
+  const offline = useOfflineStatus();
+  const [pngBase64, setPngBase64] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [printing, setPrinting] = useState(false);
+  const [printResult, setPrintResult] = useState<string | null>(null);
+
+  const built = useMemo(() => (template ? buildZpl(template) : null), [template]);
+
+  useEffect(() => {
+    if (!built) return;
+    if (offline.isOffline) {
+      setPngBase64(null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    renderZplPreview({ zpl: built.zpl, widthInches: built.w, heightInches: built.h })
+      .then((res) => {
+        if (!cancelled) {
+          setPngBase64(res.pngBase64);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [built, offline.isOffline]);
+
+  if (!template || !built) {
+    return (
+      <View className="flex-1 items-center justify-center bg-ohanafy-paper dark:bg-ohanafy-dark-surface">
+        <Text className="text-base text-ohanafy-muted dark:text-ohanafy-dark-muted">
+          Missing template parameter
+        </Text>
+      </View>
+    );
+  }
+
+  const handlePrint = async (): Promise<void> => {
+    setPrinting(true);
+    try {
+      const result = await printZpl(built.zpl);
+      if (accountId) {
+        await recordLabelPrint({
+          accountId,
+          templateType: template,
+          productName: DEMO.productName,
+          printerSerial: result.printerSerial,
+          zplSnapshot: built.zpl,
+        });
+      }
+      setPrintResult(result.message);
+    } finally {
+      setPrinting(false);
+    }
+  };
+
+  return (
+    <ErrorBoundary screenName="LabelPreview">
+      <ScrollView
+        accessibilityLabel="Label preview"
+        className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface"
+        contentContainerClassName="px-4 pt-12 pb-32"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+        </Pressable>
+        <Text className="mb-4 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          Preview
+        </Text>
+
+        {loading ? (
+          <View className="items-center justify-center py-12">
+            <ActivityIndicator color="#4A5F80" />
+            <Text className="mt-3 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+              Rendering preview…
+            </Text>
+          </View>
+        ) : pngBase64 ? (
+          <View className="items-center rounded-2xl bg-ohanafy-cork p-4 dark:bg-ohanafy-dark-elevated">
+            <Image
+              accessibilityLabel="Rendered label preview"
+              source={{ uri: `data:image/png;base64,${pngBase64}` }}
+              style={{ width: built.w * 80, height: built.h * 80 }}
+              resizeMode="contain"
+            />
+          </View>
+        ) : (
+          // Offline / Labelary unreachable — show raw ZPL as the §8 contract calls for
+          <View className="rounded-2xl bg-ohanafy-cork p-4 dark:bg-ohanafy-dark-elevated">
+            <Text className="mb-2 text-xs font-bold uppercase tracking-wider text-ohanafy-muted dark:text-ohanafy-dark-muted">
+              Offline ZPL fallback
+            </Text>
+            <Text className="font-mono text-xs text-ohanafy-ink dark:text-ohanafy-dark-text">
+              {built.zpl}
+            </Text>
+          </View>
+        )}
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Print label"
+          accessibilityState={{ disabled: printing }}
+          disabled={printing}
+          onPress={handlePrint}
+          className={
+            printing
+              ? 'mt-6 rounded-xl bg-ohanafy-cork px-4 py-4 dark:bg-ohanafy-dark-elevated'
+              : 'mt-6 rounded-xl bg-ohanafy-denim px-4 py-4 active:opacity-80'
+          }
+        >
+          <Text
+            className={
+              printing
+                ? 'text-center text-base font-bold text-ohanafy-muted'
+                : 'text-center text-base font-bold text-ohanafy-paper'
+            }
+          >
+            {printing ? 'Sending…' : 'Print to Zebra'}
+          </Text>
+        </Pressable>
+        {printResult ? (
+          <Text
+            accessibilityLiveRegion="polite"
+            className="mt-3 text-center text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted"
+          >
+            {printResult}
+          </Text>
+        ) : null}
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/app/label/select.tsx
+++ b/app/label/select.tsx
@@ -1,0 +1,81 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { Pressable, Text, View } from 'react-native';
+
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import type { LabelTemplateType } from '@/zpl';
+
+const TEMPLATES: Array<{
+  type: LabelTemplateType;
+  title: string;
+  size: string;
+  description: string;
+}> = [
+  {
+    type: 'shelf_talker',
+    title: 'Shelf Talker',
+    size: '2.5" × 1.5"',
+    description: 'Compact tag for cooler / shelf placement.',
+  },
+  {
+    type: 'product_card',
+    title: 'Product Card',
+    size: '4" × 3"',
+    description: '3 key facts about the product.',
+  },
+  {
+    type: 'delivery_receipt',
+    title: 'Delivery Receipt',
+    size: '4" × 6"',
+    description: 'Order summary with line totals + signature line.',
+  },
+];
+
+export default function LabelSelect(): React.ReactNode {
+  const params = useLocalSearchParams<{ accountId?: string; productId?: string; orderId?: string }>();
+
+  return (
+    <ErrorBoundary screenName="LabelSelect">
+      <View
+        accessibilityLabel="Select label type"
+        className="flex-1 bg-ohanafy-paper px-4 pt-12 dark:bg-ohanafy-dark-surface"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+        </Pressable>
+        <Text className="mb-4 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          Pick a label
+        </Text>
+        {TEMPLATES.map((tpl) => (
+          <Pressable
+            key={tpl.type}
+            accessibilityRole="button"
+            accessibilityLabel={`${tpl.title}, ${tpl.size}`}
+            accessibilityHint={tpl.description}
+            onPress={() =>
+              router.push({
+                pathname: '/label/preview',
+                params: { template: tpl.type, ...params },
+              })
+            }
+            className="mb-3 rounded-2xl bg-ohanafy-cork p-4 active:opacity-80 dark:bg-ohanafy-dark-elevated"
+          >
+            <Text className="text-lg font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+              {tpl.title}
+            </Text>
+            <Text className="mt-1 text-xs font-bold uppercase tracking-wider text-ohanafy-muted dark:text-ohanafy-dark-muted">
+              {tpl.size}
+            </Text>
+            <Text className="mt-2 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+              {tpl.description}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </ErrorBoundary>
+  );
+}

--- a/app/settings/memories.tsx
+++ b/app/settings/memories.tsx
@@ -1,0 +1,95 @@
+import { router } from 'expo-router';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+
+import { runLearningAgent } from '@/ai/agents';
+import { useAuthStore } from '@/auth/store';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { database } from '@/db';
+import { deleteMemory, useMemories } from '@/hooks/useMemories';
+import type { Memory } from '@/db/models/Memory';
+
+export default function Memories(): React.ReactNode {
+  const repId = useAuthStore((s) => s.userId) ?? 'demo-rep';
+  const { memories, loading } = useMemories(repId);
+
+  const handleSynthesize = async (): Promise<void> => {
+    await runLearningAgent(database, { repId });
+  };
+
+  const handleDelete = async (memory: Memory): Promise<void> => {
+    await deleteMemory(memory);
+  };
+
+  return (
+    <ErrorBoundary screenName="Memories">
+      <ScrollView
+        accessibilityLabel="AI memories for your account"
+        className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface"
+        contentContainerClassName="px-4 pt-12 pb-12"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+        </Pressable>
+        <Text className="mb-2 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          AI Memories
+        </Text>
+        <Text className="mb-4 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+          Patterns the AI has learned from your corrections. Higher confidence
+          = more consistent examples. Delete anything that no longer fits.
+        </Text>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Run learning agent now"
+          onPress={handleSynthesize}
+          className="mb-4 rounded-xl border border-ohanafy-denim px-4 py-3"
+        >
+          <Text className="text-center text-sm font-bold text-ohanafy-denim dark:text-ohanafy-denim-light">
+            Run learning now
+          </Text>
+        </Pressable>
+
+        {loading ? null : memories.length === 0 ? (
+          <Text className="text-center text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+            No memories yet. The AI starts learning after a few accept/edit/reject taps on voice commands.
+          </Text>
+        ) : (
+          memories.map((m) => (
+            <View
+              key={m.id}
+              className="mb-3 rounded-2xl bg-ohanafy-cork p-3 dark:bg-ohanafy-dark-elevated"
+            >
+              <View className="flex-row items-center justify-between">
+                <Text className="text-xs font-bold uppercase tracking-wider text-ohanafy-muted dark:text-ohanafy-dark-muted">
+                  {m.category}
+                </Text>
+                <Text className="text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+                  {Math.round(m.confidence * 100)}% confidence
+                </Text>
+              </View>
+              <Text className="mt-1 text-base text-ohanafy-ink dark:text-ohanafy-dark-text">
+                {m.key}
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Delete memory: ${m.key}`}
+                accessibilityHint="Removes this learned pattern. The AI may re-learn it from future corrections."
+                onPress={() => handleDelete(m)}
+                className="mt-2 self-end rounded-full px-3 py-1"
+              >
+                <Text className="text-xs font-bold text-ohanafy-denim dark:text-ohanafy-denim-light">
+                  Delete
+                </Text>
+              </Pressable>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/packages/sfdx-package/README.md
+++ b/packages/sfdx-package/README.md
@@ -1,0 +1,43 @@
+# Ohanafy Field — Managed Package (SFDX)
+
+The 2GP managed package for Ohanafy Field. Namespace: `ohfy_field__`.
+
+## Contents
+
+- **Connected App** — `Ohanafy_Field_Mobile.connectedApp-meta.xml` migrated from `scripts/sf-bootstrap/` (PKCE-enabled, scopes `api refresh_token offline_access`, callback `com.ohanafy.field://oauth/callback`)
+- **6 custom objects** (per Roles doc §12):
+  - `Admin_Config__mdt` — org-wide settings (sync interval, feature flags)
+  - `Admin_Audit_Log__c` — immutable audit trail
+  - `ZPL_Template__c` — custom label templates per org
+  - `Territory_Assignment__c` — manual rep ↔ account mapping fallback
+  - `Notification_Rule__c` — configurable notification rules
+  - `AI_Config__mdt` — encrypted AI settings (API key, prompts)
+
+## Build & deploy
+
+```bash
+# Authenticate to a DevHub
+sf org login web --set-default-dev-hub
+
+# Validate metadata against the dev sandbox
+cd packages/sfdx-package
+sf project deploy validate --target-org ohanafy-sandbox
+
+# Create a new package version (DevHub)
+sf package version create --package "Ohanafy Field" --installation-key-bypass --wait 30
+```
+
+## CI gate
+
+PMD runs on every push when any `*.cls` exists under `force-app/main/default/classes/`. Zero violations required (Security Review §3). The Apex classes themselves arrive on Day 5 — managers' approvals + admin console controllers.
+
+## What ships in v1.0.0
+
+- Day 1: nothing (mobile-only)
+- Day 4: 6 custom objects + Connected App
+- Day 5: Apex permission set assignment helpers, admin console controllers
+- Day 7: AppExchange listing screenshots + Privacy Policy link
+
+## Namespace
+
+Existing managed package: `ohfy__` (do not modify). New module: `ohfy_field__`.

--- a/packages/sfdx-package/force-app/main/default/connectedApps/Ohanafy_Field_Mobile.connectedApp-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/connectedApps/Ohanafy_Field_Mobile.connectedApp-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConnectedApp xmlns="http://soap.sforce.com/2006/04/metadata">
+    <contactEmail>daniel.zeder@ohanafy.com</contactEmail>
+    <description>Ohanafy Field — mobile OAuth client (PKCE). Used for development and the AppExchange-distributed mobile app.</description>
+    <label>Ohanafy Field Mobile</label>
+    <oauthConfig>
+        <callbackUrl>com.ohanafy.field://oauth/callback</callbackUrl>
+        <isAdminApproved>false</isAdminApproved>
+        <isConsumerSecretOptional>true</isConsumerSecretOptional>
+        <isIntrospectAllTokens>false</isIntrospectAllTokens>
+        <isPkceRequired>true</isPkceRequired>
+        <isSecretRequiredForRefreshToken>false</isSecretRequiredForRefreshToken>
+        <scopes>Api</scopes>
+        <scopes>RefreshToken</scopes>
+    </oauthConfig>
+</ConnectedApp>

--- a/packages/sfdx-package/force-app/main/default/objects/AI_Config__mdt/AI_Config__mdt.object-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/AI_Config__mdt/AI_Config__mdt.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Encrypted AI settings (Anthropic API key, model overrides, prompt customizations). Subscribers may protect this metadata at install time.</description>
+    <label>AI Config</label>
+    <pluralLabel>AI Configs</pluralLabel>
+    <visibility>Protected</visibility>
+</CustomObject>

--- a/packages/sfdx-package/force-app/main/default/objects/AI_Config__mdt/fields/Anthropic_Api_Key__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/AI_Config__mdt/fields/Anthropic_Api_Key__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Anthropic_Api_Key__c</fullName>
+    <description>Anthropic API key. Stored as protected metadata. Mobile app fetches post-auth and writes to SecureStore — never exposed in the bundle.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Anthropic API Key</label>
+    <length>200</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/Admin_Audit_Log__c.object-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/Admin_Audit_Log__c.object-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Immutable audit trail of admin-console changes for the Ohanafy Field package.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableHistory>false</enableHistory>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <label>Admin Audit Log</label>
+    <nameField>
+        <displayFormat>AAL-{0000}</displayFormat>
+        <label>Audit ID</label>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Admin Audit Logs</pluralLabel>
+    <sharingModel>ReadWrite</sharingModel>
+</CustomObject>

--- a/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/fields/Action_Type__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/fields/Action_Type__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Action_Type__c</fullName>
+    <description>The category of admin action that was logged.</description>
+    <externalId>false</externalId>
+    <label>Action Type</label>
+    <length>120</length>
+    <required>true</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/fields/Actor__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/fields/Actor__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Actor__c</fullName>
+    <description>The user who performed the admin action.</description>
+    <externalId>false</externalId>
+    <label>Actor</label>
+    <referenceTo>User</referenceTo>
+    <relationshipLabel>Admin Audit Logs</relationshipLabel>
+    <relationshipName>Admin_Audit_Logs</relationshipName>
+    <required>true</required>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/fields/Payload__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Admin_Audit_Log__c/fields/Payload__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Payload__c</fullName>
+    <description>JSON snapshot of the action payload (before/after diff).</description>
+    <externalId>false</externalId>
+    <label>Payload</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>10</visibleLines>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/Admin_Config__mdt/Admin_Config__mdt.object-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Admin_Config__mdt/Admin_Config__mdt.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Custom metadata for org-wide Ohanafy Field settings (sync interval, feature flags, default territory).</description>
+    <label>Admin Config</label>
+    <pluralLabel>Admin Configs</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/packages/sfdx-package/force-app/main/default/objects/Admin_Config__mdt/fields/Sync_Interval_Minutes__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Admin_Config__mdt/fields/Sync_Interval_Minutes__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Sync_Interval_Minutes__c</fullName>
+    <description>How often the mobile app polls Salesforce in the background. Defaults to 15 minutes.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Sync Interval (Minutes)</label>
+    <precision>4</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/Notification_Rule__c/Notification_Rule__c.object-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Notification_Rule__c/Notification_Rule__c.object-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Configurable rules that drive in-app and push notifications (e.g., visit reminders, large-order approval requests).</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableHistory>true</enableHistory>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <label>Notification Rule</label>
+    <nameField>
+        <label>Rule Name</label>
+        <type>Text</type>
+    </nameField>
+    <pluralLabel>Notification Rules</pluralLabel>
+    <sharingModel>ReadWrite</sharingModel>
+</CustomObject>

--- a/packages/sfdx-package/force-app/main/default/objects/Notification_Rule__c/fields/Channel__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Notification_Rule__c/fields/Channel__c.field-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Channel__c</fullName>
+    <description>Where this notification fires.</description>
+    <externalId>false</externalId>
+    <label>Channel</label>
+    <required>true</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value><fullName>push</fullName><default>true</default><label>Push (mobile)</label></value>
+            <value><fullName>in_app</fullName><default>false</default><label>In-app banner</label></value>
+            <value><fullName>email</fullName><default>false</default><label>Email</label></value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/Notification_Rule__c/fields/Trigger_Event__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Notification_Rule__c/fields/Trigger_Event__c.field-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Trigger_Event__c</fullName>
+    <description>The event that fires this notification.</description>
+    <externalId>false</externalId>
+    <label>Trigger Event</label>
+    <required>true</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value><fullName>visit_reminder</fullName><default>true</default><label>Visit Reminder</label></value>
+            <value><fullName>large_order_approval</fullName><default>false</default><label>Large Order Approval</label></value>
+            <value><fullName>delivery_exception</fullName><default>false</default><label>Delivery Exception</label></value>
+            <value><fullName>inventory_alert</fullName><default>false</default><label>Inventory Alert</label></value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/Territory_Assignment__c/Territory_Assignment__c.object-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Territory_Assignment__c/Territory_Assignment__c.object-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Manual rep ↔ account mapping. Used as a fallback when Salesforce Territory Management isn't available or doesn't cover the desired model.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableHistory>true</enableHistory>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <label>Territory Assignment</label>
+    <nameField>
+        <displayFormat>TA-{00000}</displayFormat>
+        <label>Assignment ID</label>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Territory Assignments</pluralLabel>
+    <sharingModel>ReadWrite</sharingModel>
+</CustomObject>

--- a/packages/sfdx-package/force-app/main/default/objects/Territory_Assignment__c/fields/Rep__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/Territory_Assignment__c/fields/Rep__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Rep__c</fullName>
+    <description>The sales rep assigned to the account.</description>
+    <externalId>false</externalId>
+    <label>Rep</label>
+    <referenceTo>User</referenceTo>
+    <relationshipLabel>Territory Assignments</relationshipLabel>
+    <relationshipName>Territory_Assignments</relationshipName>
+    <required>true</required>
+    <type>Lookup</type>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/ZPL_Template__c/ZPL_Template__c.object-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/ZPL_Template__c/ZPL_Template__c.object-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Custom ZPL templates per org. Overrides the default templates shipped with the package.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableHistory>true</enableHistory>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <label>ZPL Template</label>
+    <nameField>
+        <label>Template Name</label>
+        <type>Text</type>
+    </nameField>
+    <pluralLabel>ZPL Templates</pluralLabel>
+    <sharingModel>ReadWrite</sharingModel>
+</CustomObject>

--- a/packages/sfdx-package/force-app/main/default/objects/ZPL_Template__c/fields/Template_Type__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/ZPL_Template__c/fields/Template_Type__c.field-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Template_Type__c</fullName>
+    <description>Which built-in template this row overrides.</description>
+    <externalId>false</externalId>
+    <label>Template Type</label>
+    <required>true</required>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value><fullName>shelf_talker</fullName><default>true</default><label>Shelf Talker</label></value>
+            <value><fullName>product_card</fullName><default>false</default><label>Product Card</label></value>
+            <value><fullName>delivery_receipt</fullName><default>false</default><label>Delivery Receipt</label></value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/packages/sfdx-package/force-app/main/default/objects/ZPL_Template__c/fields/ZPL_Source__c.field-meta.xml
+++ b/packages/sfdx-package/force-app/main/default/objects/ZPL_Template__c/fields/ZPL_Source__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ZPL_Source__c</fullName>
+    <description>Raw ZPL II source. Tokens like {{productName}}, {{price}} are expanded by the mobile app at print time.</description>
+    <externalId>false</externalId>
+    <label>ZPL Source</label>
+    <length>32768</length>
+    <required>true</required>
+    <type>LongTextArea</type>
+    <visibleLines>20</visibleLines>
+</CustomField>

--- a/packages/sfdx-package/sfdx-project.json
+++ b/packages/sfdx-package/sfdx-project.json
@@ -1,0 +1,16 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true,
+      "package": "Ohanafy Field",
+      "versionName": "v1.0",
+      "versionNumber": "1.0.0.NEXT"
+    }
+  ],
+  "name": "ohanafy-field",
+  "namespace": "ohfy_field",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "61.0",
+  "packageAliases": {}
+}

--- a/src/ai/agents/index.ts
+++ b/src/ai/agents/index.ts
@@ -2,3 +2,5 @@ export { interpretCommand } from './command-agent';
 export { getVisitInsight } from './visit-prep-agent';
 export type { VisitInsight } from './visit-prep-agent';
 export { cleanNote } from './note-agent';
+export { runLearningAgent } from './learning-agent';
+export type { LearningRunResult } from './learning-agent';

--- a/src/ai/agents/learning-agent.ts
+++ b/src/ai/agents/learning-agent.ts
@@ -1,0 +1,134 @@
+import type { Database } from '@nozbe/watermelondb';
+import { Q } from '@nozbe/watermelondb';
+
+import { writeMemory, type MemoryCategory } from '@/db/repositories/memories';
+import type { FeedbackEvent } from '@/db/models/FeedbackEvent';
+
+// Synthesizes Memory records from accumulated FeedbackEvents.
+// Confidence model (per ai-tool-builder agent guidance):
+//   ≥ 4 consistent examples → 0.9
+//   2-3 examples → 0.7
+//   1 example → 0.5 (stored as a hint only)
+//
+// Idempotent — every processed event is marked `synthesized = true`.
+// Designed to run in the background; never blocks UI.
+
+const NOISE_FLOOR = 3;
+
+function confidenceForCount(n: number): number {
+  if (n >= 4) return 0.9;
+  if (n >= 2) return 0.7;
+  return 0.5;
+}
+
+interface LearningRunOptions {
+  repId: string;
+}
+
+export interface LearningRunResult {
+  processed: number;
+  memoriesCreated: number;
+  patternsBelowFloor: number;
+}
+
+interface ParsedFeedback {
+  event: FeedbackEvent;
+  productKey: string | null;
+  noteSubject: string | null;
+}
+
+function summarizeEditedAction(event: FeedbackEvent): ParsedFeedback {
+  let productKey: string | null = null;
+  let noteSubject: string | null = null;
+  try {
+    const ai = JSON.parse(event.aiOutput) as { action?: { type?: string; items?: Array<{ productName?: string }>; note?: string } };
+    if (ai?.action?.type === 'ADD_TO_ORDER' && ai.action.items?.[0]?.productName) {
+      productKey = ai.action.items[0].productName.toLowerCase();
+    } else if (ai?.action?.type === 'LOG_NOTE' && ai.action.note) {
+      noteSubject = ai.action.note.toLowerCase().split(/\s+/).slice(0, 3).join(' ');
+    }
+  } catch {
+    // ignore malformed events
+  }
+  return { event, productKey, noteSubject };
+}
+
+export async function runLearningAgent(
+  db: Database,
+  opts: LearningRunOptions
+): Promise<LearningRunResult> {
+  const events = await db
+    .get<FeedbackEvent>('feedback_events')
+    .query(
+      Q.where('rep_id', opts.repId),
+      Q.where('synthesized', false),
+      Q.where('event_type', Q.oneOf(['command_edited', 'command_rejected', 'insight_edited']))
+    )
+    .fetch();
+
+  if (events.length === 0) {
+    return { processed: 0, memoriesCreated: 0, patternsBelowFloor: 0 };
+  }
+
+  // Bucket by inferred subject
+  const productBuckets = new Map<string, ParsedFeedback[]>();
+  const noteBuckets = new Map<string, ParsedFeedback[]>();
+  for (const e of events) {
+    const parsed = summarizeEditedAction(e);
+    if (parsed.productKey) {
+      const bucket = productBuckets.get(parsed.productKey) ?? [];
+      bucket.push(parsed);
+      productBuckets.set(parsed.productKey, bucket);
+    } else if (parsed.noteSubject) {
+      const bucket = noteBuckets.get(parsed.noteSubject) ?? [];
+      bucket.push(parsed);
+      noteBuckets.set(parsed.noteSubject, bucket);
+    }
+  }
+
+  let memoriesCreated = 0;
+  let patternsBelowFloor = 0;
+
+  for (const [key, bucket] of productBuckets.entries()) {
+    if (bucket.length < NOISE_FLOOR) {
+      patternsBelowFloor += 1;
+      continue;
+    }
+    await writeMemory(db, {
+      repId: opts.repId,
+      category: 'PRODUCT_NICKNAME' satisfies MemoryCategory,
+      key,
+      value: JSON.stringify({ examples: bucket.length }),
+      confidence: confidenceForCount(bucket.length),
+      source: 'learning_agent',
+    });
+    memoriesCreated += 1;
+  }
+
+  for (const [key, bucket] of noteBuckets.entries()) {
+    if (bucket.length < NOISE_FLOOR) {
+      patternsBelowFloor += 1;
+      continue;
+    }
+    await writeMemory(db, {
+      repId: opts.repId,
+      category: 'NOTE_PHRASING' satisfies MemoryCategory,
+      key,
+      value: JSON.stringify({ examples: bucket.length }),
+      confidence: confidenceForCount(bucket.length),
+      source: 'learning_agent',
+    });
+    memoriesCreated += 1;
+  }
+
+  // Mark all processed events as synthesized — idempotent on re-runs
+  await db.write(async () => {
+    for (const e of events) {
+      await e.update((rec) => {
+        rec.synthesized = true;
+      });
+    }
+  });
+
+  return { processed: events.length, memoriesCreated, patternsBelowFloor };
+}

--- a/src/hooks/useMemories.ts
+++ b/src/hooks/useMemories.ts
@@ -1,0 +1,31 @@
+import { Q } from '@nozbe/watermelondb';
+import { useEffect, useState } from 'react';
+
+import { database } from '@/db';
+import type { Memory } from '@/db/models/Memory';
+
+export function useMemories(repId: string): { memories: Memory[]; loading: boolean } {
+  const [memories, setMemories] = useState<Memory[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!repId) return;
+    const subscription = database
+      .get<Memory>('memories')
+      .query(Q.where('rep_id', repId), Q.sortBy('confidence', Q.desc))
+      .observe()
+      .subscribe((next) => {
+        setMemories(next);
+        setLoading(false);
+      });
+    return () => subscription.unsubscribe();
+  }, [repId]);
+
+  return { memories, loading };
+}
+
+export async function deleteMemory(memory: Memory): Promise<void> {
+  await database.write(async () => {
+    await memory.markAsDeleted();
+  });
+}

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -1,0 +1,62 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: false,
+    shouldSetBadge: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
+  }),
+});
+
+export async function requestNotificationPermission(): Promise<boolean> {
+  const settings = await Notifications.getPermissionsAsync();
+  if (settings.granted || settings.ios?.status === Notifications.IosAuthorizationStatus.AUTHORIZED) {
+    return true;
+  }
+  const ask = await Notifications.requestPermissionsAsync({
+    ios: {
+      allowAlert: true,
+      allowBadge: true,
+      allowSound: false,
+    },
+  });
+  return ask.granted;
+}
+
+export interface VisitReminderInput {
+  accountName: string;
+  accountId: string;
+  scheduledAtMs: number;
+}
+
+export async function scheduleVisitReminder(input: VisitReminderInput): Promise<string> {
+  const trigger: Notifications.DateTriggerInput = {
+    type: Notifications.SchedulableTriggerInputTypes.DATE,
+    date: new Date(input.scheduledAtMs),
+  };
+  const identifier = await Notifications.scheduleNotificationAsync({
+    content: {
+      title: `Visit: ${input.accountName}`,
+      body: 'Tap to open the account.',
+      data: { accountId: input.accountId, kind: 'visit_reminder' },
+    },
+    trigger,
+  });
+  return identifier;
+}
+
+export async function cancelReminder(identifier: string): Promise<void> {
+  await Notifications.cancelScheduledNotificationAsync(identifier);
+}
+
+export async function configureAndroidChannel(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  await Notifications.setNotificationChannelAsync('visit_reminders', {
+    name: 'Visit reminders',
+    importance: Notifications.AndroidImportance.DEFAULT,
+    vibrationPattern: [0, 200, 100, 200],
+  });
+}

--- a/src/zpl/index.ts
+++ b/src/zpl/index.ts
@@ -1,0 +1,20 @@
+export {
+  generateShelfTalker,
+  generateProductCard,
+  generateDeliveryReceipt,
+} from './templates';
+export type {
+  ShelfTalkerParams,
+  ProductCardParams,
+  DeliveryReceiptParams,
+  DeliveryReceiptLine,
+  LabelTemplateType,
+} from './templates';
+
+export { renderZplPreview } from './preview';
+export {
+  discoverPrinters,
+  printZpl,
+  recordLabelPrint,
+} from './printer';
+export type { DiscoveredPrinter, PrintResult, RecordLabelPrintInput } from './printer';

--- a/src/zpl/preview.ts
+++ b/src/zpl/preview.ts
@@ -1,0 +1,44 @@
+// Labelary preview API — renders ZPL to a PNG.
+// Free tier, no auth: http://api.labelary.com/v1/printers/{dpmm}dpmm/labels/{W}x{H}/{idx}/
+
+interface PreviewOptions {
+  zpl: string;
+  widthInches: number;
+  heightInches: number;
+  dpmm?: 8 | 12;
+}
+
+export async function renderZplPreview(opts: PreviewOptions): Promise<{
+  pngBase64: string;
+}> {
+  const dpmm = opts.dpmm ?? 8;
+  const url = `http://api.labelary.com/v1/printers/${dpmm}dpmm/labels/${opts.widthInches}x${opts.heightInches}/0/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'image/png',
+    },
+    body: opts.zpl,
+  });
+  if (!response.ok) {
+    throw new Error(`Labelary preview failed: ${response.status} ${response.statusText}`);
+  }
+  // RN's fetch supports response.arrayBuffer(); we base64-encode it for inline display
+  const buffer = await response.arrayBuffer();
+  return { pngBase64: arrayBufferToBase64(buffer) };
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  // btoa is available in RN's Hermes JS runtime as a global
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+  if (typeof g.btoa === 'function') return g.btoa(binary);
+  // Node fallback for tests
+  return Buffer.from(binary, 'binary').toString('base64');
+}

--- a/src/zpl/printer.ts
+++ b/src/zpl/printer.ts
@@ -1,0 +1,73 @@
+// Zebra printer wrapper. Day 4 ships a TypeScript stub that logs the ZPL string
+// in dev — the actual native bridge to Zebra Link-OS SDK is added in a Day 5/6
+// iOS+Android dev build. This wrapper keeps every screen + repository call site
+// stable across both phases.
+
+import { Platform } from 'react-native';
+
+import { database } from '@/db';
+import type { LabelPrint } from '@/db/models/LabelPrint';
+
+export interface DiscoveredPrinter {
+  serial: string;
+  name: string;
+  connectionType: 'bluetooth' | 'network';
+}
+
+export async function discoverPrinters(): Promise<DiscoveredPrinter[]> {
+  // Stub. Real impl uses Zebra Link-OS SDK BluetoothDeviceManager.
+  // eslint-disable-next-line no-console
+  console.warn('[zebra] discoverPrinters: stub — returning empty list. Native module pending.');
+  return [];
+}
+
+export interface PrintResult {
+  success: boolean;
+  printerSerial: string;
+  message: string;
+  simulated: boolean;
+}
+
+export async function printZpl(
+  zpl: string,
+  options: { printerSerial?: string } = {}
+): Promise<PrintResult> {
+  const printerSerial = options.printerSerial ?? 'simulator';
+  // Stub. Real impl resolves the ZQ520/ZQ630 instance and calls .write(zpl).
+  // eslint-disable-next-line no-console
+  console.warn(`[zebra] printZpl on ${Platform.OS}: stub — ZPL string captured.`);
+  // eslint-disable-next-line no-console
+  console.warn(zpl);
+  return {
+    success: true,
+    printerSerial,
+    message: 'Simulated print (Day 5 device build wires the native bridge)',
+    simulated: true,
+  };
+}
+
+export interface RecordLabelPrintInput {
+  accountId: string;
+  productId?: string;
+  templateType: 'shelf_talker' | 'product_card' | 'delivery_receipt';
+  productName: string;
+  printerSerial?: string;
+  zplSnapshot: string;
+}
+
+export async function recordLabelPrint(input: RecordLabelPrintInput): Promise<LabelPrint> {
+  let created!: LabelPrint;
+  await database.write(async () => {
+    created = await database.get<LabelPrint>('label_prints').create((rec) => {
+      rec.accountId = input.accountId;
+      rec.productId = input.productId;
+      rec.templateType = input.templateType;
+      rec.productName = input.productName;
+      rec.printerSerial = input.printerSerial;
+      rec.printedAt = new Date();
+      rec.zplSnapshot = input.zplSnapshot;
+      rec.sfSyncStatus = 'pending';
+    });
+  });
+  return created;
+}

--- a/src/zpl/templates/delivery-receipt.ts
+++ b/src/zpl/templates/delivery-receipt.ts
@@ -1,0 +1,75 @@
+import { dollars, sanitizeForZpl, truncate } from '../util';
+
+export interface DeliveryReceiptLine {
+  productName: string;
+  quantity: number;
+  unit: string;
+  unitPrice: number;
+  lineTotal: number;
+}
+
+export interface DeliveryReceiptParams {
+  accountName: string;
+  orderNumber: string;
+  deliveryDate: Date;
+  lines: DeliveryReceiptLine[];
+  totalAmount: number;
+  rep: string;
+}
+
+// 4" × 6" @ 8dpmm — PW=640, LL=960
+const PW = 640;
+const LL = 960;
+const MAX_ACCOUNT_CHARS = 28;
+const MAX_LINE_CHARS = 28;
+const MAX_LINES = 16;
+const LINE_HEIGHT = 32;
+
+export function generateDeliveryReceipt(params: DeliveryReceiptParams): string {
+  const account = sanitizeForZpl(truncate(params.accountName, MAX_ACCOUNT_CHARS));
+  const dateStr = params.deliveryDate.toLocaleDateString('en-US');
+  const orderNum = sanitizeForZpl(truncate(params.orderNumber, 20));
+  const rep = sanitizeForZpl(truncate(params.rep, 24));
+  const lines = params.lines.slice(0, MAX_LINES);
+
+  const out = [
+    '^XA',
+    '^CI28',
+    `^PW${PW}`,
+    `^LL${LL}`,
+    // Header
+    `^FO30,25^A0N,40,40^FDOhanafy Field^FS`,
+    `^FO30,75^A0N,24,24^FDDelivery Receipt^FS`,
+    // Account block
+    `^FO30,130^A0N,28,28^FD${account}^FS`,
+    `^FO30,170^A0N,22,22^FDOrder: ${orderNum}^FS`,
+    `^FO30,200^A0N,22,22^FDDate: ${dateStr}^FS`,
+    `^FO30,230^A0N,22,22^FDRep: ${rep}^FS`,
+    // Divider above lines
+    `^FO30,275^GB580,2,2^FS`,
+    `^FO30,285^A0N,22,22^FDQty  Item                     Total^FS`,
+    `^FO30,315^GB580,2,2^FS`,
+  ];
+
+  // Line items
+  lines.forEach((line, idx) => {
+    const y = 330 + idx * LINE_HEIGHT;
+    const item = sanitizeForZpl(truncate(line.productName, MAX_LINE_CHARS));
+    const total = dollars(line.lineTotal);
+    out.push(`^FO30,${y}^A0N,22,22^FD${line.quantity} ${line.unit}  ${item}^FS`);
+    out.push(`^FO450,${y}^A0N,22,22^FD${total}^FS`);
+  });
+
+  // Total
+  const totalY = 330 + lines.length * LINE_HEIGHT + 30;
+  out.push(`^FO30,${totalY}^GB580,2,2^FS`);
+  out.push(`^FO30,${totalY + 15}^A0N,32,32^FDTotal: ${dollars(params.totalAmount)}^FS`);
+
+  // Signature line
+  const sigY = totalY + 80;
+  out.push(`^FO30,${sigY}^GB580,2,2^FS`);
+  out.push(`^FO30,${sigY + 12}^A0N,18,18^FDSignature^FS`);
+
+  out.push('^XZ');
+  return out.join('\n');
+}

--- a/src/zpl/templates/index.ts
+++ b/src/zpl/templates/index.ts
@@ -1,0 +1,11 @@
+export { generateShelfTalker } from './shelf-talker';
+export type { ShelfTalkerParams } from './shelf-talker';
+export { generateProductCard } from './product-card';
+export type { ProductCardParams } from './product-card';
+export { generateDeliveryReceipt } from './delivery-receipt';
+export type {
+  DeliveryReceiptParams,
+  DeliveryReceiptLine,
+} from './delivery-receipt';
+
+export type LabelTemplateType = 'shelf_talker' | 'product_card' | 'delivery_receipt';

--- a/src/zpl/templates/product-card.ts
+++ b/src/zpl/templates/product-card.ts
@@ -1,0 +1,47 @@
+import { dollars, sanitizeForZpl, truncate } from '../util';
+
+export interface ProductCardParams {
+  productName: string;
+  skuCode: string;
+  pricePerCase: number;
+  facts: string[]; // 1–3 short bullets
+}
+
+// 4" × 3" @ 8dpmm — PW=640 (margin 620), LL=480
+const PW = 640;
+const LL = 480;
+const MAX_NAME_CHARS = 28;
+const MAX_FACT_CHARS = 40;
+const MAX_FACTS = 3;
+
+export function generateProductCard(params: ProductCardParams): string {
+  const name = sanitizeForZpl(truncate(params.productName, MAX_NAME_CHARS));
+  const sku = sanitizeForZpl(truncate(params.skuCode, 24));
+  const price = dollars(params.pricePerCase);
+  const facts = params.facts
+    .slice(0, MAX_FACTS)
+    .map((f) => sanitizeForZpl(truncate(f, MAX_FACT_CHARS)));
+
+  const lines = [
+    '^XA',
+    '^CI28',
+    `^PW${PW}`,
+    `^LL${LL}`,
+    // Header band
+    `^FO30,25^A0N,48,48^FD${name}^FS`,
+    `^FO30,80^A0N,28,28^FDSKU: ${sku}^FS`,
+    // Divider
+    `^FO30,120^GB580,2,2^FS`,
+    // Price
+    `^FO30,140^A0N,72,72^FD${price}^FS`,
+  ];
+
+  // Facts
+  facts.forEach((fact, idx) => {
+    const y = 230 + idx * 50;
+    lines.push(`^FO30,${y}^A0N,28,28^FD• ${fact}^FS`);
+  });
+
+  lines.push('^XZ');
+  return lines.join('\n');
+}

--- a/src/zpl/templates/shelf-talker.ts
+++ b/src/zpl/templates/shelf-talker.ts
@@ -1,0 +1,48 @@
+import { dollars, sanitizeForZpl, truncate } from '../util';
+
+export interface ShelfTalkerParams {
+  productName: string;
+  skuCode: string;
+  pricePerCase: number;
+  promoLine?: string;
+}
+
+// 2.5" × 1.5" @ 8dpmm — keep all ^FO x coordinates < 380 (PW400 - 20 margin).
+// Layout (top to bottom):
+//   1. Product name (36pt, truncated to 22 chars)
+//   2. SKU code (22pt, secondary)
+//   3. Price (54pt — most prominent)
+//   4. Optional promo line (22pt italics-ish via spacing)
+const PW = 400;
+const LL = 240;
+const MAX_NAME_CHARS = 22;
+const MAX_PROMO_CHARS = 28;
+
+export function generateShelfTalker(params: ShelfTalkerParams): string {
+  const name = sanitizeForZpl(truncate(params.productName, MAX_NAME_CHARS));
+  const sku = sanitizeForZpl(truncate(params.skuCode, 18));
+  const price = dollars(params.pricePerCase);
+  const promo = params.promoLine
+    ? sanitizeForZpl(truncate(params.promoLine, MAX_PROMO_CHARS))
+    : null;
+
+  const lines = [
+    '^XA',
+    '^CI28',
+    `^PW${PW}`,
+    `^LL${LL}`,
+    // Name
+    `^FO20,15^A0N,36,36^FD${name}^FS`,
+    // SKU
+    `^FO20,60^A0N,22,22^FD${sku}^FS`,
+    // Price (right-aligned via FB block)
+    `^FO20,95^A0N,54,54^FD${price}^FS`,
+  ];
+
+  if (promo) {
+    lines.push(`^FO20,170^A0N,22,22^FD${promo}^FS`);
+  }
+
+  lines.push('^XZ');
+  return lines.join('\n');
+}

--- a/src/zpl/util.ts
+++ b/src/zpl/util.ts
@@ -1,0 +1,20 @@
+// ZPL II text safety helpers — shared across templates.
+
+export function truncate(text: string, maxChars: number, suffix = '…'): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars - suffix.length).trimEnd() + suffix;
+}
+
+// Strip / replace characters that break ZPL field data (caret, tilde).
+export function sanitizeForZpl(text: string): string {
+  return text.replace(/\^/g, '/').replace(/~/g, '-');
+}
+
+export function dollars(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+// dpmm × 25.4 × inches — see zpl2-reference skill
+export function inchesToDots(inches: number, dpmm = 8): number {
+  return Math.round(inches * dpmm * 25.4);
+}


### PR DESCRIPTION
## Summary

Day 4 per Bible §9 Thursday + Roles §12 — printing, learning, push, the managed package skeleton.

- **ZPL** — 3 templates (TDD, 22 tests + snapshots): `shelf-talker` 2.5×1.5", `product-card` 4×3", `delivery-receipt` 4×6". All `^FO x` verified within margin, long names truncated. `renderZplPreview` POSTs to Labelary, offline fallback shows raw ZPL. `printZpl` is a TypeScript stub that logs in dev — the native Zebra Link-OS SDK bridge is a Day 5/6 device build (call sites stable across both phases).
- **Label flow** — `/label/select` → `/label/preview` with Labelary PNG inline; print writes to `label_prints` table.
- **Learning agent** — synthesizes `FeedbackEvent` rows into `Memory` rows with confidence scores (≥4 = 0.9, 2-3 = 0.7, 1 = 0.5 hint). Noise floor 3 before any memory is created. Idempotent via `synthesized` flag. 5 unit tests.
- **Memory management UI** — Settings → AI Memories: list sorted by confidence, delete, run-learning-now button.
- **Push notifications** — `expo-notifications` permission + Android channel + `scheduleVisitReminder` helper, wired into the root layout.
- **SFDX managed package** — `packages/sfdx-package/` with `ohfy_field` namespace, Connected App migrated from `scripts/sf-bootstrap/`, all **6 new custom objects** from Roles §12: `Admin_Config__mdt`, `Admin_Audit_Log__c`, `ZPL_Template__c`, `Territory_Assignment__c`, `Notification_Rule__c`, `AI_Config__mdt` (protected). Apex classes land Day 5.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — **76/76 pass** (Day 1: 27, Day 2: 4, Day 3: 18, Day 4: 27)
- [x] `npx eslint src/ app/` — exit 0
- [ ] On device: open The Rail → New Order → /label/select → shelf talker → see Labelary PNG preview → tap Print (logs in dev console; Day 5 sends to real Zebra)
- [ ] In Settings → AI Memories, run learning agent after a few command_edited events; verify memories appear with the right confidence
- [ ] `sf project deploy validate --target-org ohanafy-sandbox --source-dir packages/sfdx-package` — Day 5 task once we have a 2GP DevHub registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)