### PR TITLE
feat(day-5): tests, onboarding, user guide, Maestro E2E flows

### DIFF
--- a/__tests__/unit/data/user-guide.test.ts
+++ b/__tests__/unit/data/user-guide.test.ts
@@ -1,0 +1,44 @@
+import { GUIDE_SECTIONS, searchGuide } from '@/data/user-guide';
+
+describe('user guide', () => {
+  it('contains all 7 sections', () => {
+    expect(GUIDE_SECTIONS).toHaveLength(7);
+  });
+
+  it('every section has id, title, and non-empty body', () => {
+    for (const section of GUIDE_SECTIONS) {
+      expect(section.id).toMatch(/^[a-z-]+$/);
+      expect(section.title.length).toBeGreaterThan(0);
+      expect(section.body.length).toBeGreaterThan(50);
+    }
+  });
+});
+
+describe('searchGuide', () => {
+  it('returns empty for empty query', () => {
+    expect(searchGuide('')).toEqual([]);
+    expect(searchGuide('   ')).toEqual([]);
+  });
+
+  it('finds the voice section when searching "voice"', () => {
+    const hits = searchGuide('voice');
+    const ids = hits.map((h) => h.section.id);
+    expect(ids).toContain('voice-commands');
+  });
+
+  it('returns case-insensitive matches', () => {
+    expect(searchGuide('SYNC').length).toBeGreaterThan(0);
+    expect(searchGuide('sync').length).toBeGreaterThan(0);
+  });
+
+  it('caps matches per section to keep results readable', () => {
+    const hits = searchGuide('the');
+    for (const hit of hits) {
+      expect(hit.matches.length).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it('returns no hits for a phrase that does not appear', () => {
+    expect(searchGuide('helicopter')).toEqual([]);
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
 
 import { AccountCard } from '@/components/account/AccountCard';
+import { CoachMark } from '@/components/onboarding/CoachMark';
 import { EmptyState } from '@/components/shared/EmptyState';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { LoadingSkeleton } from '@/components/shared/LoadingSkeleton';
@@ -37,6 +38,12 @@ export default function Accounts(): React.ReactNode {
           <Text className="mb-3 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
             Accounts
           </Text>
+          <CoachMark
+            markId="accounts-list"
+            title="Your accounts are here"
+            body="Tap any account to see AI insights and start an order. Accounts that need attention are flagged."
+          />
+
           <TextInput
             accessibilityLabel="Search accounts"
             accessibilityHint="Filters the account list as you type"

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -50,6 +50,21 @@ export default function Settings(): React.ReactNode {
             View and manage what the AI has learned from your corrections.
           </Text>
         </Pressable>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="User guide"
+          accessibilityHint="Opens the searchable offline user guide"
+          onPress={() => router.push('/guide')}
+          className="mt-3 rounded-2xl bg-ohanafy-cork p-4 active:opacity-80 dark:bg-ohanafy-dark-elevated"
+        >
+          <Text className="text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+            User Guide
+          </Text>
+          <Text className="mt-1 text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted">
+            7 sections, available offline. Search or browse.
+          </Text>
+        </Pressable>
       </ScrollView>
     </ErrorBoundary>
   );

--- a/app/account/[id].tsx
+++ b/app/account/[id].tsx
@@ -4,6 +4,7 @@ import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-nati
 
 import { useAuthStore } from '@/auth/store';
 import { InsightBanner } from '@/components/ai/InsightBanner';
+import { CoachMark } from '@/components/onboarding/CoachMark';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { database } from '@/db';
 import type { Account } from '@/db/models/Account';
@@ -95,6 +96,11 @@ export default function AccountDetail(): React.ReactNode {
         </Text>
 
         <View className="mt-6">
+          <CoachMark
+            markId="account-detail-insight"
+            title="Pre-call briefing"
+            body="The AI scanned this account's history and surfaced the most important thing to know. Tap thumbs-up or thumbs-down to teach it your preferences."
+          />
           <InsightBanner account={account} />
         </View>
 

--- a/app/guide/[section].tsx
+++ b/app/guide/[section].tsx
@@ -1,0 +1,47 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { Pressable, ScrollView, Text } from 'react-native';
+
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { GUIDE_SECTIONS } from '@/data/user-guide';
+
+export default function GuideSectionScreen(): React.ReactNode {
+  const { section: id } = useLocalSearchParams<{ section: string }>();
+  const section = GUIDE_SECTIONS.find((s) => s.id === id);
+
+  if (!section) {
+    return (
+      <ErrorBoundary screenName="GuideSection">
+        <ScrollView className="flex-1 bg-ohanafy-paper px-4 pt-12 dark:bg-ohanafy-dark-surface">
+          <Text className="text-base text-ohanafy-muted dark:text-ohanafy-dark-muted">
+            Section not found.
+          </Text>
+        </ScrollView>
+      </ErrorBoundary>
+    );
+  }
+
+  return (
+    <ErrorBoundary screenName="GuideSection">
+      <ScrollView
+        accessibilityLabel={section.title}
+        className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface"
+        contentContainerClassName="px-4 pt-12 pb-12"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back to guide"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+        </Pressable>
+        <Text className="mb-4 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          {section.title}
+        </Text>
+        <Text className="text-base leading-6 text-ohanafy-ink dark:text-ohanafy-dark-text">
+          {section.body}
+        </Text>
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/app/guide/_layout.tsx
+++ b/app/guide/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function GuideLayout(): React.ReactNode {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/guide/index.tsx
+++ b/app/guide/index.tsx
@@ -1,0 +1,91 @@
+import { router } from 'expo-router';
+import { useMemo, useState } from 'react';
+import { Pressable, ScrollView, Text, TextInput } from 'react-native';
+
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { GUIDE_SECTIONS, searchGuide } from '@/data/user-guide';
+
+export default function GuideIndex(): React.ReactNode {
+  const [query, setQuery] = useState('');
+  const hits = useMemo(() => searchGuide(query), [query]);
+
+  return (
+    <ErrorBoundary screenName="GuideIndex">
+      <ScrollView
+        accessibilityLabel="User guide"
+        className="flex-1 bg-ohanafy-paper dark:bg-ohanafy-dark-surface"
+        contentContainerClassName="px-4 pt-12 pb-12"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          onPress={() => router.back()}
+          className="mb-4 self-start"
+        >
+          <Text className="text-base text-ohanafy-denim dark:text-ohanafy-denim-light">← Back</Text>
+        </Pressable>
+        <Text className="mb-1 text-2xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+          User Guide
+        </Text>
+        <Text className="mb-4 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+          Available offline. Search or browse below.
+        </Text>
+
+        <TextInput
+          accessibilityLabel="Search the guide"
+          accessibilityHint="Filters guide sections as you type"
+          placeholder="Search…"
+          placeholderTextColor="#9a9a9a"
+          value={query}
+          onChangeText={setQuery}
+          className="mb-4 rounded-xl bg-ohanafy-cork px-4 py-3 text-base text-ohanafy-ink dark:bg-ohanafy-dark-elevated dark:text-ohanafy-dark-text"
+        />
+
+        {query.trim().length > 0 ? (
+          hits.length === 0 ? (
+            <Text className="text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+              No matches for &quot;{query}&quot;
+            </Text>
+          ) : (
+            hits.map((hit) => (
+              <Pressable
+                key={hit.section.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Open guide section: ${hit.section.title}`}
+                onPress={() => router.push(`/guide/${hit.section.id}`)}
+                className="mb-3 rounded-2xl bg-ohanafy-cork p-4 active:opacity-80 dark:bg-ohanafy-dark-elevated"
+              >
+                <Text className="text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+                  {hit.section.title}
+                </Text>
+                {hit.matches.map((m, i) => (
+                  <Text
+                    key={i}
+                    numberOfLines={2}
+                    className="mt-1 text-xs text-ohanafy-muted dark:text-ohanafy-dark-muted"
+                  >
+                    {m}
+                  </Text>
+                ))}
+              </Pressable>
+            ))
+          )
+        ) : (
+          GUIDE_SECTIONS.map((section) => (
+            <Pressable
+              key={section.id}
+              accessibilityRole="button"
+              accessibilityLabel={`Open guide section: ${section.title}`}
+              onPress={() => router.push(`/guide/${section.id}`)}
+              className="mb-3 rounded-2xl bg-ohanafy-cork p-4 active:opacity-80 dark:bg-ohanafy-dark-elevated"
+            >
+              <Text className="text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+                {section.title}
+              </Text>
+            </Pressable>
+          ))
+        )}
+      </ScrollView>
+    </ErrorBoundary>
+  );
+}

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function OnboardingLayout(): React.ReactNode {
+  return <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }} />;
+}

--- a/app/onboarding/done.tsx
+++ b/app/onboarding/done.tsx
@@ -1,0 +1,25 @@
+import * as SecureStore from 'expo-secure-store';
+import { router } from 'expo-router';
+
+import { OnboardingStep } from '@/components/onboarding/OnboardingStep';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+
+export default function OnboardingDone(): React.ReactNode {
+  const handleComplete = async (): Promise<void> => {
+    await SecureStore.setItemAsync('onboarding_complete', '1');
+    router.replace('/(tabs)');
+  };
+
+  return (
+    <ErrorBoundary screenName="OnboardingDone">
+      <OnboardingStep
+        step={5}
+        totalSteps={5}
+        heading="You're all set"
+        body="Ohanafy Field is ready. Your accounts are cached for offline use. The AI gets smarter as you use it. Tap any ? button on a screen, or open Settings → User Guide whenever you need help."
+        primaryCta="Go to my accounts"
+        onPrimary={handleComplete}
+      />
+    </ErrorBoundary>
+  );
+}

--- a/app/onboarding/first-visit.tsx
+++ b/app/onboarding/first-visit.tsx
@@ -1,0 +1,62 @@
+import { router } from 'expo-router';
+import { Text, View } from 'react-native';
+
+import { OnboardingStep } from '@/components/onboarding/OnboardingStep';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+
+const TIPS: Array<{ icon: string; title: string; body: string }> = [
+  {
+    icon: '📋',
+    title: 'Open an account',
+    body: 'Tap any card on the home screen. The AI surfaces a pre-call insight at the top.',
+  },
+  {
+    icon: '🎤',
+    title: 'Use your voice',
+    body: 'Tap the mic and say things like "add 2 kegs Pale Ale". Accept, edit, or reject.',
+  },
+  {
+    icon: '🖨️',
+    title: 'Print on the spot',
+    body: 'Generate shelf talkers in seconds. Hand them to the buyer before you leave.',
+  },
+  {
+    icon: '🔄',
+    title: 'It all works offline',
+    body: "Place orders without signal. They sync to Salesforce when you reconnect.",
+  },
+];
+
+export default function OnboardingFirstVisit(): React.ReactNode {
+  return (
+    <ErrorBoundary screenName="OnboardingFirstVisit">
+      <OnboardingStep
+        step={4}
+        totalSteps={5}
+        heading="Try your first visit"
+        body="Here's the rep workflow you'll use 8–12 times a day."
+        primaryCta="I'm ready"
+        onPrimary={() => router.push('/onboarding/done')}
+      >
+        <View>
+          {TIPS.map((tip) => (
+            <View
+              key={tip.title}
+              className="mb-3 flex-row rounded-2xl bg-ohanafy-cork p-3 dark:bg-ohanafy-dark-elevated"
+            >
+              <Text className="mr-3 text-2xl">{tip.icon}</Text>
+              <View className="flex-1">
+                <Text className="text-base font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+                  {tip.title}
+                </Text>
+                <Text className="mt-1 text-sm text-ohanafy-muted dark:text-ohanafy-dark-muted">
+                  {tip.body}
+                </Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      </OnboardingStep>
+    </ErrorBoundary>
+  );
+}

--- a/app/onboarding/printer.tsx
+++ b/app/onboarding/printer.tsx
@@ -1,0 +1,30 @@
+import { router } from 'expo-router';
+
+import { OnboardingStep } from '@/components/onboarding/OnboardingStep';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { discoverPrinters } from '@/zpl/printer';
+
+export default function OnboardingPrinter(): React.ReactNode {
+  const handleFind = async (): Promise<void> => {
+    // Stub for Day 5; the real Bluetooth pair flow ships when the native
+    // Zebra Link-OS module lands (Day 6 device build). For now this just
+    // opens the native module's discovery (no-op in dev) and continues.
+    await discoverPrinters();
+    router.push('/onboarding/first-visit');
+  };
+
+  return (
+    <ErrorBoundary screenName="OnboardingPrinter">
+      <OnboardingStep
+        step={3}
+        totalSteps={5}
+        heading="Pair your label printer"
+        body="Connect your Zebra ZQ520 or ZQ630 to print shelf talkers and delivery receipts on the spot. You can do this later from Settings → Printers."
+        primaryCta="Find My Printer"
+        secondaryCta="Skip for now"
+        onPrimary={handleFind}
+        onSecondary={() => router.push('/onboarding/first-visit')}
+      />
+    </ErrorBoundary>
+  );
+}

--- a/app/onboarding/territory.tsx
+++ b/app/onboarding/territory.tsx
@@ -1,0 +1,80 @@
+import { Q } from '@nozbe/watermelondb';
+import { router } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Text, View } from 'react-native';
+
+import { useAuthStore } from '@/auth/store';
+import { OnboardingStep } from '@/components/onboarding/OnboardingStep';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { database } from '@/db';
+import type { Account } from '@/db/models/Account';
+
+interface TerritoryStats {
+  total: number;
+  byType: Record<string, number>;
+}
+
+export default function OnboardingTerritory(): React.ReactNode {
+  const email = useAuthStore((s) => s.email);
+  const [stats, setStats] = useState<TerritoryStats>({ total: 0, byType: {} });
+
+  useEffect(() => {
+    let active = true;
+    (async (): Promise<void> => {
+      const all = await database
+        .get<Account>('accounts')
+        .query(Q.where('is_archived', false))
+        .fetch();
+      if (!active) return;
+      const byType: Record<string, number> = {};
+      for (const a of all) {
+        byType[a.accountType] = (byType[a.accountType] ?? 0) + 1;
+      }
+      setStats({ total: all.length, byType });
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <ErrorBoundary screenName="OnboardingTerritory">
+      <OnboardingStep
+        step={2}
+        totalSteps={5}
+        heading="Your territory"
+        body={`${email ? `Welcome, ${email}.` : 'Welcome.'} ${stats.total} accounts loaded to your device. They're available offline.`}
+        primaryCta="Continue"
+        onPrimary={() => router.push('/onboarding/printer')}
+      >
+        <View className="rounded-2xl bg-ohanafy-cork p-4 dark:bg-ohanafy-dark-elevated">
+          {Object.entries(stats.byType).map(([type, count]) => (
+            <View key={type} className="mb-2 flex-row items-center justify-between">
+              <Text className="text-sm text-ohanafy-ink dark:text-ohanafy-dark-text">
+                {labelFor(type)}
+              </Text>
+              <Text className="text-sm font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+                {count}
+              </Text>
+            </View>
+          ))}
+        </View>
+      </OnboardingStep>
+    </ErrorBoundary>
+  );
+}
+
+function labelFor(type: string): string {
+  switch (type) {
+    case 'on_premise':
+      return 'On-premise';
+    case 'off_premise_chain':
+      return 'Off-premise chain';
+    case 'off_premise_indie':
+      return 'Off-premise indie';
+    case 'convenience':
+      return 'Convenience';
+    default:
+      return type;
+  }
+}

--- a/app/onboarding/welcome.tsx
+++ b/app/onboarding/welcome.tsx
@@ -1,0 +1,19 @@
+import { router } from 'expo-router';
+
+import { OnboardingStep } from '@/components/onboarding/OnboardingStep';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+
+export default function OnboardingWelcome(): React.ReactNode {
+  return (
+    <ErrorBoundary screenName="OnboardingWelcome">
+      <OnboardingStep
+        step={1}
+        totalSteps={5}
+        heading="Welcome to Ohanafy Field"
+        body="Your territory. Your accounts. Your AI assistant. Works offline, listens to your voice, prints labels on the spot."
+        primaryCta="Get Started"
+        onPrimary={() => router.push('/onboarding/territory')}
+      />
+    </ErrorBoundary>
+  );
+}

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -1,0 +1,55 @@
+# Maestro E2E flows
+
+End-to-end tests for Ohanafy Field. Run on iOS simulators or Android emulators
+with the [Maestro CLI](https://maestro.mobile.dev).
+
+## Setup
+
+```bash
+brew tap mobile-dev-inc/tap
+brew install maestro
+```
+
+## Run a single flow
+
+```bash
+maestro test maestro/flows/onboarding.yaml
+```
+
+## Run the whole suite
+
+```bash
+maestro test maestro/flows/
+```
+
+## Test mode
+
+All flows set `MAESTRO_TEST_MODE=true`. The app reads this env var to:
+
+- Skip Salesforce OAuth — fall through with the user identified by `MAESTRO_FIXTURE_USER` (defaults to `daniel.zeder@ohanafy.com`)
+- Use seed data instead of live Salesforce sync
+- Expose a few `debug-*` testIDs that test code uses to inject transcripts, trigger sync manually, etc.
+
+These hooks are gated on `process.env.MAESTRO_TEST_MODE === 'true'` so they're
+stripped from production builds.
+
+## Flows
+
+| Flow | Source | Purpose |
+|---|---|---|
+| `onboarding.yaml` | Bible §9 Day 5 | 5-step onboarding wizard |
+| `account-visit.yaml` | Bible §9 Day 5 | Open account → place order → confirm |
+| `voice-order.yaml` | Bible §9 Day 5 | Voice command → CommandFeedback → Accept |
+| `offline-sync.yaml` | Bible §9 Day 5 | Place order offline, reconnect, sync |
+| `zpl-print.yaml` | Bible §9 Day 5 | Label preview + simulated print |
+| `ai-correction-learning.yaml` | Bible Appendix E | 3 corrections → memory created |
+| `role-detection.yaml` | Roles §12 | Each role lands on the right tab set |
+| `permission-gate.yaml` | Roles §12 | Manager-only features hidden for Sales Rep |
+| `role-switch.yaml` | Roles §12 | Multi-role user switches roles |
+| `no-permission.yaml` | Roles §12 | User with no Permission Sets sees the screen |
+| `admin-console.yaml` | Roles §12 | Admin sees the App Admin role |
+
+## Helpers
+
+`helpers/go-offline.yaml` and `helpers/go-online.yaml` toggle airplane mode in
+a cross-platform way. Used by `offline-sync.yaml`.

--- a/maestro/flows/account-visit.yaml
+++ b/maestro/flows/account-visit.yaml
@@ -1,0 +1,29 @@
+appId: com.ohanafy.field
+---
+# Full happy path: open an account, see insight, place a small order, confirm.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+      MAESTRO_SKIP_ONBOARDING: "true"
+
+- tapOn: "Sign in with Salesforce"
+- assertVisible: "Accounts"
+
+- tapOn:
+    id: "account-card-a01_the_rail"
+- assertVisible: "Pre-call insight"
+
+- tapOn: "New Order"
+- tapOn: "+ Add Item"
+- tapOn:
+    id: "product-p01_yh_pale_ale_hb"
+- tapOn: "Done"
+- assertVisible: "Yellowhammer Pale Ale"
+
+- tapOn: "Review"
+- assertVisible: "Confirm Order"
+- tapOn: "Place Order"
+
+- assertVisible: "Accounts"
+- assertVisible: "pending sync"

--- a/maestro/flows/admin-console.yaml
+++ b/maestro/flows/admin-console.yaml
@@ -1,0 +1,17 @@
+appId: com.ohanafy.field
+---
+# Admin user — verify the Admin Console option appears in Settings.
+# The Admin Console Lightning app itself is a Salesforce-side screen; this
+# flow just verifies the launcher is gated correctly.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+      MAESTRO_FIXTURE_USER: "daniel.zeder@ohanafy.com"
+
+- tapOn: "Sign in with Salesforce"
+- tapOn: "Settings"
+
+# Admin role gives manage_admin_console permission. Day 6 adds the launcher
+# button; for Day 5 we just verify the role switcher includes "App Admin".
+- assertVisible: "App Admin"

--- a/maestro/flows/ai-correction-learning.yaml
+++ b/maestro/flows/ai-correction-learning.yaml
@@ -1,0 +1,32 @@
+appId: com.ohanafy.field
+---
+# 3 voice corrections → run learning agent → verify a memory was created.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+
+- tapOn: "Sign in with Salesforce"
+- tapOn:
+    id: "account-card-a01_the_rail"
+- tapOn: "New Order"
+
+# Inject 3 fake voice corrections via the test-mode hook
+- repeat:
+    times: 3
+    commands:
+      - tapOn:
+          id: "voice-button"
+      - tapOn:
+          id: "debug-inject-transcript"
+      - tapOn: "Edit"
+      - tapOn:
+          id: "debug-confirm-edit"
+
+# Open Settings → AI Memories → Run learning now
+- tapOn: "Settings"
+- tapOn: "AI Memories"
+- tapOn: "Run learning now"
+
+# Verify at least one memory appears
+- assertVisible: "PRODUCT_NICKNAME"

--- a/maestro/flows/no-permission.yaml
+++ b/maestro/flows/no-permission.yaml
@@ -1,0 +1,14 @@
+appId: com.ohanafy.field
+---
+# Login with a user who has zero ohfy_field__ Permission Sets assigned.
+# Verify the no-permission screen renders with the right messaging.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+      MAESTRO_FIXTURE_USER: "unknown@example.com"
+
+- tapOn: "Sign in with Salesforce"
+
+- assertVisible: "No access yet"
+- assertVisible: "ohfy_field__"

--- a/maestro/flows/offline-sync.yaml
+++ b/maestro/flows/offline-sync.yaml
@@ -1,0 +1,35 @@
+appId: com.ohanafy.field
+---
+# Place an order with the network OFF, restore network, verify it syncs.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+
+- tapOn: "Sign in with Salesforce"
+
+# Disable network — Maestro on iOS uses setAirplaneMode; Android equivalent
+# below for cross-platform support
+- runFlow:
+    file: ../helpers/go-offline.yaml
+
+- tapOn:
+    id: "account-card-a01_the_rail"
+- tapOn: "New Order"
+- tapOn: "+ Add Item"
+- tapOn:
+    id: "product-p01_yh_pale_ale_hb"
+- tapOn: "Done"
+- tapOn: "Review"
+- tapOn: "Place Order"
+
+- assertVisible: "Offline"
+- assertVisible: "pending sync"
+
+- runFlow:
+    file: ../helpers/go-online.yaml
+
+# Sync engine flushes on NetInfo reconnect — wait up to 10s for synced state
+- waitForAnimationToEnd:
+    timeout: 10000
+- assertNotVisible: "pending sync"

--- a/maestro/flows/onboarding.yaml
+++ b/maestro/flows/onboarding.yaml
@@ -1,0 +1,29 @@
+appId: com.ohanafy.field
+---
+# Walks the 5-step onboarding wizard end-to-end.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+
+# Step 1: Welcome
+- assertVisible: "Welcome to Ohanafy Field"
+- tapOn: "Get Started"
+
+# Step 2: Territory
+- assertVisible: "Your territory"
+- assertVisible: "accounts loaded"
+- tapOn: "Continue"
+
+# Step 3: Pair printer (skip path)
+- assertVisible: "Pair your label printer"
+- tapOn: "Skip for now"
+
+# Step 4: First visit tour
+- assertVisible: "Try your first visit"
+- tapOn: "I'm ready"
+
+# Step 5: Done — completes and routes to tabs
+- assertVisible: "You're all set"
+- tapOn: "Go to my accounts"
+- assertVisible: "Accounts"

--- a/maestro/flows/permission-gate.yaml
+++ b/maestro/flows/permission-gate.yaml
@@ -1,0 +1,17 @@
+appId: com.ohanafy.field
+---
+# Login as Sales Rep; verify manager-only features are absent. The
+# PermissionGate component should hide them rather than render-and-disable.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+      MAESTRO_FIXTURE_USER: "daniel.zeder+salesrep@ohanafy.com"
+
+- tapOn: "Sign in with Salesforce"
+- tapOn: "Settings"
+
+# Sales Rep has no admin console permission — RoleSwitcher hides itself
+# when the user has only one role.
+- assertNotVisible: "Role"
+- assertNotVisible: "App Admin"

--- a/maestro/flows/role-detection.yaml
+++ b/maestro/flows/role-detection.yaml
@@ -1,0 +1,17 @@
+appId: com.ohanafy.field
+---
+# Roles doc §12 — login as each of the 6 functional roles, verify correct tab
+# set renders. Tab sets per Roles Appendix C. Day 5 only ships FieldSalesRep
+# tabs; the other roles route to the no-permission screen until Day 6 adds
+# their tab sets.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+      MAESTRO_FIXTURE_USER: "daniel.zeder+salesrep@ohanafy.com"
+
+- tapOn: "Sign in with Salesforce"
+- assertVisible: "Accounts"
+- assertVisible: "Route"
+- assertVisible: "Orders"
+- assertVisible: "Settings"

--- a/maestro/flows/role-switch.yaml
+++ b/maestro/flows/role-switch.yaml
@@ -1,0 +1,24 @@
+appId: com.ohanafy.field
+---
+# Multi-role user (admin) — switch from FieldSalesRep to Driver and back.
+# Verify the active-role pill changes and downstream PermissionGates re-evaluate.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+      MAESTRO_FIXTURE_USER: "daniel.zeder@ohanafy.com"
+
+- tapOn: "Sign in with Salesforce"
+- tapOn: "Settings"
+
+# Default primary role is AppAdmin
+- assertVisible: "Role"
+- assertVisible: "App Admin"
+
+# Switch to FieldSalesRep
+- tapOn: "Field Sales Rep"
+- assertVisible: "Field Sales Rep"
+
+# Switch to Driver — Day 6 will add a tab set; for now, no-permission screen
+- tapOn: "Driver"
+- assertVisible: "No access yet"

--- a/maestro/flows/voice-order.yaml
+++ b/maestro/flows/voice-order.yaml
@@ -1,0 +1,23 @@
+appId: com.ohanafy.field
+---
+# Voice command path: dictate "add 2 kegs pale ale" → Accept → line added.
+# Maestro can't actually emit microphone audio; this flow asserts the UI
+# affordances and uses a debug button (test mode only) to inject a transcript.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+
+- tapOn: "Sign in with Salesforce"
+- tapOn:
+    id: "account-card-a01_the_rail"
+- tapOn: "New Order"
+
+- tapOn:
+    id: "voice-button"
+# Test-mode hook injects a fixed transcript and walks through the agent.
+- tapOn:
+    id: "debug-inject-transcript"
+- assertVisible: "AI heard"
+- tapOn: "Accept"
+- assertVisible: "Yellowhammer Pale Ale"

--- a/maestro/flows/zpl-print.yaml
+++ b/maestro/flows/zpl-print.yaml
@@ -1,0 +1,22 @@
+appId: com.ohanafy.field
+---
+# Label preview + print path. In dev/CI the printer is the stub — the test
+# verifies the preview renders and the print step records a label_print row.
+- launchApp:
+    clearState: true
+    env:
+      MAESTRO_TEST_MODE: "true"
+
+- tapOn: "Sign in with Salesforce"
+- tapOn:
+    id: "account-card-a01_the_rail"
+
+# Day 5 wires a "Print Label" entry on account detail (Day 6 polish).
+# For now, tap the dev shortcut into /label/select.
+- tapOn:
+    id: "debug-open-label-select"
+
+- tapOn: "Shelf Talker"
+- assertVisible: "Preview"
+- tapOn: "Print to Zebra"
+- assertVisible: "Simulated print"

--- a/maestro/helpers/go-offline.yaml
+++ b/maestro/helpers/go-offline.yaml
@@ -1,0 +1,6 @@
+appId: com.ohanafy.field
+---
+# Cross-platform helper: turn off the device network. Maestro's setAirplaneMode
+# works on iOS simulators and Android emulators in test mode.
+- setAirplaneMode:
+    enabled: true

--- a/maestro/helpers/go-online.yaml
+++ b/maestro/helpers/go-online.yaml
@@ -1,0 +1,4 @@
+appId: com.ohanafy.field
+---
+- setAirplaneMode:
+    enabled: false

--- a/src/components/onboarding/CoachMark.tsx
+++ b/src/components/onboarding/CoachMark.tsx
@@ -1,0 +1,47 @@
+import { Pressable, Text, View } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { useCoachMark } from '@/hooks/useCoachMark';
+
+interface CoachMarkProps {
+  markId: string;
+  title: string;
+  body: string;
+}
+
+// Inline tooltip-style coach mark. Day 5 ships the simple inline version per
+// the Bible §19 onboarding spec; Day 6 polish can layer a true overlay if the
+// designer review calls for one.
+export function CoachMark({ markId, title, body }: CoachMarkProps): React.ReactNode {
+  const { visible, dismiss } = useCoachMark(markId);
+  if (!visible) return null;
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(180)}
+      exiting={FadeOut.duration(120)}
+      className="mb-3 rounded-2xl bg-ohanafy-mellow p-4"
+    >
+      <View
+        accessibilityRole="alert"
+        accessibilityLabel={`${title}. ${body}`}
+        accessibilityLiveRegion="polite"
+      >
+        <Text className="text-xs font-bold uppercase tracking-wider text-ohanafy-ink opacity-70">
+          Tip
+        </Text>
+        <Text className="mt-1 text-base font-bold text-ohanafy-ink">{title}</Text>
+        <Text className="mt-1 text-sm text-ohanafy-ink">{body}</Text>
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Got it"
+        accessibilityHint="Dismisses this tip. It won't be shown again."
+        onPress={dismiss}
+        className="mt-3 self-start rounded-full bg-ohanafy-ink px-3 py-1.5 active:opacity-80"
+      >
+        <Text className="text-xs font-bold text-ohanafy-paper">Got it</Text>
+      </Pressable>
+    </Animated.View>
+  );
+}

--- a/src/components/onboarding/OnboardingStep.tsx
+++ b/src/components/onboarding/OnboardingStep.tsx
@@ -1,0 +1,80 @@
+import { Pressable, Text, View } from 'react-native';
+
+interface OnboardingStepProps {
+  step: number;
+  totalSteps: number;
+  heading: string;
+  body: string;
+  primaryCta: string;
+  secondaryCta?: string;
+  onPrimary: () => void;
+  onSecondary?: () => void;
+  children?: React.ReactNode;
+}
+
+export function OnboardingStep({
+  step,
+  totalSteps,
+  heading,
+  body,
+  primaryCta,
+  secondaryCta,
+  onPrimary,
+  onSecondary,
+  children,
+}: OnboardingStepProps): React.ReactNode {
+  return (
+    <View
+      accessibilityLabel={`Onboarding step ${step} of ${totalSteps}: ${heading}`}
+      className="flex-1 bg-ohanafy-paper px-6 pt-16 dark:bg-ohanafy-dark-surface"
+    >
+      <View className="mb-4 flex-row gap-2">
+        {Array.from({ length: totalSteps }, (_, i) => (
+          <View
+            key={i}
+            className={
+              i < step
+                ? 'h-1.5 flex-1 rounded-full bg-ohanafy-denim'
+                : 'h-1.5 flex-1 rounded-full bg-ohanafy-cork dark:bg-ohanafy-dark-elevated'
+            }
+          />
+        ))}
+      </View>
+
+      <Text className="mb-2 text-xs font-bold uppercase tracking-wider text-ohanafy-muted dark:text-ohanafy-dark-muted">
+        Step {step} of {totalSteps}
+      </Text>
+      <Text className="mb-3 text-3xl font-bold text-ohanafy-ink dark:text-ohanafy-dark-text">
+        {heading}
+      </Text>
+      <Text className="mb-6 text-base leading-6 text-ohanafy-ink dark:text-ohanafy-dark-text">
+        {body}
+      </Text>
+
+      <View className="flex-1">{children}</View>
+
+      <View className="pb-12">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={primaryCta}
+          onPress={onPrimary}
+          className="rounded-xl bg-ohanafy-denim px-4 py-4 active:opacity-80"
+        >
+          <Text className="text-center text-base font-bold text-ohanafy-paper">{primaryCta}</Text>
+        </Pressable>
+        {secondaryCta ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={secondaryCta}
+            onPress={onSecondary}
+            className="mt-3 px-4 py-3"
+          >
+            <Text className="text-center text-sm font-bold text-ohanafy-denim dark:text-ohanafy-denim-light">
+              {secondaryCta}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/src/data/user-guide.ts
+++ b/src/data/user-guide.ts
@@ -1,0 +1,184 @@
+// User Guide content — sourced from OHANAFY-FIELD-PRODUCT-BIBLE.md Appendix F.
+// Bundled into the app build so it's offline by default. Searchable via the
+// Guide screen.
+
+export interface GuideSection {
+  id: string;
+  title: string;
+  body: string;
+}
+
+export const GUIDE_SECTIONS: GuideSection[] = [
+  {
+    id: 'getting-started',
+    title: '1. Getting Started',
+    body: `Setting up Ohanafy Field takes about 5 minutes. After downloading the app:
+
+1. Sign in with Salesforce. Tap "Sign in with Salesforce" and log in with your Ohanafy credentials. Ohanafy Field connects to your Salesforce org to load your territory.
+
+2. Let the app sync. On first launch, Ohanafy Field downloads your accounts, products, and order history. This takes 30 to 60 seconds on a good connection. After that, everything is available offline.
+
+3. Pair your Zebra printer. If you have a Zebra ZQ520 or ZQ630 printer, go to Settings → Printers to pair it. You can also do this during onboarding. The app works without a printer — you just won't be able to print labels.
+
+4. Enable Face ID / Touch ID. When prompted, allow biometric unlock. This lets you open the app with one glance instead of typing your PIN each time.
+
+After setup, your account list will be on the home screen, sorted alphabetically. Accounts needing attention (not visited in 21+ days) are highlighted and can be filtered with the Needs Attention button.`,
+  },
+  {
+    id: 'account-visits',
+    title: '2. Account Visits',
+    body: `Before you walk in:
+Open the account from your list. Ohanafy Field shows you an AI insight at the top of the account screen — the most important thing to know before you knock. This might be a stale reorder, a flagged issue from your last visit, or a selling opportunity.
+
+Tap thumbs-up if the insight was helpful. Tap thumbs-down if it wasn't. This feedback helps the AI learn what matters to you and your accounts.
+
+During the visit:
+- Use the Voice button (microphone icon, bottom right) to log notes and orders hands-free.
+- The Visit History section shows your last 3 visits with notes.
+- The Last Order summary shows the last placed order and its status.
+
+After the visit:
+Tap "Log Visit" to save the visit to Ohanafy Field. You can add or edit your notes before saving. If you're offline, the visit is saved locally and syncs when you get signal.`,
+  },
+  {
+    id: 'taking-orders',
+    title: '3. Taking Orders',
+    body: `Tap "New Order" from the account detail screen to open the order entry screen.
+
+Adding items:
+- Browse products by category (Beer Kegs / Beer Cases / Energy / Other).
+- Tap a product to add it; use the +/- stepper to change quantity.
+- Swipe left on a line item to remove it.
+- The order total updates automatically.
+
+Using voice to order:
+Tap the mic button and speak naturally. For example: "Add 2 kegs Pale Ale", "Put a case of Modelo on the order", "Three Red Bull Sugarfrees".
+
+The AI will show you what it understood. Tap Accept to add it, Edit to change it, or Reject to start over.
+
+Confirming the order:
+Tap "Confirm Order" to review the full order. Add a delivery date and any notes, then tap "Place Order." If you're offline, the order is saved locally (shown as "Pending Sync") and submitted to Salesforce when you reconnect.`,
+  },
+  {
+    id: 'voice-commands',
+    title: '4. Voice Commands',
+    body: `Ohanafy Field understands natural speech. You don't need to use specific phrases — speak the way you normally would.
+
+Order commands:
+- "Add [quantity] [product]" — adds to current order
+- "Put [quantity] [product] on the order" — same
+- "Remove the [product]" — removes from order
+- "Change the [product] to [quantity]" — updates quantity
+
+Note commands:
+- "Note [text]" — logs a visit note
+- "Log that [text]" — same
+- "Remember [text]" — same
+
+Tips for better accuracy:
+- Speak clearly and at a normal pace — the app handles natural speech.
+- If the AI gets a product name wrong, tap Edit and correct it; the AI learns from your corrections over time.`,
+  },
+  {
+    id: 'label-printing',
+    title: '5. Label Printing',
+    body: `Ohanafy Field can print shelf talkers, product cards, and delivery receipts directly to your Zebra ZQ520 or ZQ630.
+
+Before printing:
+- Your Zebra printer must be paired via Bluetooth (Settings → Printers).
+- Load the correct label stock (see your label type's size below).
+- The printer must be powered on and within Bluetooth range (~30 feet).
+
+Printing a shelf talker:
+1. From an account detail or order screen, tap "Print Label".
+2. Select "Shelf Talker".
+3. Choose the product.
+4. Tap the preview to verify the label looks correct.
+5. Tap "Print".
+
+The shelf talker prints in seconds. Hand it to the buyer while you're still in the store.
+
+Label sizes:
+- Shelf talker: 2.5" × 1.5" — Zebra ZP #10010044 or equivalent
+- Product card: 4" × 3" — Zebra #800274-605 or equivalent
+- Delivery receipt: 4" × 6" — Zebra #800274-607 or equivalent
+
+If the printer won't connect:
+1. Make sure Bluetooth is enabled on your phone.
+2. Make sure the printer is powered on (green status light).
+3. Try "Forget Printer" and re-pair in Settings → Printers.
+4. Check that the label stock is loaded correctly (media sensing light should be off).`,
+  },
+  {
+    id: 'ai-features',
+    title: '6. AI Features',
+    body: `Ohanafy Field's AI gets smarter the more you use it. Here's how it works.
+
+AI visit prep: Before each visit, the AI analyzes your account's order history and visit notes to surface one key insight. This is not a generic tip — it's specific to this account's data.
+
+AI voice commands: When you speak, the AI interprets your words into app actions. It understands products by partial name, common abbreviations, and context.
+
+How the AI learns:
+Every time you accept, edit, or reject an AI suggestion, the app learns. After several corrections:
+- The AI gets better at recognizing your product shorthand.
+- Account-specific patterns are remembered (e.g., The Rail always orders in pairs).
+- Your note style is learned over time.
+
+Reviewing your AI memories:
+Go to Settings → AI Memory to see what the AI has learned. You can edit or delete any memory. Memories are saved to Salesforce, so they're available on any device you use.
+
+A badge that says "customer-calibrated" on an AI insight means the AI used past corrections and feedback from your visits to this specific account — the insight is more personalized than the default.`,
+  },
+  {
+    id: 'troubleshooting',
+    title: '7. Troubleshooting',
+    body: `The app won't sync:
+- Check that you have signal (the offline banner will say "Offline" if not).
+- Tap "Sync Now" in Settings to manually trigger a sync.
+- Check Settings → Sync Status for any failed items.
+- If items show "Failed after 3 attempts", contact support with the error details.
+
+Voice commands are inaccurate:
+- Speak clearly and at a normal pace.
+- Try moving to a quieter location.
+- If a specific product name is consistently misheard, use Edit to correct it — the AI will learn the correct mapping after 2 to 3 corrections.
+- As a last resort, add items manually using the product search.
+
+Printer won't print:
+- Check Bluetooth is on and the printer is powered and within range.
+- Check the printer has label stock loaded.
+- Try a calibration print from the printer menu (hold the feed button).
+- Re-pair the printer in Settings → Printers.
+
+An order shows "Sync Failed":
+- This usually means a Salesforce session issue. Go to Settings → Account and tap "Refresh Connection".
+- If the error persists, export the order as a PDF (tap the order → Share) and enter it manually as a backup.
+
+Contacting support:
+Email support@ohanafy.com. Tap "Contact Support" in Settings for a pre-filled email with your device info and app version.`,
+  },
+];
+
+export interface SearchHit {
+  section: GuideSection;
+  matches: string[];
+}
+
+export function searchGuide(query: string): SearchHit[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return [];
+  const hits: SearchHit[] = [];
+  for (const section of GUIDE_SECTIONS) {
+    const matches: string[] = [];
+    const titleHit = section.title.toLowerCase().includes(q);
+    if (titleHit) matches.push(section.title);
+    for (const line of section.body.split('\n')) {
+      if (line.toLowerCase().includes(q) && line.trim().length > 0) {
+        matches.push(line.trim());
+        if (matches.length >= 3) break;
+      }
+    }
+    if (matches.length > 0) hits.push({ section, matches });
+  }
+  return hits;
+}

--- a/src/hooks/useCoachMark.ts
+++ b/src/hooks/useCoachMark.ts
@@ -1,0 +1,30 @@
+import * as SecureStore from 'expo-secure-store';
+import { useEffect, useState } from 'react';
+
+const KEY_PREFIX = 'coach_mark_dismissed_';
+
+export interface CoachMarkApi {
+  visible: boolean;
+  dismiss: () => Promise<void>;
+}
+
+export function useCoachMark(markId: string): CoachMarkApi {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    SecureStore.getItemAsync(KEY_PREFIX + markId).then((value) => {
+      if (active) setVisible(value !== '1');
+    });
+    return () => {
+      active = false;
+    };
+  }, [markId]);
+
+  const dismiss = async (): Promise<void> => {
+    await SecureStore.setItemAsync(KEY_PREFIX + markId, '1');
+    setVisible(false);
+  };
+
+  return { visible, dismiss };
+}


### PR DESCRIPTION
## Summary

Day 5 per Bible §9 Friday + Roles §12 — pick-up-and-know-what-to-do, plus the test suite that catches regressions tomorrow.

- **Onboarding wizard** (Bible Appendix G — 5 steps): `/onboarding/welcome → territory → printer → first-visit → done`. `OnboardingStep` component with progress bar + primary/secondary CTAs. Territory step queries seeded accounts and shows breakdown by type. Done writes `onboarding_complete` to SecureStore and routes to tabs.
- **Coach marks**: `useCoachMark` hook persists dismissal in SecureStore (one-time per markId). `CoachMark` component with FadeIn/Out + Got-it button. Wired on the accounts list and on account detail.
- **User guide** (Appendix F — 7 sections, offline by default): `src/data/user-guide.ts` with all 7 sections + `searchGuide()` helper (case-insensitive, ≤3 hits/section). `/guide` TOC + search; `/guide/[section]` body. Settings entry point. **5 unit tests** on content + search.
- **11 Maestro E2E flows**: 6 Bible-spec (`onboarding`, `account-visit`, `voice-order`, `offline-sync`, `zpl-print`, `ai-correction-learning`) + 5 Roles §12 (`role-detection`, `permission-gate`, `role-switch`, `no-permission`, `admin-console`). Cross-platform `go-offline.yaml` / `go-online.yaml` helpers. `maestro/README.md` documents the test-mode hooks.

Roles §12 Day 5 deliverables met:
- ✔ permissions table in WDB (Day 1)
- ✔ permission set fixtures in loader (Day 1)
- ✔ no-permission screen + role switcher (Day 1)
- ✔ all 5 role-based Maestro flows (this PR)

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — **83/83 pass** (Day 1: 27, Day 2: 4, Day 3: 18, Day 4: 27, Day 5: 5 user-guide + 2 search edge cases)
- [x] `npx eslint src/ app/` — exit 0
- [ ] On device: launch onboarding flow, walk all 5 steps, land on tabs
- [ ] On device: open Settings → User Guide, search "voice", verify section 4 appears
- [ ] On device: dismiss the accounts coach mark, kill the app, relaunch, confirm it doesn't reappear
- [ ] (Future) `maestro test maestro/flows/onboarding.yaml` — requires iOS simulator + Maestro CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)